### PR TITLE
To get the recommended database for exomol ions

### DIFF
--- a/src/exojax/spec/defmol.py
+++ b/src/exojax/spec/defmol.py
@@ -62,6 +62,10 @@ def search_molfile(database, molecules):
                 return e2s(molecules)+'/'+molecules+'/'+exomol_defmol
             except:
                 molname_exact = s2e_stable(molecules)
+                # ions
+                if "+" in molecules:
+                    molecules = molecules.replace("+","_p")
+                    molname_exact = molname_exact + "_p"
                 print('Warning:', molecules, 'is interpreted as', molname_exact)
                 rec = get_exomol_database_list(molecules, molname_exact)
                 # default (recommended) database by ExoMol


### PR DESCRIPTION
I have just added a few lines to get the recommended database for the ions in the ExoMol database. An example script you could use is as follows. Thank you.

```
from exojax.spec import defmol

db_dir = defmol.search_molfile("ExoMol", "H3O+")
print(db_dir)

db_dir = defmol.search_molfile("ExoMol", "H3+")
print(db_dir)