### PR TITLE
Features/rm feather

### DIFF
--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -107,6 +107,7 @@ def read_pf(pff):
 
     """
     dat = pd.read_csv(pff,sep="\s+",names=("T","QT"))
+
     return dat
 
 def read_trans(transf):
@@ -283,6 +284,8 @@ def read_broad(broadf):
                "kalower","kclower","kaupper","kcupper",\
                "v1lower","v2lower","v3lower",\
                "v1upper","v2upper","v3upper"))
+
+
     return bdat
 
 def check_bdat(bdat):

--- a/src/exojax/spec/exomolapi.py
+++ b/src/exojax/spec/exomolapi.py
@@ -147,18 +147,18 @@ def read_states(statesf):
 
     """
     try:        
-        dat = pd.read_csv(statesf,compression="bz2",sep="\s+",usecols=range(4),names=("i","E","g","J"))
+        dat = vaex.from_csv(statesf,compression="bz2",sep="\s+",usecols=range(4),names=("i","E","g","J"),convert=True)
     except:
-        dat = pd.read_csv(statesf,sep="\s+",usecols=range(4),names=("i","E","g","J"))
+        dat = vaex.read_csv(statef,sep="\s+",usecols=range(4),names=("i","E","g","J"),convert=True)
         
     return dat
 
 
-def pickup_gE(states,ndtrans,trans_file,trans_lines=False):
+def pickup_gE(ndstates,ndtrans,trans_file,trans_lines=False):
     """extract g_upper (gup), E_lower (elower), and J_lower and J_upper from states DataFrame and insert them to transition DataFrame.
 
     Args:
-       states: states pandas DataFrame
+       ndstates: states numpy array
        ndtrans: transition numpy array
        trans_file: name of the transition file
        trans_lines: By default (False) we use nu_lines computed using the state file, i.e. E_upper - E_lower. If trans_nuline=True, we use the nu_lines in the transition file. Note that some trans files do not this info.
@@ -172,11 +172,11 @@ def pickup_gE(states,ndtrans,trans_file,trans_lines=False):
 
 
     """
-    ndstates=states.to_numpy()
-
+    #ndstates=states.to_numpy()
+    
     iorig=np.array(ndstates[:,0],dtype=int)
     maxii=int(np.max(iorig)+1) 
-    newstates=np.zeros((maxii,np.shape(states)[1]-1),dtype=float)
+    newstates=np.zeros((maxii,np.shape(ndstates)[1]-1),dtype=float)
     newstates[iorig,:]=ndstates[:,1:] 
 
     i_upper=np.array(ndtrans[:,0],dtype=int)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -91,13 +91,12 @@ class MdbExomol(object):
             self.alpha_ref_def=0.07
 
         #load states
-        if self.states_file.with_suffix(".hdf5").exists():
-            states=vaex.open(self.states_file.with_suffix(".hdf5"))
+        if self.states_file.with_suffix(".bz2.hdf5").exists():
+            states=vaex.open(self.states_file.with_suffix(".bz2.hdf5"))
             ndstates=vaex.array_types.to_numpy(states)
         else:
             print(explanation_states)
             states=exomolapi.read_states(self.states_file)
-            states.export(self.states_file.with_suffix(".hdf5"))
             ndstates=vaex.array_types.to_numpy(states)
 
         #load pf


### PR DESCRIPTION
Related to #112. unified to Vaex for large files.
- not only the trans but also the states file is saved as the Vaex format.
- To do so, changed the input of exomolapi.pickup_gE to numpy array of the state from pandas. 
