### PR TITLE
Bugfix/premodit f32

### DIFF
--- a/src/exojax/spec/lsd.py
+++ b/src/exojax/spec/lsd.py
@@ -6,10 +6,12 @@
 
 """
 import numpy as np
-from jax.numpy import index_exp 
+from jax.numpy import index_exp
 import jax.numpy as jnp
 from jax import jit
+import warnings
 from exojax.utils.constants import hcperk, Tref
+
 
 def getix(x, xv):
     """jnp version of getix.
@@ -37,7 +39,7 @@ def getix(x, xv):
     indarr = jnp.arange(len(xv))
     pos = jnp.interp(x, xv, indarr)
     index = (pos).astype(int)
-    cont = (pos-index)
+    cont = (pos - index)
     return cont, index
 
 
@@ -58,8 +60,9 @@ def npgetix(x, xv):
     indarr = np.arange(len(xv))
     pos = np.interp(x, xv, indarr)
     index = (pos).astype(int)
-    cont = (pos-index)
+    cont = (pos - index)
     return cont, index
+
 
 def npgetix_exp(x, xv, Ttyp):
     """numpy version of getix weigthed by exp(-hc/kT).
@@ -76,16 +79,19 @@ def npgetix_exp(x, xv, Ttyp):
     Note:
        cont is the contribution for i=index+1. 1 - cont is the contribution for i=index. For other i, the contribution should be zero.
     """
+    if Ttyp < Tref:
+        warnings.warn("We have not test for Ttyp < Tref yet.", UserWarning)
 
-    if Ttyp is not None:
-        x=np.exp(-hcperk*x*(1.0/Ttyp-1.0/Tref))
-        xv=np.exp(-hcperk*xv*(1.0/Ttyp-1.0/Tref))
-    
-    indarr = np.arange(len(xv))
-    pos = np.interp(x, xv, indarr)
+    x_ = np.array(x, dtype=np.float64)
+    xv_ = np.array(xv, dtype=np.float64)
+    x_ = np.exp(-hcperk * x_ * (1.0 / Ttyp - 1.0 / Tref))
+    xv_ = np.exp(-hcperk * xv_ * (1.0 / Ttyp - 1.0 / Tref))
+    indarr = np.arange(len(xv_))
+    pos = np.interp(x_, xv_, indarr)
     index = (pos).astype(int)
-    cont = (pos-index)
-    return cont, index    
+    cont = (pos - index)
+    return cont, index
+
 
 def add2D(a, w, cx, ix, cy, iy):
     """Add into an array when contirbutions and indices are given (2D).
@@ -102,10 +108,10 @@ def add2D(a, w, cx, ix, cy, iy):
         a
 
     """
-    a = a.at[index_exp[ix, iy]].add(w*(1-cx)*(1-cy))
-    a = a.at[index_exp[ix, iy+1]].add(w*(1-cx)*cy)
-    a = a.at[index_exp[ix+1, iy]].add(w*cx*(1-cy))
-    a = a.at[index_exp[ix+1, iy+1]].add(w*cx*cy)
+    a = a.at[index_exp[ix, iy]].add(w * (1 - cx) * (1 - cy))
+    a = a.at[index_exp[ix, iy + 1]].add(w * (1 - cx) * cy)
+    a = a.at[index_exp[ix + 1, iy]].add(w * cx * (1 - cy))
+    a = a.at[index_exp[ix + 1, iy + 1]].add(w * cx * cy)
     return a
 
 
