### PR TITLE
Added a feature to remove transitions with zero wavenumber

### DIFF
--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -183,7 +183,7 @@ def pickup_gE(states,ndtrans,trans_file,trans_lines=False):
         jupper=jupper[mask]
         print("WARNING: {0:,} transitions with the wavenumber=zero in {1} have been ignored.".format(len_org - len(nu_lines), trans_file))
         if trans_lines:
-            print("This is because the value for the wavenumber culumn in the transition file is zero for those transitions.")
+            print("This is because the value for the wavenumber column in the transition file is zero for those transitions.")
         else:
             print("This is because the upper and lower state IDs in the transition file indicate the same energy level when referring to the states file for those transitions.")
 

--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -128,12 +128,13 @@ def read_states(statesf):
     return dat
 
 
-def pickup_gE(states,ndtrans,trans_lines=False):
+def pickup_gE(states,ndtrans,trans_file,trans_lines=False):
     """extract g_upper (gup), E_lower (elower), and J_lower and J_upper from states DataFrame and insert them to transition DataFrame.
 
     Args:
        states: states pandas DataFrame
        ndtrans: transition numpy array
+       trans_file: name of the transition file
        trans_lines: By default (False) we use nu_lines computed using the state file, i.e. E_upper - E_lower. If trans_nuline=True, we use the nu_lines in the transition file. Note that some trans files do not this info.
 
 
@@ -169,6 +170,23 @@ def pickup_gE(states,ndtrans,trans_lines=False):
     else:
         nu_lines=eupper-elower
     
+    ### MASKING ###
+    mask=(nu_lines>0.0)
+    if False in mask:
+        len_org = len(nu_lines)
+
+        A=A[mask]
+        nu_lines=nu_lines[mask]
+        elower=elower[mask]
+        gup=gup[mask]
+        jlower=jlower[mask]
+        jupper=jupper[mask]
+        print("WARNING: {0:,} transitions with the wavenumber=zero in {1} have been ignored.".format(len_org - len(nu_lines), trans_file))
+        if trans_lines:
+            print("This is because the value for the wavenumber culumn in the transition file is zero for those transitions.")
+        else:
+            print("This is because the upper and lower state IDs in the transition file indicate the same energy level when referring to the states file for those transitions.")
+
     #See Issue #16
     #import matplotlib.pyplot as plt
     #nu_lines_t=ndtrans[:,3]
@@ -178,7 +196,7 @@ def pickup_gE(states,ndtrans,trans_lines=False):
     #plt.savefig("nudiff.png", bbox_inches="tight", pad_inches=0.0)
     #plt.show()
 
-    return A, nu_lines, elower, gup, jlower, jupper
+    return A, nu_lines, elower, gup, jlower, jupper, mask
 
 
 def pickup_gEslow(states,trans):

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -134,7 +134,7 @@ class MdbExomol(object):
                 mask_needed=True
 
             #compute gup and elower
-            self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
+            self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper, mask_zeronu=exomolapi.pickup_gE(states,ndtrans,self.trans_file)
 
             if self.trans_file.with_suffix(".hdf").exists():
                 self.Sij0=ndtrans[:,4]
@@ -142,6 +142,7 @@ class MdbExomol(object):
                 ##Line strength: input should be ndarray not jnp array
                 self.Sij0=exomol.Sij0(self._A,self._gpp,self.nu_lines,self._elower,self.QTref)
 
+                trans=trans[mask_zeronu]
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
                 key="all_nurange"
@@ -175,21 +176,23 @@ class MdbExomol(object):
 
                 #compute gup and elower
                 if k==0:
-                    self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper=exomolapi.pickup_gE(states,ndtrans)
+                    self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper, mask_zeronu=exomolapi.pickup_gE(states,ndtrans,trans_file)
                     if trans_file.with_suffix(".hdf").exists():
                         self.Sij0=ndtrans[:,4]
                     else:
                         ##Line strength: input should be ndarray not jnp array
                         self.Sij0=exomol.Sij0(self._A,self._gpp,self.nu_lines,self._elower,self.QTref)
+                        trans=trans[mask_zeronu]
                         trans["nu_lines"]=self.nu_lines
                         trans["Sij0"]=self.Sij0
                 else:
-                    Ax, nulx, elowerx, gppx, jlowerx, jupperx=exomolapi.pickup_gE(states,ndtrans)
+                    Ax, nulx, elowerx, gppx, jlowerx, jupperx, mask_zeronu=exomolapi.pickup_gE(states,ndtrans,trans_file)
                     if trans_file.with_suffix(".hdf").exists():
                         Sij0x=ndtrans[:,4]
                     else:
                         ##Line strength: input should be ndarray not jnp array
                         Sij0x=exomol.Sij0(Ax,gppx,nulx,elowerx,self.QTref)
+                        trans=trans[mask_zeronu]
                         trans["nu_lines"]=nulx
                         trans["Sij0"]=Sij0x
 


### PR DESCRIPTION
Regarding the issue reported by @bmorris3 in #99, I have modified the code to remove transitions the wavenumbers of which result in zero. This is due to either of the following reasons that are attributed to the original transition/states files.

- The upper and lower state IDs in the transition file indicate the same energy level when referring to the states file
- The value for the wavenumber column in the transition file is zero

I have also added a warning for this case.