### PR TITLE
Setdgm hitran

### DIFF
--- a/src/exojax/spec/hapi.py
+++ b/src/exojax/spec/hapi.py
@@ -16809,6 +16809,15 @@ def BD_TIPS_2017_PYTHON_SLICE(M, I, T, n=20):  # testing
     return None, Qt
 
 
+def get_TMIN_TMAX_FOR_BD_TIPS_2017_PYTHON(M, I):
+    # get temperature grid
+    TT = TIPS_2017_ISOT_HASH[(M, I)]
+    Tmin = min(TT)
+    Tmax = max(TT)
+
+    return Tmin, Tmax
+
+
 # ALIASES FOR TIPS
 def PYTIPS2011(M, I, T): return BD_TIPS_2011_PYTHON(M, I, T)[1]
 def PYTIPS2017(M, I, T): return BD_TIPS_2017_PYTHON(M, I, T)[1]

--- a/src/exojax/spec/modit.py
+++ b/src/exojax/spec/modit.py
@@ -21,6 +21,9 @@ from exojax.spec import gamma_natural
 from exojax.spec.hitran import SijT
 from exojax.spec import normalized_doppler_sigma
 
+# hitran/hitemp
+from exojax.spec.hitran import gamma_hitran
+
 # vald
 from exojax.spec.atomll import gamma_vald3, interp_QT284
 
@@ -289,6 +292,63 @@ def setdgm_exomol(mdb, fT, Parr, R, molmass, res, *kargs):
     Tarr_list = fT(*kargs)
     for Tarr in Tarr_list:
         SijM, ngammaLM, nsigmaDl = exomol(mdb, Tarr, Parr, R, molmass)
+        set_dgm_minmax.append(minmax_dgmatrix(ngammaLM, res))
+    dgm_ngammaL = precompute_dgmatrix(set_dgm_minmax, res=res)
+    return jnp.array(dgm_ngammaL)
+
+
+def hitran(mdb, Tarr, Parr, Pself, R, molmass):
+    """compute molecular line information required for MODIT using HITRAN/HITEMP mdb.
+    Note that the partition function ratio for temperatures above 3,500 K is assumed to be the value at 3,500 K since HAPI does not support those high temperatures.
+    Args:
+       mdb: mdb instance
+       Tarr: Temperature array
+       Parr: Pressure array
+       Pself: Partial pressure array
+       R: spectral resolution
+       molmass: molecular mass
+    Returns:
+       line intensity matrix,
+       normalized gammaL matrix,
+       normalized sigmaD matrix
+    """
+    Tarr = np.clip(Tarr, None, 3500.)
+    qt = mdb.Qr_layer_HAPI(Tarr)
+    SijM = jit(vmap(SijT, (0, None, None, None, 0)))(
+        Tarr, mdb.logsij0, mdb.dev_nu_lines, mdb.elower, qt)
+    gammaLMP = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))(
+        Parr, Tarr, Pself, mdb.n_air, mdb.gamma_air, mdb.gamma_self)
+    gammaLMN = gamma_natural(mdb.A)
+    gammaLM = gammaLMP+gammaLMN[None, :]
+    ngammaLM = gammaLM/(mdb.dev_nu_lines/R)
+    nsigmaDl = normalized_doppler_sigma(Tarr, molmass, R)[:, jnp.newaxis]
+    return SijM, ngammaLM, nsigmaDl
+
+
+def setdgm_hitran(mdb, fT, Parr, Pself_ref, R, molmass, res, *kargs):
+    """Easy Setting of DIT Grid Matrix (dgm) using HITRAN/HITEMP.
+    Args:
+       mdb: mdb instance
+       fT: function of temperature array
+       Parr: pressure array
+       Pself_ref: reference partial pressure array
+       R: spectral resolution
+       molmass: molecular mass
+       res: resolution of dgm
+       *kargs: arguments for fT
+    Returns:
+       DIT Grid Matrix (dgm) of normalized gammaL
+    Example:
+       >>> fT = lambda T0,alpha: T0[:,None]*(Parr[None,:]/Pref)**alpha[:,None]
+       >>> T0_test=np.array([1100.0,1500.0,1100.0,1500.0])
+       >>> alpha_test=np.array([0.2,0.2,0.05,0.05])
+       >>> res=0.2
+       >>> dgm_ngammaL=setdgm_hitran(mdbCH4,fT,Parr,Pself,R,molmassCH4,res,T0_test,alpha_test)
+    """
+    set_dgm_minmax = []
+    Tarr_list = fT(*kargs)
+    for Tarr in Tarr_list:
+        SijM, ngammaLM, nsigmaDl = hitran(mdb, Tarr, Parr, Pself_ref, R, molmass)
         set_dgm_minmax.append(minmax_dgmatrix(ngammaLM, res))
     dgm_ngammaL = precompute_dgmatrix(set_dgm_minmax, res=res)
     return jnp.array(dgm_ngammaL)

