### PR TITLE
bugfix for HITEMP/HITRAN HMC

### DIFF
--- a/tests/endtoend/reverse/reverse_modit_hitemp.py
+++ b/tests/endtoend/reverse/reverse_modit_hitemp.py
@@ -17,10 +17,13 @@ import matplotlib.pyplot as plt
 import jax.numpy as jnp
 from exojax.spec import rtransfer as rt
 from exojax.spec import modit
-from exojax.spec import moldb, contdb
+from exojax.spec import api, contdb
 from exojax.utils.grids import wavenumber_grid
 from exojax.spec.rtransfer import rtrun, dtauM, dtauCIA, wavenumber_grid
-from exojax.spec import planck, response
+from exojax.spec import planck
+from exojax.spec.response import ipgauss_sampling
+from exojax.spec.spin_rotation import convolve_rigid_rotation
+from exojax.utils.grids import velocity_grid
 from exojax.spec import molinfo
 from exojax.utils.constants import RJ
 from exojax.utils.instfunc import resolution_to_gaussian_std
@@ -30,29 +33,31 @@ from exojax.spec import initspec
 dat = pd.read_csv('spectrum_co.txt', delimiter=',', names=('wav', 'flux'))
 wavd = dat['wav'].values
 flux = dat['flux'].values
-nusd = jnp.array(1.e8/wavd[::-1])
+nusd = jnp.array(1.e8 / wavd[::-1])
 sigmain = 0.05
 norm = 20000
-nflux = flux/norm+np.random.normal(0, sigmain, len(wavd))
+nflux = flux / norm + np.random.normal(0, sigmain, len(wavd))
 
 NP = 100
 Parr, dParr, k = rt.pressure_layer(NP=NP)
 Nx = 5000
-nus, wav, res = wavenumber_grid(np.min(wavd)-5.0, np.max(wavd) +
-                       5.0, Nx, unit='AA', xsmode='modit')
+nus, wav, res = wavenumber_grid(np.min(wavd) - 5.0,
+                                np.max(wavd) + 5.0,
+                                Nx,
+                                unit='AA',
+                                xsmode='modit')
 Rinst = 100000.
 beta_inst = resolution_to_gaussian_std(Rinst)
-
 
 molmassCO = molinfo.molmass('CO')
 mmw = 2.33  # mean molecular weight
 mmrH2 = 0.74
 molmassH2 = molinfo.molmass('H2')
-vmrH2 = (mmrH2*mmw/molmassH2)  # VMR
+vmrH2 = (mmrH2 * mmw / molmassH2)  # VMR
 
 #
 Mp = 33.2
-mdbCO=moldb.MdbHit('.database/CO/05_HITEMP2019/05_HITEMP2019.par.bz2',nus,crit=1.e-30)
+mdbCO = api.MdbHitemp('.database/CO', nus, crit=1.e-30, gpu_transfer=True)
 cdbH2H2 = contdb.CdbCIA('.database/H2-H2_2011.cia', nus)
 print('N=', len(mdbCO.nu_lines))
 
@@ -61,60 +66,67 @@ Pref = 1.0  # bar
 ONEARR = np.ones_like(Parr)
 ONEWAV = jnp.ones_like(nflux)
 
-#
-
 cnu, indexnu, R, pmarray = initspec.init_modit(mdbCO.nu_lines, nus)
 
+
 # Precomputing gdm_ngammaL
-
-
-def fT(T0, alpha): return T0[:, None]*(Parr[None, :]/Pref)**alpha[:, None]
+def fT(T0, alpha):
+    return T0[:, None] * (Parr[None, :] / Pref)**alpha[:, None]
 
 
 T0_test = np.array([1100.0, 1500.0, 1100.0, 1500.0])
 alpha_test = np.array([0.2, 0.2, 0.05, 0.05])
 res = 0.2
 vmrCO_ref = 4.9e-4
-dgm_ngammaL = setdgm_hitran(
-    mdbCO, fT, Parr, Parr*vmrCO_ref, R, molmassCO, res, T0_test, alpha_test)
+dgm_ngammaL = setdgm_hitran(mdbCO, fT, Parr, Parr * vmrCO_ref, R, molmassCO,
+                            res, T0_test, alpha_test)
 
 # check dgm
 if False:
     from exojax.plot.ditplot import plot_dgmn
-    Tarr = 1300.*(Parr/Pref)**0.1
-    SijM_CO, ngammaLM_CO, nsigmaDl_CO = modit.hitran(
-        mdbCO, Tarr, Parr, Parr*vmrCO_ref, R, molmassCO)
+    Tarr = 1300. * (Parr / Pref)**0.1
+    SijM_CO, ngammaLM_CO, nsigmaDl_CO = modit.hitran(mdbCO, Tarr, Parr,
+                                                     Parr * vmrCO_ref, R,
+                                                     molmassCO)
     plot_dgmn(Parr, dgm_ngammaL, ngammaLM_CO, 0, 6)
     plt.show()
 
-# a core driver
-
+#settings before HMC                                                                   
+vsini_max = 100.0
+vr_array = velocity_grid(res, vsini_max)
 
 def frun(Tarr, MMR_CO, Mp, Rp, u1, u2, RV, vsini):