@@ -126,14 +132,14 @@ def add3D(a, w, cx, ix, cy, iy, cz, iz):
         a
 
     """
-    a = a.at[index_exp[ix, iy, iz]].add(w*(1-cx)*(1-cy)*(1-cz))
-    a = a.at[index_exp[ix, iy+1, iz]].add(w*(1-cx)*cy*(1-cz))
-    a = a.at[index_exp[ix+1, iy, iz]].add(w*cx*(1-cy)*(1-cz))
-    a = a.at[index_exp[ix+1, iy+1, iz]].add(w*cx*cy*(1-cz))
-    a = a.at[index_exp[ix, iy, iz+1]].add(w*(1-cx)*(1-cy)*cz)
-    a = a.at[index_exp[ix, iy+1, iz+1]].add(w*(1-cx)*cy*cz)
-    a = a.at[index_exp[ix+1, iy, iz+1]].add(w*cx*(1-cy)*cz)
-    a = a.at[index_exp[ix+1, iy+1, iz+1]].add(w*cx*cy*cz)
+    a = a.at[index_exp[ix, iy, iz]].add(w * (1 - cx) * (1 - cy) * (1 - cz))
+    a = a.at[index_exp[ix, iy + 1, iz]].add(w * (1 - cx) * cy * (1 - cz))
+    a = a.at[index_exp[ix + 1, iy, iz]].add(w * cx * (1 - cy) * (1 - cz))
+    a = a.at[index_exp[ix + 1, iy + 1, iz]].add(w * cx * cy * (1 - cz))
+    a = a.at[index_exp[ix, iy, iz + 1]].add(w * (1 - cx) * (1 - cy) * cz)
+    a = a.at[index_exp[ix, iy + 1, iz + 1]].add(w * (1 - cx) * cy * cz)
+    a = a.at[index_exp[ix + 1, iy, iz + 1]].add(w * cx * (1 - cy) * cz)
+    a = a.at[index_exp[ix + 1, iy + 1, iz + 1]].add(w * cx * cy * cz)
     return a
 
 
@@ -154,13 +160,15 @@ def npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz):
         lineshape density a(nx,ny,nz)
 
     """
-    np.add.at(a, (ix, direct_iy, iz), w*(1-cx)*direct_cy*(1-cz))
-    np.add.at(a, (ix+1, direct_iy, iz), w*cx*direct_cy*(1-cz))
-    np.add.at(a, (ix, direct_iy, iz+1), w*(1-cx)*direct_cy*cz)
-    np.add.at(a, (ix+1, direct_iy, iz+1), w*cx*direct_cy*cz)
+    np.add.at(a, (ix, direct_iy, iz), w * (1 - cx) * direct_cy * (1 - cz))
+    np.add.at(a, (ix + 1, direct_iy, iz), w * cx * direct_cy * (1 - cz))
+    np.add.at(a, (ix, direct_iy, iz + 1), w * (1 - cx) * direct_cy * cz)
+    np.add.at(a, (ix + 1, direct_iy, iz + 1), w * cx * direct_cy * cz)
     return a
 
-def npadd3D_multi_index(a, w, cx, ix, cz, iz, uidx, multi_cont_lines, neighbor_uidx):
+
+def npadd3D_multi_index(a, w, cx, ix, cz, iz, uidx, multi_cont_lines,
+                        neighbor_uidx):
     """ numpy version: Add into an array using multi_index system in y
     Args:
         a: lineshape density (LSD) array (np.array)
@@ -175,27 +183,28 @@ def npadd3D_multi_index(a, w, cx, ix, cz, iz, uidx, multi_cont_lines, neighbor_u
     
     """
     conjugate_multi_cont_lines = 1.0 - multi_cont_lines
-    
+
     # index position
     direct_iy = uidx
-    direct_cy = np.prod(conjugate_multi_cont_lines,axis=1) 
+    direct_cy = np.prod(conjugate_multi_cont_lines, axis=1)
     a = npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz)
-    
+
     # index position + (1, 0)
     direct_iy = neighbor_uidx[uidx, 0]
-    direct_cy = multi_cont_lines[:,0]*conjugate_multi_cont_lines[:,1]
+    direct_cy = multi_cont_lines[:, 0] * conjugate_multi_cont_lines[:, 1]
     a = npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz)
-    
+
     # index position + (0, 1)
     direct_iy = neighbor_uidx[uidx, 1]
-    direct_cy = conjugate_multi_cont_lines[:,0]*multi_cont_lines[:,1]
+    direct_cy = conjugate_multi_cont_lines[:, 0] * multi_cont_lines[:, 1]
     a = npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz)
