### PR TITLE
Modified to use vaex instead of pandas

### DIFF
--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -125,9 +125,9 @@ def read_trans(transf):
 
     """
     try:
-        dat = vaex.from_csv(transf,compression="bz2",sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
+        dat = vaex.from_csv(transf,compression="bz2",sep="\s+",names=("i_upper","i_lower","A","nu_lines"),convert=True)
     except:
-        dat = vaex.read_csv(transf,sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
+        dat = vaex.read_csv(transf,sep="\s+",names=("i_upper","i_lower","A","nu_lines"),convert=True)
 
     return dat 
 

--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -3,6 +3,7 @@
 """
 import numpy as np
 import pandas as pd
+import vaex
 
 def read_def(deff):
     """Exomol IO for a definition file
@@ -120,13 +121,13 @@ def read_trans(transf):
     Args: 
         transf: transition file
     Returns:
-        transition data in pandas DataFrame
+        transition data in vaex DataFrame
 
     """
     try:
-        dat = pd.read_csv(transf,compression="bz2",sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
+        dat = vaex.from_csv(transf,compression="bz2",sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
     except:
-        dat = pd.read_csv(transf,sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
+        dat = vaex.read_csv(transf,sep="\s+",names=("i_upper","i_lower","A","nu_lines"))
 
     return dat 
 

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -121,7 +121,6 @@ class MdbExomol(object):
                     cdt=cdt * (trans.Sij0>self.crit)
                 trans=trans[cdt]
                 ndtrans=vaex.array_types.to_numpy(trans)
-                del trans
 
                 #mask has been alraedy applied
                 mask_needed=False
@@ -150,7 +149,6 @@ class MdbExomol(object):
                 trans["nu_lines"]=self.nu_lines
                 trans["Sij0"]=self.Sij0
                 trans.export(self.trans_file.with_suffix(".hdf5"))
-                del trans
         else:
             imin=np.searchsorted(numinf,self.nurange[0],side="right")-1 #left side
             imax=np.searchsorted(numinf,self.nurange[1],side="right")-1 #left side
@@ -168,7 +166,6 @@ class MdbExomol(object):
                         cdt=cdt * (trans.Sij0>self.crit)
                     trans=trans[cdt]
                     ndtrans=vaex.array_types.to_numpy(trans)
-                    del trans
                     self.trans_file.append(trans_file)
 
                     #mask has been alraedy applied
@@ -224,7 +221,6 @@ class MdbExomol(object):
 
                 if not trans_file.with_suffix(".hdf5").exists():
                     trans.export(trans_file.with_suffix(".hdf5"))
-                    del trans
         
         ### MASKING ###
         mask=(self.nu_lines>self.nurange[0]-self.margin)\

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -52,7 +52,8 @@ class MdbExomol(object):
            The trans/states files can be very large. For the first time to read it, we convert it to the feather-format. After the second-time, we use the feather format instead.
 
         """
-        explanation="Note: Couldn't find the hdf5 format. We convert data to the hdf5 format. After the second time, it will become much faster."
+        explanation_states="Note: Couldn't find the feather format. We convert data to the feather format. After the second time, it will become much faster."
+        explanation_trans="Note: Couldn't find the hdf5 format. We convert data to the hdf5 format. After the second time, it will become much faster."
         
         self.path = pathlib.Path(path)
         t0=self.path.parents[0].stem        
@@ -94,7 +95,7 @@ class MdbExomol(object):
         if self.states_file.with_suffix(".feather").exists():
             states=pd.read_feather(self.states_file.with_suffix(".feather"))
         else:
-            print(explanation)
+            print(explanation_states)
             states=exomolapi.read_states(self.states_file)
             states.to_feather(self.states_file.with_suffix(".feather"))
         #load pf
@@ -125,7 +126,7 @@ class MdbExomol(object):
                 #mask has been alraedy applied
                 mask_needed=False
             else:
-                print(explanation)
+                print(explanation_trans)
                 trans=exomolapi.read_trans(self.trans_file)
                 ndtrans=vaex.array_types.to_numpy(trans)
 
@@ -173,7 +174,7 @@ class MdbExomol(object):
                     #mask has been alraedy applied
                     mask_needed=False
                 else:
-                    print(explanation)
+                    print(explanation_trans)
                     trans=exomolapi.read_trans(trans_file)
                     ndtrans=vaex.array_types.to_numpy(trans)
                     self.trans_file.append(trans_file)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -52,7 +52,7 @@ class MdbExomol(object):
            The trans/states files can be very large. For the first time to read it, we convert it to the feather-format. After the second-time, we use the feather format instead.
 
         """
-        explanation="Note: Couldn't find the hdf format. We convert data to the hdf format. After the second time, it will become much faster."
+        explanation="Note: Couldn't find the hdf5 format. We convert data to the hdf5 format. After the second time, it will become much faster."
         
         self.path = pathlib.Path(path)
         t0=self.path.parents[0].stem        
@@ -159,18 +159,23 @@ class MdbExomol(object):
                 if not trans_file.exists():
                     self.download(molec,extension=[".trans.bz2"],numtag=numtag[i])
 
-                if trans_file.with_suffix(".hdf").exists():
-                    trans=pd.read_hdf(trans_file.with_suffix(".hdf"), where=where)
-                    ndtrans=trans.to_numpy()
+                if trans_file.with_suffix(".hdf5").exists():
+                    trans=vaex.open(self.trans_file.with_suffix(".hdf5"))
+                    cdt=(trans.nu_lines>self.nurange[0]-self.margin) \
+                        * (trans.nu_lines<self.nurange[1]+self.margin)
+                    if not np.isneginf(self.crit):
+                        cdt=cdt * (trans.Sij0>self.crit)
+                    trans=trans[cdt]
+                    ndtrans=vaex.array_types.to_numpy(trans)
                     del trans
                     self.trans_file.append(trans_file)
 
-                    #mask has been alraedy applied when reading the hdf file in the above
+                    #mask has been alraedy applied
                     mask_needed=False
                 else:
                     print(explanation)
                     trans=exomolapi.read_trans(trans_file)
-                    ndtrans=trans.to_numpy()
+                    ndtrans=vaex.array_types.to_numpy(trans)
                     self.trans_file.append(trans_file)
                     
                     #mask needs to be applied
@@ -179,22 +184,32 @@ class MdbExomol(object):
                 #compute gup and elower
                 if k==0:
                     self._A, self.nu_lines, self._elower, self._gpp, self._jlower, self._jupper, mask_zeronu=exomolapi.pickup_gE(states,ndtrans,trans_file)
-                    if trans_file.with_suffix(".hdf").exists():
+                    if trans_file.with_suffix(".hdf5").exists():
                         self.Sij0=ndtrans[:,4]
                     else:
                         ##Line strength: input should be ndarray not jnp array
                         self.Sij0=exomol.Sij0(self._A,self._gpp,self.nu_lines,self._elower,self.QTref)
-                        trans=trans[mask_zeronu]
+
+                        #exclude the lines whose nu_lines evaluated inside exomolapi.pickup_gE (thus sometimes different from the "nu_lines" column in trans) is not positive
+                        trans["nu_positive"]=mask_zeronu
+                        trans=trans[trans.nu_positive].extract()
+                        trans.drop('nu_positive',inplace=True)
+
                         trans["nu_lines"]=self.nu_lines
                         trans["Sij0"]=self.Sij0
                 else:
                     Ax, nulx, elowerx, gppx, jlowerx, jupperx, mask_zeronu=exomolapi.pickup_gE(states,ndtrans,trans_file)
-                    if trans_file.with_suffix(".hdf").exists():
+                    if trans_file.with_suffix(".hdf5").exists():
                         Sij0x=ndtrans[:,4]
                     else:
                         ##Line strength: input should be ndarray not jnp array
                         Sij0x=exomol.Sij0(Ax,gppx,nulx,elowerx,self.QTref)
-                        trans=trans[mask_zeronu]
+
+                        #exclude the lines whose nu_lines evaluated inside exomolapi.pickup_gE (thus sometimes different from the "nu_lines" column in trans) is not positive
+                        trans["nu_positive"]=mask_zeronu
+                        trans=trans[trans.nu_positive].extract()
+                        trans.drop('nu_positive',inplace=True)
+
                         trans["nu_lines"]=nulx
                         trans["Sij0"]=Sij0x
 
@@ -206,9 +221,8 @@ class MdbExomol(object):
                     self._jupper=np.hstack([self._jupper,jupperx])
                     self.Sij0=np.hstack([self.Sij0,Sij0x])
 
-                if not trans_file.with_suffix(".hdf").exists():
-                    key=("nurange"+"__"+numtag[i]).replace("-","_")
-                    trans.to_hdf(trans_file.with_suffix(".hdf"), key=key, format="table", data_columns=True)
+                if not trans_file.with_suffix(".hdf5").exists():
+                    trans.export(trans_file.with_suffix(".hdf5"))
                     del trans
         
         ### MASKING ###

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -161,7 +161,7 @@ class MdbExomol(object):
                     self.download(molec,extension=[".trans.bz2"],numtag=numtag[i])
 
                 if trans_file.with_suffix(".hdf5").exists():
-                    trans=vaex.open(self.trans_file.with_suffix(".hdf5"))
+                    trans=vaex.open(trans_file.with_suffix(".hdf5"))
                     cdt=(trans.nu_lines>self.nurange[0]-self.margin) \
                         * (trans.nu_lines<self.nurange[1]+self.margin)
                     if not np.isneginf(self.crit):


### PR DESCRIPTION
Based on the [kind advice](https://github.com/HajimeKawahara/exojax/pull/99#issuecomment-882553032) from @erwanp, I have modified the code to use vaex, which is indeed much faster!!, instead of pandas. (For example, for the case of 11300-11400 wavenumber grid file of [this Exomol CH4 line list](https://www.exomol.com/data/molecules/CH4/12C-1H4/YT34to10/), the cpu time for the first time call of [moldb.MdbExomol](https://github.com/HajimeKawahara/exojax/blob/22a15577495ab1c2b8f0341307b64d05b7c85075/src/exojax/spec/moldb.py) has been decreased by 70% in my environment. I used nus,wav,res=nugrid(11310,11390,1000) without crit option.)

I switched on the option of convert=True when reading the transition data from the CSV file. This option allows the code to read large CSV file in chunks while taking slightly longer cpu time (for ex., 1.5% for 8300-8400 wavenumber grid file of [the same Exomol CH4 line list](https://www.exomol.com/data/molecules/CH4/12C-1H4/YT34to10/). See [here](https://vaex.io/docs/faq.html) for the details of this option.)

Thank you.