### PR TITLE
Cut on log of critical value rather than raw value

### DIFF
--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -61,6 +61,7 @@ class MdbExomol(object):
         molecbroad=t0+"__"+self.bkgdatm
 
         self.crit = crit
+        self.log_crit = np.log10(crit)
         self.margin = margin
         self.nurange=[np.min(nurange),np.max(nurange)]
         self.broadf=broadf
@@ -149,6 +150,7 @@ class MdbExomol(object):
 
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
+                trans['logSij0']=np.log10(self.Sij0)
                 key="all_nurange"
                 trans.to_hdf(self.trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
                 del trans
@@ -167,7 +169,7 @@ class MdbExomol(object):
                     where.append("nu_lines>nu_lines_min")
                     where.append("nu_lines<nu_lines_max")
                     if not np.isneginf(self.crit):
-                        where.append("Sij0>self.crit")
+                        where.append("logSij0>self.log_crit")
 
                     trans=pd.read_hdf(trans_file.with_suffix(".hdf"), where=where)
                     ndtrans=trans.to_numpy()


### PR DESCRIPTION
Hi @HajimeKawahara and @ykawashima, 

I'm working with the dev branch and had problems querying the new HDF5 tables via the `crit` keyword. I still can't figure out exactly what the cause of the problem is, but the `where` command in `pd.read_hdf` is not respecting the critical `Sij0`. I'm wondering if this has to do with the floats we use to represent small values of Sij0. For example, I've been using TiO with `crit~1e-16` and finding that the `MdbExomol` object that gets returned is empty, even though there should be some lines in my wavelength range. 

In my experimentations, I found that I could fix this if I alter the `where` query based on the _log_ of the Sij0 values, which is what I've implemented in this PR. This makes for a larger HDF5 database, but the tradeoff is that you can then successfully read-in only portions of it. This PR will only "work" if you delete your existing HDF archives.

If you have any insight on how to improve this PR to make the old behavior work correctly, your help is appreciated and I'll happily close this PR 😄 