### PR TITLE
del trans after the conversion of trans to ndtrans

### DIFF
--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -128,12 +128,12 @@ def read_states(statesf):
     return dat
 
 
-def pickup_gE(states,trans,trans_lines=False):
+def pickup_gE(states,ndtrans,trans_lines=False):
     """extract g_upper (gup), E_lower (elower), and J_lower and J_upper from states DataFrame and insert them to transition DataFrame.
 
     Args:
        states: states pandas DataFrame
-       trans: transition pandas DataFrame
+       ndtrans: transition numpy array
        trans_lines: By default (False) we use nu_lines computed using the state file, i.e. E_upper - E_lower. If trans_nuline=True, we use the nu_lines in the transition file. Note that some trans files do not this info.
 
 
@@ -146,7 +146,6 @@ def pickup_gE(states,trans,trans_lines=False):
 
     """
     ndstates=states.to_numpy()
-    ndtrans=trans.to_numpy()
 
     iorig=np.array(ndstates[:,0],dtype=int)
     maxii=int(np.max(iorig)+1) 

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -109,12 +109,16 @@ class MdbExomol(object):
 
             if self.trans_file.with_suffix(".feather").exists():
                 trans=pd.read_feather(self.trans_file.with_suffix(".feather"))
+                ndtrans=trans.to_numpy()
+                del trans
             else:
                 print(explanation)
                 trans=exomolapi.read_trans(self.trans_file)
                 trans.to_feather(self.trans_file.with_suffix(".feather"))
+                ndtrans=trans.to_numpy()
+                del trans
             #compute gup and elower
-            self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,trans)        
+            self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
         else:
             imin=np.searchsorted(numinf,self.nurange[0],side="right")-1 #left side
             imax=np.searchsorted(numinf,self.nurange[1],side="right")-1 #left side
@@ -125,16 +129,20 @@ class MdbExomol(object):
                     self.download(molec,extension=[".trans.bz2"],numtag=numtag[i])
                 if trans_file.with_suffix(".feather").exists():
                     trans=pd.read_feather(trans_file.with_suffix(".feather"))
+                    ndtrans=trans.to_numpy()
+                    del trans
                 else:
                     print(explanation)
                     trans=exomolapi.read_trans(trans_file)
                     trans.to_feather(trans_file.with_suffix(".feather"))
+                    ndtrans=trans.to_numpy()
+                    del trans
                 self.trans_file.append(trans_file)
                 #compute gup and elower                
                 if k==0:
-                    self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,trans)
+                    self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
                 else:
-                    Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,trans)
+                    Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,ndtrans)
                     self._A=np.hstack([self._A,Ax])
                     self.nu_lines=np.hstack([self.nu_lines,nulx])
                     self._elower=np.hstack([self._elower,elowerx])


### PR DESCRIPTION
I modified moldb.py and exomolapi.py to reduce the memory size by converting trans to ndtrans just after reading the transition data and freeing the memory used for trans.