### PR TITLE
Hdf5

### DIFF
--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -131,32 +131,54 @@ class MdbExomol(object):
                     trans=pd.read_hdf(trans_file.with_suffix(".hdf"))
                     ndtrans=trans.to_numpy()
                     del trans
+
+                    self.trans_file.append(trans_file)
+                    #compute gup and elower
+                    if k==0:
+                        self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
+                    else:
+                        Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,ndtrans)
+                        self._A=np.hstack([self._A,Ax])
+                        self.nu_lines=np.hstack([self.nu_lines,nulx])
+                        self._elower=np.hstack([self._elower,elowerx])
+                        self._gpp=np.hstack([self._gpp,gppx])
+                        self._jlower=np.hstack([self._jlower,jlowerx])
+                        self._jupper=np.hstack([self._jupper,jupperx])
+
+                    self.Tref=296.0
+                    self.QTref=np.array(self.QT_interp(self.Tref))
+
+                    self.Sij0=ndtrans[:,4]
                 else:
                     print(explanation)
                     trans=exomolapi.read_trans(trans_file)
                     key=("nurange"+"__"+numtag[i]).replace('-','_')
                     trans.to_hdf(trans_file.with_suffix(".hdf"), key=key)
                     ndtrans=trans.to_numpy()
-                    del trans
-                self.trans_file.append(trans_file)
-                #compute gup and elower                
-                if k==0:
-                    self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
-                else:
-                    Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,ndtrans)
-                    self._A=np.hstack([self._A,Ax])
-                    self.nu_lines=np.hstack([self.nu_lines,nulx])
-                    self._elower=np.hstack([self._elower,elowerx])
-                    self._gpp=np.hstack([self._gpp,gppx])
-                    self._jlower=np.hstack([self._jlower,jlowerx])
-                    self._jupper=np.hstack([self._jupper,jupperx])
                     
+                    self.trans_file.append(trans_file)
+                    #compute gup and elower
+                    if k==0:
+                        self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
+                    else:
+                        Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,ndtrans)
+                        self._A=np.hstack([self._A,Ax])
+                        self.nu_lines=np.hstack([self.nu_lines,nulx])
+                        self._elower=np.hstack([self._elower,elowerx])
+                        self._gpp=np.hstack([self._gpp,gppx])
+                        self._jlower=np.hstack([self._jlower,jlowerx])
+                        self._jupper=np.hstack([self._jupper,jupperx])
 
-        self.Tref=296.0        
-        self.QTref=np.array(self.QT_interp(self.Tref))
+                    self.Tref=296.0
+                    self.QTref=np.array(self.QT_interp(self.Tref))
         
-        ##Line strength: input should be ndarray not jnp array
-        self.Sij0=exomol.Sij0(self._A,self._gpp,self.nu_lines,self._elower,self.QTref)
+                    ##Line strength: input should be ndarray not jnp array
+                    self.Sij0=exomol.Sij0(self._A,self._gpp,self.nu_lines,self._elower,self.QTref)
+
+                    trans['Sij0']=self.Sij0
+                    key=("nurange"+"__"+numtag[i]).replace('-','_')
+                    trans.to_hdf(trans_file.with_suffix(".hdf"), key=key)
+                    del trans
         
         ### MASKING ###
         mask=(self.nu_lines>self.nurange[0]-self.margin)\

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -133,7 +133,6 @@ class MdbExomol(object):
             else:
                 print(explanation)
                 trans=exomolapi.read_trans(self.trans_file)
-                ndtrans=trans.to_numpy()
 
                 #mask needs to be applied
                 mask_needed=True
@@ -149,6 +148,8 @@ class MdbExomol(object):
 
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
+                ndtrans=trans.to_numpy()
+
                 key=("nurange"+"__"+numtag[i]).replace("-","_")
                 trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                 del trans
@@ -196,7 +197,6 @@ class MdbExomol(object):
                 else:
                     print(explanation)
                     trans=exomolapi.read_trans(trans_file)
-                    ndtrans=trans.to_numpy()
                     
                     #mask needs to be applied
                     mask_needed=True
@@ -222,6 +222,8 @@ class MdbExomol(object):
 
                     trans["nu_lines"]=self.nu_lines
                     trans["Sij0"]=self.Sij0
