### PR TITLE
Bugfix for downloading Exomol H2O  

### DIFF
--- a/src/exojax/utils/molname.py
+++ b/src/exojax/utils/molname.py
@@ -37,6 +37,7 @@ def exact_molecule_name_to_isotope_number(exact_molecule_name):
         #check hitran exact name
         exact_hitran_molecule_name = exact_molname_exomol_to_hitran(
             exact_molecule_name)
+        print("HITRAN exact name=",exact_hitran_molecule_name)
         keys = [
             k for k, v in isotope_name_dict.items()
             if v == exact_hitran_molecule_name
@@ -47,7 +48,7 @@ def exact_molecule_name_to_isotope_number(exact_molecule_name):
     else:
         print("No isotope number identified")
         print("Report at https://github.com/HajimeKawahara/exojax/issues.")
-        return None
+        return None, None
 
     return molnumber, isotope_number
 
@@ -114,8 +115,19 @@ def exact_molname_exomol_to_hitran(exact_exomol_molecule_name):
     Returns:
         str: exact exomol molecule name such as (12C)(16O)
     """
-    return "(" + exact_exomol_molecule_name.replace("-", ")(") + ")"
-
+    component = exact_exomol_molecule_name.split("-")
+    hitran_exact_name=""
+    hydrolist = ["1H", "1H2", "2H", "2H2"]
+    replacelist = ["H", "H2", "D", "D2"]
+    for c in component:
+        if c in hydrolist:
+            ind = hydrolist.index(c)
+            hitran_exact_name=hitran_exact_name+replacelist[ind]
+        elif c[-1].isdigit():
+            hitran_exact_name=hitran_exact_name+"("+c[:-1]+")"+c[-1]
+        else:
+            hitran_exact_name=hitran_exact_name+"("+c+")"
+    return hitran_exact_name
 
 def e2s(exact_exomol_molecule_name):
 

--- a/tests/unittests/utils/molname_test.py
+++ b/tests/unittests/utils/molname_test.py
@@ -14,7 +14,12 @@ def test_exact_molecule_name_to_isotope_number():
     eemn = "16O-13C-17O"
     molnum, isonum = exact_molecule_name_to_isotope_number(eemn)
     assert isonum == 6
-
+    eemn = "1H2-16O"
+    molnum, isonum = exact_molecule_name_to_isotope_number(eemn)
+    assert isonum == 1
+    eemn = "12C-16O2"
+    molnum, isonum = exact_molecule_name_to_isotope_number(eemn)
+    
 def test_exact_isotope_name_from_isotope():
     simple_molecule_name = "CO"
     isotope = 1
@@ -79,4 +84,5 @@ def test_split_simple():
 
 
 if __name__ == '__main__':
-    test_s2estable()
+    #test_s2estable()
+    test_exact_molecule_name_to_isotope_number()


### PR DESCRIPTION
@ykawashima reported a bug for downloading H2O from ExoMol because of the mismatch of molecule name, related to isotope.
I fixed this bug.

```sh
Python 3.8.8 (default, Apr 13 2021, 19:58:26) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from exojax.spec import api
>>> from exojax.spec import defmol
>>> from exojax.utils.grids import wavenumber_grid
>>> db_dir = defmol.search_molfile()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: search_molfile() missing 2 required positional arguments: 'database' and 'molecules'
>>> db_dir = defmol.search_molfile("ExoMol","H2O")
Warning: H2O is interpreted as 1H2-16O
Recommendated database by ExoMol:  POKAZATEL
>>> nus, wav, res = wavenumber_grid(3020,3050,260,unit="nm")
xsmode assumes ESLOG in wavenumber space: mode=lpf
/home/kawahara/exojax/src/exojax/utils/grids.py:126: UserWarning: Resolution may be too small. R=26201.953320959652
  warnings.warn('Resolution may be too small. R=' + str(resolution),
>>> mdb = api.MdbExomol(db_dir, nus, gpu_transfer=True)
HITRAN exact name= H2(16O)
Background atmosphere:  H2
Downloading http://www.exomol.com/db/H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.def and saving as H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.def
Downloading http://www.exomol.com/db/H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.pf and saving as H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.pf
Downloading http://www.exomol.com/db/H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.states.bz2 and saving as H2O/1H2-16O/POKAZATEL/1H2-16O__POKAZATEL.states.bz2
``` 