### PR TITLE
Hitemp rename

### DIFF
--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -456,6 +456,9 @@ class MdbHit(object):
            extract: If True, it extracts the opacity having the wavenumber between nurange +- margin. Use when you want to reduce the memory use.
         """
         from exojax.spec.hitran import SijT
+        if ("hit" in path and path[-4:] == ".bz2"):
+            path = path[:-4]
+            print('Warning: path changed (.bz2 removed):', path)
         if ("HITEMP" in path and path[-4:] == ".par"):
             path = path + '.bz2'
             print('Warning: path changed (.bz2 added):', path)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -458,7 +458,7 @@ class MdbHit(object):
         from exojax.spec.hitran import SijT
         if ("HITEMP" in path and path[-4:] == ".par"):
             path = path + '.bz2'
-            print('self.path changed (.bz2 added):', self.path)
+            print('path changed (.bz2 added):', path)
         
         self.path = pathlib.Path(path)
         numinf, numtag = hitranapi.read_path(self.path)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -458,7 +458,7 @@ class MdbHit(object):
         from exojax.spec.hitran import SijT
         if ("HITEMP" in path and path[-4:] == ".par"):
             path = path + '.bz2'
-            print('path changed (.bz2 added):', path)
+            print('Warning: path changed (.bz2 added):', path)
         
         self.path = pathlib.Path(path)
         numinf, numtag = hitranapi.read_path(self.path)

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -459,7 +459,7 @@ class MdbHit(object):
         if ("HITEMP" in path and path[-4:] == ".par"):
             path = path + '.bz2'
             print('Warning: path changed (.bz2 added):', path)
-        
+
         self.path = pathlib.Path(path)
         numinf, numtag = hitranapi.read_path(self.path)
         self.Tref = 296.0

--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -456,7 +456,10 @@ class MdbHit(object):
            extract: If True, it extracts the opacity having the wavenumber between nurange +- margin. Use when you want to reduce the memory use.
         """
         from exojax.spec.hitran import SijT
-
+        if ("HITEMP" in path and path[-4:] == ".par"):
+            path = path + '.bz2'
+            print('self.path changed (.bz2 added):', self.path)
+        
         self.path = pathlib.Path(path)
         numinf, numtag = hitranapi.read_path(self.path)
         self.Tref = 296.0


### PR DESCRIPTION
Sorry for the multiple pull requests, but I have added a feature to rename the HITEMP path when ".bz2" is missing. (I thought it is a bit confusing as HITEMP requires ".par.bz2" path while HITRAN requires ".par" path.) Thank you in advance.