### PR TITLE
hotfix for autoxs crit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
             ),
             'write_to_template': '__version__ = "{version}"\n',
         },
-        version='1.1.0',
+        version='1.1.1',
         author=find_meta('author'),
         author_email=find_meta('email'),
         maintainer=find_meta('author'),

--- a/src/exojax/spec/autospec.py
+++ b/src/exojax/spec/autospec.py
@@ -22,7 +22,7 @@ __all__ = ['AutoXS', 'AutoRT']
 class AutoXS(object):
     """exojax auto cross section generator."""
 
-    def __init__(self, nus, database, molecules, databasedir='.database', memory_size=30, broadf=True, crit=-np.inf, xsmode='auto', autogridconv=True, pdit=1.5):
+    def __init__(self, nus, database, molecules, databasedir='.database', memory_size=30, broadf=True, crit=0.0, xsmode='auto', autogridconv=True, pdit=1.5):
         """
         Args:
            nus: wavenumber bin (cm-1)


### PR DESCRIPTION
I found we forgot to update `crit=0.0` for autoxs, yielding error for autoxs by default.  This bug is related to #225 

See [this discussion](https://github.com/HajimeKawahara/exojax/pull/225#issuecomment-1059762128) for autort. 