+                    ndtrans=trans.to_numpy()
+
                     key=("nurange"+"__"+numtag[i]).replace("-","_")
                     trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                     del trans

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -51,7 +51,7 @@ class MdbExomol(object):
            The trans/states files can be very large. For the first time to read it, we convert it to the feather-format. After the second-time, we use the feather format instead.
 
         """
-        explanation="Note: Couldn't find the feather format. We convert data to the feather format. After the second time, it will become much faster."
+        explanation="Note: Couldn't find the hdf format. We convert data to the hdf format. After the second time, it will become much faster."
         
         self.path = pathlib.Path(path)
         t0=self.path.parents[0].stem        
@@ -127,32 +127,15 @@ class MdbExomol(object):
                 trans_file = self.path/pathlib.Path(molec+"__"+numtag[i]+".trans.bz2")
                 if not trans_file.exists():
                     self.download(molec,extension=[".trans.bz2"],numtag=numtag[i])
-                # if trans_file.with_suffix(".feather").exists():
-                #     trans=pd.read_feather(trans_file.with_suffix(".feather"))
-                #     ndtrans=trans.to_numpy()
-                #     del trans
                 if trans_file.with_suffix(".hdf").exists():
-                # import h5py
-                # with h5py.File("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", 'r') as f:
-                #     key_list=list(f.keys())
-                # print(key_list)
-                # key=("nurange"+"__"+numtag[i]).replace('-','_')
-                # if key in key_list:
                     trans=pd.read_hdf(trans_file.with_suffix(".hdf"))
-#                    trans=pd.read_hdf("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", key=key)
                     ndtrans=trans.to_numpy()
                     del trans
                 else:
                     print(explanation)
-                    # trans=exomolapi.read_trans(trans_file)
-                    # trans.to_feather(trans_file.with_suffix(".feather"))
-                    # ndtrans=trans.to_numpy()
                     trans=exomolapi.read_trans(trans_file)
-                    print(numtag[i])
                     key=("nurange"+"__"+numtag[i]).replace('-','_')
-                    print(key)
                     trans.to_hdf(trans_file.with_suffix(".hdf"), key=key)
-#                    trans.to_hdf("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", key=key)
                     ndtrans=trans.to_numpy()
                     del trans
                 self.trans_file.append(trans_file)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -127,14 +127,32 @@ class MdbExomol(object):
                 trans_file = self.path/pathlib.Path(molec+"__"+numtag[i]+".trans.bz2")
                 if not trans_file.exists():
                     self.download(molec,extension=[".trans.bz2"],numtag=numtag[i])
-                if trans_file.with_suffix(".feather").exists():
-                    trans=pd.read_feather(trans_file.with_suffix(".feather"))
+                # if trans_file.with_suffix(".feather").exists():
+                #     trans=pd.read_feather(trans_file.with_suffix(".feather"))
+                #     ndtrans=trans.to_numpy()
+                #     del trans
+                if trans_file.with_suffix(".hdf").exists():
+                # import h5py
+                # with h5py.File("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", 'r') as f:
+                #     key_list=list(f.keys())
+                # print(key_list)
+                # key=("nurange"+"__"+numtag[i]).replace('-','_')
+                # if key in key_list:
+                    trans=pd.read_hdf(trans_file.with_suffix(".hdf"))
+#                    trans=pd.read_hdf("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", key=key)
                     ndtrans=trans.to_numpy()
                     del trans
                 else:
                     print(explanation)
+                    # trans=exomolapi.read_trans(trans_file)
+                    # trans.to_feather(trans_file.with_suffix(".feather"))
+                    # ndtrans=trans.to_numpy()
                     trans=exomolapi.read_trans(trans_file)
-                    trans.to_feather(trans_file.with_suffix(".feather"))
+                    print(numtag[i])
+                    key=("nurange"+"__"+numtag[i]).replace('-','_')
+                    print(key)
+                    trans.to_hdf(trans_file.with_suffix(".hdf"), key=key)
+#                    trans.to_hdf("/home/kawashima/database/CH4/12C-1H4/YT34to10/all.hdf", key=key)
                     ndtrans=trans.to_numpy()
                     del trans
                 self.trans_file.append(trans_file)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -133,6 +133,7 @@ class MdbExomol(object):
             else:
                 print(explanation)
                 trans=exomolapi.read_trans(self.trans_file)
+                ndtrans=trans.to_numpy()
 
                 #mask needs to be applied
                 mask_needed=True
@@ -148,8 +149,6 @@ class MdbExomol(object):
 
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
-                ndtrans=trans.to_numpy()
-
                 key=("nurange"+"__"+numtag[i]).replace("-","_")
                 trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                 del trans
@@ -197,6 +196,7 @@ class MdbExomol(object):
                 else:
                     print(explanation)
                     trans=exomolapi.read_trans(trans_file)
+                    ndtrans=trans.to_numpy()
                     
                     #mask needs to be applied
                     mask_needed=True
@@ -222,8 +222,6 @@ class MdbExomol(object):
 
                     trans["nu_lines"]=self.nu_lines
                     trans["Sij0"]=self.Sij0
-                    ndtrans=trans.to_numpy()
-
                     key=("nurange"+"__"+numtag[i]).replace("-","_")
                     trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                     del trans

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -120,6 +120,9 @@ class MdbExomol(object):
                 ndtrans=trans.to_numpy()
                 del trans
 
+                #mask has been alraedy applied when reading the hdf file in the above
+                mask_needed=False
+
                 #compute gup and elower
                 self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
 
@@ -131,6 +134,9 @@ class MdbExomol(object):
                 print(explanation)
                 trans=exomolapi.read_trans(self.trans_file)
                 ndtrans=trans.to_numpy()
+
+                #mask needs to be applied
+                mask_needed=True
 
                 #compute gup and elower
                 self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
@@ -167,6 +173,9 @@ class MdbExomol(object):
                     ndtrans=trans.to_numpy()
                     del trans
 
+                    #mask has been alraedy applied when reading the hdf file in the above
+                    mask_needed=False
+
                     self.trans_file.append(trans_file)
                     #compute gup and elower
                     if k==0:
@@ -189,6 +198,9 @@ class MdbExomol(object):
                     trans=exomolapi.read_trans(trans_file)
                     ndtrans=trans.to_numpy()
                     
+                    #mask needs to be applied
+                    mask_needed=True
+
                     self.trans_file.append(trans_file)
                     #compute gup and elower
                     if k==0:
@@ -218,27 +230,29 @@ class MdbExomol(object):
         mask=(self.nu_lines>self.nurange[0]-self.margin)\
         *(self.nu_lines<self.nurange[1]+self.margin)\
         *(self.Sij0>self.crit)
+
+        self.masking(mask,mask_needed)
         
-        self.masking(mask)
-        
-    def masking(self,mask):
+    def masking(self,mask,mask_needed=True):
         """applying mask and (re)generate jnp.arrays
         
         Args:
            mask: mask to be applied. self.mask is updated.