-    g = 2478.57730044555*Mp/Rp**2
-    VMR_CO = MMR_CO*mmw/molmassCO
-    SijM_CO, ngammaLM_CO, nsigmaDl_CO = modit.hitran(
-        mdbCO, Tarr, Parr, Parr*VMR_CO, R, molmassCO)
-    xsm_CO = modit.xsmatrix(
-        cnu, indexnu, R, pmarray, nsigmaDl_CO, ngammaLM_CO, SijM_CO, nus, dgm_ngammaL)
+    g = 2478.57730044555 * Mp / Rp**2
+    VMR_CO = MMR_CO * mmw / molmassCO
+    SijM_CO, ngammaLM_CO, nsigmaDl_CO = modit.hitran(mdbCO, Tarr, Parr,
+                                                     Parr * VMR_CO, R,
+                                                     molmassCO)
+    xsm_CO = modit.xsmatrix(cnu, indexnu, R, pmarray, nsigmaDl_CO, ngammaLM_CO,
+                            SijM_CO, nus, dgm_ngammaL)
     # abs is used to remove negative values in xsv
-    dtaumCO = dtauM(dParr, jnp.abs(xsm_CO), MMR_CO*ONEARR, molmassCO, g)
+    dtaumCO = dtauM(dParr, jnp.abs(xsm_CO), MMR_CO * ONEARR, molmassCO, g)
     # CIA
-    dtaucH2H2 = dtauCIA(nus, Tarr, Parr, dParr, vmrH2, vmrH2,
-                        mmw, g, cdbH2H2.nucia, cdbH2H2.tcia, cdbH2H2.logac)
-    dtau = dtaumCO+dtaucH2H2
+    dtaucH2H2 = dtauCIA(nus, Tarr, Parr, dParr, vmrH2, vmrH2, mmw, g,
+                        cdbH2H2.nucia, cdbH2H2.tcia, cdbH2H2.logac)
+    dtau = dtaumCO + dtaucH2H2
     sourcef = planck.piBarr(Tarr, nus)
-    F0 = rtrun(dtau, sourcef)/norm
-    Frot = response.rigidrot(nus, F0, vsini, u1, u2)
-    mu = response.ipgauss_sampling(nusd, nus, Frot, beta_inst, RV)
+    F0 = rtrun(dtau, sourcef) / norm
+    Frot = convolve_rigid_rotation(F0, vr_array, vsini, u1, u2)
+    mu = ipgauss_sampling(nusd, nus, Frot, beta_inst, RV)
     return mu
 
 
 # test
 if False:
-    Tarr = 1200.0*(Parr/Pref)**0.1
-    mu = frun(Tarr, MMR_CO=0.0059, Mp=33.2, Rp=0.88,
-              u1=0.0, u2=0.0, RV=10.0, vsini=20.0)
+    Tarr = 1200.0 * (Parr / Pref)**0.1
+    mu = frun(Tarr,
+              MMR_CO=0.0059,
+              Mp=33.2,
+              Rp=0.88,
+              u1=0.0,
+              u2=0.0,
+              RV=10.0,
+              vsini=20.0)
     plt.plot(wavd, mu)
     plt.show()
 
@@ -128,11 +140,11 @@ def model_c(nu1, y1):
     T0 = numpyro.sample('T0', dist.Uniform(1000.0, 1500.0))
     alpha = numpyro.sample('alpha', dist.Uniform(0.05, 0.2))
     vsini = numpyro.sample('vsini', dist.Uniform(15.0, 25.0))
-    g = 2478.57730044555*Mp/Rp**2  # gravity
+    g = 2478.57730044555 * Mp / Rp**2  # gravity
     u1 = 0.0
     u2 = 0.0
     # T-P model//
-    Tarr = T0*(Parr/Pref)**alpha
+    Tarr = T0 * (Parr / Pref)**alpha
     # line computation CO
     mu = frun(Tarr, MMR_CO, Mp, Rp, u1, u2, RV, vsini)
     numpyro.sample('y1', dist.Normal(mu, sigmain), obs=y1)
@@ -158,13 +170,20 @@ hpdi_mu1 = hpdi(predictions['y1'], 0.9)
 fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(20, 6.0))
 ax.plot(wavd[::-1], median_mu1, color='C0')
 ax.plot(wavd[::-1], nflux, '+', color='black', label='data')
-ax.fill_between(wavd[::-1], hpdi_mu1[0], hpdi_mu1[1],
-                alpha=0.3, interpolate=True, color='C0', label='90% area')
+ax.fill_between(wavd[::-1],
+                hpdi_mu1[0],
+                hpdi_mu1[1],
+                alpha=0.3,
+                interpolate=True,
+                color='C0',
+                label='90% area')
 plt.xlabel('wavelength ($\AA$)', fontsize=16)
 plt.legend(fontsize=16)
 plt.tick_params(labelsize=16)
 
 pararr = ['Rp', 'T0', 'alpha', 'MMR_CO', 'vsini', 'RV']
-arviz.plot_pair(arviz.from_numpyro(mcmc), kind='kde',
-                divergences=False, marginals=True)
+arviz.plot_pair(arviz.from_numpyro(mcmc),
+                kind='kde',
+                divergences=False,
+                marginals=True)
 plt.show()


### PR DESCRIPTION
When implementing `api`, I made a bug in `MdbHitemp` and `MdbHitran`:
I used `jnp array` for `self.uniqiso`, but this breaks JITtable feature. 
I restored them to `np.array`.

I rewrote `exojax/tests/endtoend/reverse/reverse_modit_hitemp.py` using `api`.

