### PR TITLE
remove out-of-bounds check in jax function

### DIFF
--- a/src/exojax/spec/dit.py
+++ b/src/exojax/spec/dit.py
@@ -63,7 +63,7 @@ def npgetix(x,xv):
     indarr=np.arange(len(xv))
     pos = np.interp(x,xv,indarr)
     index = (pos).astype(int)
-    assert jnp.max(index) + 1 < len(xv)
+    assert np.max(index) + 1 < len(xv)
     cont = (pos-index)
     return cont,index
 

--- a/src/exojax/spec/dit.py
+++ b/src/exojax/spec/dit.py
@@ -40,7 +40,6 @@ def getix(x,xv):
     indarr=jnp.arange(len(xv))
     pos = jnp.interp(x,xv,indarr)
     index = (pos).astype(int)
-    assert jnp.max(index) + 1 < len(xv)
     cont = (pos-index)
     return cont,index
 


### PR DESCRIPTION
JAX cannot handle the out-of-bounds check during JIT, so I took it out.
Should have tested this before opening the previous PR, sorry for that..