--- a/src/exojax/spec/modit.py
+++ b/src/exojax/spec/modit.py
@@ -299,7 +299,6 @@ def setdgm_exomol(mdb, fT, Parr, R, molmass, res, *kargs):
 
 def hitran(mdb, Tarr, Parr, Pself, R, molmass):
     """compute molecular line information required for MODIT using HITRAN/HITEMP mdb.
-    Note that the partition function ratio for temperatures above 3,500 K is assumed to be the value at 3,500 K since HAPI does not support those high temperatures.
     Args:
        mdb: mdb instance
        Tarr: Temperature array
@@ -312,11 +311,7 @@ def hitran(mdb, Tarr, Parr, Pself, R, molmass):
        normalized gammaL matrix,
        normalized sigmaD matrix
     """
-    if(max(Tarr) > 3500.):
-        print('Warning: partition function ratio for temperatures > 3,500 K is assumed to be the value at 3,500 K since HAPI does not support those temperatures.')
-        qt = mdb.Qr_layer_HAPI(np.clip(Tarr, None, 3500.))
-    else:
-        qt = mdb.Qr_layer_HAPI(Tarr)
+    qt = mdb.Qr_layer_HAPI(Tarr)
     SijM = jit(vmap(SijT, (0, None, None, None, 0)))(
         Tarr, mdb.logsij0, mdb.dev_nu_lines, mdb.elower, qt)
     gammaLMP = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))(

--- a/src/exojax/spec/modit.py
+++ b/src/exojax/spec/modit.py
@@ -312,8 +312,11 @@ def hitran(mdb, Tarr, Parr, Pself, R, molmass):
        normalized gammaL matrix,
        normalized sigmaD matrix
     """
-    Tarr = np.clip(Tarr, None, 3500.)
-    qt = mdb.Qr_layer_HAPI(Tarr)
+    if(max(Tarr) > 3500.):
+        print('Warning: partition function ratio for temperatures > 3,500 K is assumed to be the value at 3,500 K since HAPI does not support those temperatures.')
+        qt = mdb.Qr_layer_HAPI(np.clip(Tarr, None, 3500.))
+    else:
+        qt = mdb.Qr_layer_HAPI(Tarr)
     SijM = jit(vmap(SijT, (0, None, None, None, 0)))(
         Tarr, mdb.logsij0, mdb.dev_nu_lines, mdb.elower, qt)
     gammaLMP = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))(

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -755,9 +755,9 @@ class MdbHit(object):
         for iso in self.uniqiso:
             Tmin, Tmax = hapi.get_TMIN_TMAX_FOR_BD_TIPS_2017_PYTHON(self.molecid, iso)
             if(max(allT) > Tmax):
-                print('Warning: partition function ratio for isotope %d of molecule %d at temperatures > %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmax, Tmax))
+                print('Warning: partition function ratio for isotope #%d of molecule #%d at temperatures > %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmax, Tmax))
             if(min(allT) < Tmin):
-                print('Warning: partition function ratio for isotope %d of molecule %d at temperatures < %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmin, Tmin))
+                print('Warning: partition function ratio for isotope #%d of molecule #%d at temperatures < %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmin, Tmin))
             allT_iso = list(np.clip(allT, Tmin, Tmax))
             Qrx.append(hapi.partitionSum(self.molecid, iso, allT_iso))
         Qrx = np.array(Qrx)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -753,7 +753,13 @@ class MdbHit(object):
         allT = list(np.concatenate([[self.Tref], Tarr]))
         Qrx = []
         for iso in self.uniqiso:
-            Qrx.append(hapi.partitionSum(self.molecid, iso, allT))
+            Tmin, Tmax = hapi.get_TMIN_TMAX_FOR_BD_TIPS_2017_PYTHON(self.molecid, iso)
+            if(max(allT) > Tmax):
+                print('Warning: partition function ratio for isotope %d of molecule %d at temperatures > %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmax, Tmax))
+            if(min(allT) < Tmin):
+                print('Warning: partition function ratio for isotope %d of molecule %d at temperatures < %.1fK is assumed to be the value at %.1fK since HAPI does not support those temperatures.' % (iso, self.molecid, Tmin, Tmin))
+            allT_iso = list(np.clip(allT, Tmin, Tmax))
+            Qrx.append(hapi.partitionSum(self.molecid, iso, allT_iso))
         Qrx = np.array(Qrx)
         qr = Qrx[:, 1:].T/Qrx[:, 0]  # Q(T)/Q(Tref)
         return qr


### PR DESCRIPTION
I have added a feature to use the setdgm when using HITRAN/HITEMP database. I note that the user needs to provide the reference partial pressure array since HITRAN/HITEMP use that information. Also, the partition function ratio for T > 3,500 K is assumed to be the value at 3,500 K (in that case, the warning will be issued).
Thank you in advance.