-    
+
     # index position + (1, 1)
     direct_iy = neighbor_uidx[uidx, 2]
-    direct_cy = np.prod(multi_cont_lines,axis=1) 
-    a = npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz)  
+    direct_cy = np.prod(multi_cont_lines, axis=1)
+    a = npadd3D_direct1D(a, w, cx, ix, direct_cy, direct_iy, cz, iz)
     return a
+
 
 @jit
 def inc3D_givenx(a, w, cx, ix, y, z, xv, yv, zv):
@@ -226,6 +235,7 @@ def inc3D_givenx(a, w, cx, ix, y, z, xv, yv, zv):
     a = add3D(a, w, cx, ix, cy, iy, cz, iz)
     return a
 
+
 @jit
 def inc2D_givenx(a, w, cx, ix, y, yv):
     """Compute integrated neighbouring contribution for 2D LSD (memory reduced sum) but using given contribution and index for x .
@@ -250,4 +260,3 @@ def inc2D_givenx(a, w, cx, ix, y, yv):
     cy, iy = getix(y, yv)
     a = add2D(a, w, cx, ix, cy, iy)
     return a
-

--- a/tests/endtoend/reverse/reverse_premodit.py
+++ b/tests/endtoend/reverse/reverse_premodit.py
@@ -73,7 +73,7 @@ ONEWAV = jnp.ones_like(nflux)
 interval_contrast = 0.1
 dit_grid_resolution = 0.1
 Ttyp = 2000.0
-
+#print(mdb)
 lbd, multi_index_uniqgrid, elower_grid, ngamma_ref_grid, n_Texp_grid, R, pmarray = initspec.init_premodit(
     mdb.nu_lines,
     nu_grid,

--- a/tests/endtoend/reverse/reverse_premodit_H2O.py
+++ b/tests/endtoend/reverse/reverse_premodit_H2O.py
@@ -1,0 +1,128 @@
+from jax.config import config
+#config.update("jax_enable_x64", True)
+#↑When FP64, the ValueError does not occur.
+
+import numpy as np
+import jax.numpy as jnp
+
+from exojax.spec.rtransfer import pressure_layer
+from exojax.spec.setrt import gen_wavenumber_grid
+from exojax.utils.instfunc import R2STD
+
+from exojax.spec import moldb, atomll, contdb
+from exojax.spec import modit, initspec, molinfo, premodit
+from exojax.spec import molinfo
+from exojax.spec.plg import MdbExomol_plg
+
+from exojax.utils.afunc import getjov_gravity
+from exojax.utils.instfunc import R2STD
+from exojax.utils.constants import RJ, pc
+from exojax.utils.gpkernel import gpkernel_RBF
+
+wls, wll, Ndata = 15035, 15040, 100
+wavd = np.linspace(wls, wll, Ndata)
+nflux = np.random.rand(Ndata)
+nusd = jnp.array(1.e8/wavd[::-1])
+
+NP = 100
+Parr, dParr, k = pressure_layer(NP = NP)
+
+Nx = 2000
+nus, wav, reso = gen_wavenumber_grid(np.min(wavd) - 5.0, np.max(wavd) + 5.0, Nx, unit="AA", xsmode="modit")
+
+Rinst=100000.
+beta_inst=R2STD(Rinst)
+
+#Reference pressure for a T-P model
+Pref=1.0 #bar
+ONEARR=np.ones_like(Parr)
+
+#Load H2O data with premodit
+molmassH2O = molinfo.molmass("H2O")
+mdbH2O_orig = moldb.MdbExomol('.database/H2O/1H2-16O/POKAZATEL', nus)
+print('N_H2O=', len(mdbH2O_orig.nu_lines))
+#
+Tgue = 3000.
+interval_contrast = 0.1
+dit_grid_resolution = 0.1
+lbd_H2O, multi_index_uniqgrid_H2O, elower_grid_H2O, \
+ngamma_ref_grid_H2O, n_Texp_grid_H2O, R_H2O, pmarray_H2O = initspec.init_premodit(
+    mdbH2O_orig.nu_lines,
+    nus,
+    mdbH2O_orig.elower,
+    mdbH2O_orig.alpha_ref,
+    mdbH2O_orig.n_Texp,
+    mdbH2O_orig.Sij0,
+    Ttyp=Tgue,
+    interval_contrast=interval_contrast,
+    dit_grid_resolution=dit_grid_resolution,
+    warning=False)
+
+from jax import random
+import numpyro.distributions as dist
+import numpyro
+from numpyro.infer import MCMC, NUTS
+from numpyro.infer import Predictive
+from numpyro.diagnostics import hpdi
+
+from exojax.spec.modit import vald_all, xsmatrix_vald, exomol, xsmatrix
+from exojax.spec.rtransfer import  dtauVALD, dtauM_mmwl, dtauHminus_mmwl, dtauCIA_mmwl, rtrun
+from exojax.spec import planck, response
+from exojax.spec import lpf
+from jax import jit, vmap
+
+#core driver frun
+def frun_lbl(VMR_H2O):
+    Tarr = 3000*(Parr/Pref)**0.1
+    RV=0.0
+    vsini=2.0
+    mmw=2.33
+    Mp=0.155 *1.99e33/1.90e30
+    Rp=0.186 *6.96e10/6.99e9
+    u1=0.0
+    u2=0.0
+    ga = getjov_gravity(Rp,Mp)
+    
+    #atmosphere (T-P profile)
+    VMR_H = 0.16
+    VMR_H2 = 0.84
+    PH = Parr* VMR_H
+    PHe = Parr* (1-VMR_H-VMR_H2)
+    PHH = Parr* VMR_H2
+    mmw = mmw*ONEARR
+
+    #H2O with premodit
+    qtarr = vmap(mdbH2O_orig.qr_interp)(Tarr)
+    xsm_H2O = premodit.xsmatrix(Tarr, Parr, R_H2O, pmarray_H2O, lbd_H2O, nus, ngamma_ref_grid_H2O,
+                   n_Texp_grid_H2O, multi_index_uniqgrid_H2O, elower_grid_H2O, molmassH2O, qtarr)
+    dtau = dtauM_mmwl(dParr, jnp.abs(xsm_H2O), VMR_H2O*ONEARR, mmw, ga)
+    
+    sourcef = planck.piBarr(Tarr, nus)
+    F0 = rtrun(dtau, sourcef)
+    Frot = response.rigidrot(nus, F0, vsini, u1, u2)
+    mu = response.ipgauss_sampling(nusd, nus, Frot, beta_inst, RV)
+    adjust_continuum1 = 1.
+    adjust_continuum2 = 1.
+    a = (adjust_continuum1 - adjust_continuum2) / (wavd[0] - wavd[-1])
+    b = adjust_continuum1 - a * wavd[0]
+    f_adjust_continuum = lambda x: a*x + b
+    mu = mu/jnp.nanmax(mu) * f_adjust_continuum(wavd[::-1])
+    
+    return(mu)
+
+def model_c(y1):
+    VMR_H2O = 10**(numpyro.sample('VMR_H2O', dist.Uniform(-7., -1.)))
+    mu = frun_lbl(VMR_H2O)
+
+    sigma = numpyro.sample('sigma',dist.Exponential(1.0))
+    numpyro.sample("y1", dist.Normal(mu, sigma), obs=y1)
+
+rng_key = random.PRNGKey(0)
+rng_key, rng_key_ = random.split(rng_key)
+num_warmup, num_samples = 1000, 2000
+kernel = NUTS(model_c, forward_mode_differentiation=True, max_tree_depth=7)
+mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
+
+mcmc.run(rng_key_, y1=nflux)
+mcmc.print_summary()
+

--- a/tests/integration/premodit/huge_elower_npgetix_exp.py
+++ b/tests/integration/premodit/huge_elower_npgetix_exp.py
@@ -1,6 +1,9 @@
+""" This test accounts for Issue #288, bug fix large elower value using f32, 
+    The bug was due to the overflow in the function when computing,
+"""
+
 from jax.config import config
 #config.update("jax_enable_x64", True)
-#↑When FP64, the ValueError does not occur.
 
 import numpy as np
 import jax.numpy as jnp
@@ -17,7 +20,6 @@ from exojax.spec.plg import MdbExomol_plg
 from exojax.utils.afunc import getjov_gravity
 from exojax.utils.instfunc import R2STD
 from exojax.utils.constants import RJ, pc
-from exojax.utils.gpkernel import gpkernel_RBF
 
 wls, wll, Ndata = 15035, 15040, 100
 wavd = np.linspace(wls, wll, Ndata)
@@ -62,14 +64,11 @@ from jax import random
 import numpyro.distributions as dist
 import numpyro
 from numpyro.infer import MCMC, NUTS
-from numpyro.infer import Predictive
-from numpyro.diagnostics import hpdi
 
-from exojax.spec.modit import vald_all, xsmatrix_vald, exomol, xsmatrix
-from exojax.spec.rtransfer import  dtauVALD, dtauM_mmwl, dtauHminus_mmwl, dtauCIA_mmwl, rtrun
+from exojax.spec.rtransfer import dtauM_mmwl, rtrun
 from exojax.spec import planck, response
 from exojax.spec import lpf
-from jax import jit, vmap
+from jax import vmap
 
 #core driver frun
 def frun_lbl(VMR_H2O):
@@ -119,7 +118,7 @@ def model_c(y1):
 
 rng_key = random.PRNGKey(0)
 rng_key, rng_key_ = random.split(rng_key)
-num_warmup, num_samples = 1000, 2000
+num_warmup, num_samples = 10, 20
 kernel = NUTS(model_c, forward_mode_differentiation=True, max_tree_depth=7)
 mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
 


### PR DESCRIPTION
Bug fix for the overflow in `npgetix_exp`, raised by @chonma0ctopus 

This was due to the overflow in the function when computing,
```python
    x_ = np.exp(-hcperk * x_ * (1.0 / Ttyp - 1.0 / Tref))
    xv_ = np.exp(-hcperk * xv_ * (1.0 / Ttyp - 1.0 / Tref))
```
using float32. 

By default, we use np.float64 for this function (note that this is assumed to run in host not device. You can change the internal data type, using `conversion_type`. 


Also I added the inf checker in it. If using  `conversion_dtype = np.float32`, then running an example, `tests/endtoend/reverse_premodit_H2O.py`, made by @chonma0ctopus, we will get this message:

```sh
  xv_ = np.exp(-hcperk * xv_ * (1.0 / Ttyp - 1.0 / Tref))

 conversion_dtype =  <class 'numpy.float32'> 

Traceback (most recent call last):
  File "reverse_premodit_H2O.py", line 49, in <module>
    ngamma_ref_grid_H2O, n_Texp_grid_H2O, R_H2O, pmarray_H2O = initspec.init_premodit(
  File "/home/kawahara/anaconda3/lib/python3.8/site-packages/exojax-1.1.3-py3.8.egg/exojax/spec/initspec.py", line 140, in init_premodit
    lbd, multi_index_uniqgrid = generate_lbd(line_strength_ref, nu_lines, nu_grid, ngamma_ref, ngamma_ref_grid,
  File "/home/kawahara/anaconda3/lib/python3.8/site-packages/exojax-1.1.3-py3.8.egg/exojax/spec/premodit.py", line 230, in generate_lbd
    cont_elower, index_elower = npgetix_exp(elower, elower_grid, Ttyp)
  File "/home/kawahara/anaconda3/lib/python3.8/site-packages/exojax-1.1.3-py3.8.egg/exojax/spec/lsd.py", line 93, in npgetix_exp
    raise ValueError("Use larger conversion_dtype.")
ValueError: Use larger conversion_dtype.
```