+           mask_needed: whether mask needs to be applied or not
 
         Note:
            We have nd arrays and jnp arrays. We apply the mask to nd arrays and generate jnp array from the corresponding nd array. For instance, self._A is nd array and self.A is jnp array.
 
         """
-        #numpy float 64 Do not convert them jnp array
-        self.nu_lines = self.nu_lines[mask]
-        self.Sij0 = self.Sij0[mask]
-        self._A=self._A[mask]
-        self._elower=self._elower[mask]
-        self._gpp=self._gpp[mask]
-        self._jlower=self._jlower[mask]
-        self._jupper=self._jupper[mask]
+        if mask_needed:
+            #numpy float 64 Do not convert them jnp array
+            self.nu_lines = self.nu_lines[mask]
+            self.Sij0 = self.Sij0[mask]
+            self._A=self._A[mask]
+            self._elower=self._elower[mask]
+            self._gpp=self._gpp[mask]
+            self._jlower=self._jlower[mask]
+            self._jupper=self._jupper[mask]
         
         #jnp arrays
         self.dev_nu_lines=jnp.array(self.nu_lines)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -149,8 +149,8 @@ class MdbExomol(object):
 
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
-                key=("nurange"+"__"+numtag[i]).replace("-","_")
-                trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
+                key="all_nurange"
+                trans.to_hdf(self.trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                 del trans
         else:
             imin=np.searchsorted(numinf,self.nurange[0],side="right")-1 #left side


### PR DESCRIPTION
For the purpose of reducing the required RAM memory when reading numerous transition line data, I have made the following modifications.
- modified moldb.py to save the transition data in hdf file instead of the feather one, which enables us to mask the transition data while reading the transition file after the second time
- To enable the masking when reading the hdf file, I have changed the moldb.py to also save 'updated' nu_lines and calculated Sij0 in the hdf file
- added "mask_needed" parameter in "masking" function so that masking process can be skipped when reading the transition data from the hdf file.

Thank you.