### PR TITLE
bugfix: autospec for CN

### DIFF
--- a/src/exojax/spec/defmol.py
+++ b/src/exojax/spec/defmol.py
@@ -114,6 +114,5 @@ if __name__ == "__main__":
     print(search_molfile("ExoMol","12C-16O"))
     print(search_molfile("ExoMol","CO"))
     print(search_molfile("ExoMol","CN"))
-
     print(search_molfile("HITRAN","CO"))
     print(search_molfile("HITEMP","CO"))


### PR DESCRIPTION
Auto recommendation failed. Added the recommendation manually in defmol.py

```python
from exojax.spec import	AutoXS
import numpy as	np
nus=np.linspace(1800.0,2200.0,40000,dtype=np.float64)
autoxs=AutoXS(nus,"ExoMol","CN")
xsv=autoxs.xsection(1000.0,1.0)
```

![CN](https://user-images.githubusercontent.com/15956904/136533761-5905e248-6671-43a4-953d-95c96abfa511.png)
