### PR TITLE
Multi hitemp (bug fix)

### DIFF
--- a/documents/userguide/hitran.rst
+++ b/documents/userguide/hitran.rst
@@ -26,7 +26,7 @@ from exojax is like that.
 HITEMP H2O and CO2
 ^^^^^^^^^^^^^^^^^
 
-For H2O and CO2, HITEMP provides multiple par files. To use those files, provide the directory path for ``moldb.MdbHit`` as follows. Note that the code interpret '01_HITEMP2020', '01_HITEMP2010.par', '01_HITEMP2019.par', and '01_HITEMP2020.par' as '01_HITEMP2010', too.
+For H2O and CO2, HITEMP provides multiple par files. To use those files, provide the directory path for ``moldb.MdbHit`` as follows.
 
 .. code:: ipython
 	  

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -470,11 +470,17 @@ class MdbHit(object):
             self._elower = hapi.getColumn(molec, 'elower')
             self._gpp = hapi.getColumn(molec, 'gpp')
         else:
-            # remove '.par' for HITEMP H2O and CO2 (multiple file cases)
-            if '.par' in str(self.path):
-                self.path = pathlib.Path(str(self.path).replace('.par', ''))
-
             molnm = str(self.path.name)[0:2]
+            if molnm == '01':
+                if self.path.name != '01_HITEMP2010':
+                    path_old = self.path
+                    self.path = self.path.parent/'01_HITEMP2010'
+                    print('Warning: Changed the line list path from', path_old, 'to', self.path)
+            if molnm == '02':
+                if self.path.name != '02_HITEMP2010':
+                    path_old = self.path
+                    self.path = self.path.parent/'02_HITEMP2010'
+                    print('Warning: Changed the line list path from', path_old, 'to', self.path)
 
             imin = np.searchsorted(
                 numinf, self.nurange[0], side='right')-1  # left side
@@ -482,7 +488,7 @@ class MdbHit(object):
                 numinf, self.nurange[1], side='right')-1  # left side
             for k, i in enumerate(range(imin, imax+1)):
                 flname = pathlib.Path(molnm+'_'+numtag[i]+'_HITEMP2010.par')
-                sub_file = self.path / numtag[i] / flname
+                sub_file = self.path/numtag[i]/flname
                 if not sub_file.exists():
                     self.download(numtag=numtag[i])
 


### PR DESCRIPTION
I have just changed a few lines so that the line lists of HITEMP H2O and CO2 should be saved in the directory "01_HITEMP2010" and "02_HITEMP2010" even if the user specify the directory such as "HITEMP2019" or "HITEMP2020".