### PR TITLE
Grid setting

### DIFF
--- a/src/exojax/utils/grids.py
+++ b/src/exojax/utils/grids.py
@@ -42,8 +42,7 @@ def _set_grid(x0, x1, N, unit, grid_mode):
     if grid_mode == 'ESLOG':
         grid = np.logspace(np.log10(x0), np.log10(x1), N, dtype=np.float64)
     elif grid_mode == 'ESLIN':
-        grid = _set_grid_eslin(unit, x0, x1, N)
-        unit = 'cm-1'
+        grid, unit = _set_grid_eslin(unit, x0, x1, N)
     else:
         raise ValueError("unavailable xsmode/unit.")
     return grid, unit
@@ -76,10 +75,11 @@ def _set_resolution(grid_mode, nus):
 
 def _set_grid_eslin(unit, x0, x1, N):
     if unit == "cm-1":
-        return np.linspace((x0), (x1), N, dtype=np.float64)
+        return np.linspace((x0), (x1), N, dtype=np.float64), unit
     else:
         cx1, cx0 = wav2nu(np.array([x0, x1]), unit)
-        return np.linspace((cx0), (cx1), N, dtype=np.float64)
+        unit = 'cm-1'
+        return np.linspace((cx0), (cx1), N, dtype=np.float64), unit
 
 
 def velocity_grid(resolution, vmax):

--- a/src/exojax/utils/grids.py
+++ b/src/exojax/utils/grids.py
@@ -30,7 +30,7 @@ def wavenumber_grid(x0, x1, N, unit='cm-1', xsmode='lpf'):
 
     _check_even_number(N)
     grid_mode = check_scale_xsmode(xsmode)
-    grid = _set_grid(x0, x1, N, unit, grid_mode)
+    grid, unit = _set_grid(x0, x1, N, unit, grid_mode)
     nus = _set_nus(unit, grid)
     wav = nu2wav(nus, unit="AA")
     resolution = _set_resolution(grid_mode, nus)
@@ -43,9 +43,10 @@ def _set_grid(x0, x1, N, unit, grid_mode):
         grid = np.logspace(np.log10(x0), np.log10(x1), N, dtype=np.float64)
     elif grid_mode == 'ESLIN':
         grid = _set_grid_eslin(unit, x0, x1, N)
+        unit = 'cm-1'
     else:
         raise ValueError("unavailable xsmode/unit.")
-    return grid
+    return grid, unit
 
 
 def _check_even_number(N):


### PR DESCRIPTION
While I testing [Forward_modeling_using_DIT.ipynb](https://github.com/HajimeKawahara/exojax/blob/release/documents/tutorials/Forward_modeling_using_DIT.ipynb), I have realized that ``nus,wav,R=wavenumber_grid(22900,23000,10000,unit="AA",xsmode="dit")`` returns nus in wavelength unit. This seems to be because _set_grid_eslin always returns the wavenumber grid, so I have changed a few lines.

A sample code is as follows:
```
from exojax.utils.grids import wavenumber_grid
nus,wav,R=wavenumber_grid(22900,23000,10000,unit="AA",xsmode="modit")
print(nus)

nus,wav,R=wavenumber_grid(22900,23000,10000,unit="AA",xsmode="dit")
print(nus)
```

Thank you.