### PR TITLE
fixed a bug regarding exact_isotope_name

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -933,7 +933,7 @@ class MdbHitran(HITRANDatabaseManager):
         Returns:
             str: exact isotope name such as (12C)(16O)
         """
-        from exojax.utils.isotopes import exact_hitran_isotope_name_from_isotope
+        from exojax.utils.molname import exact_hitran_isotope_name_from_isotope
         return exact_hitran_isotope_name_from_isotope(
             self.simple_molecule_name, isotope)
 


### PR DESCRIPTION
This pull request is just to fix a tiny bug regarding the exact_isotope_name, which I find currently cannot be called for HITRAN. You can check with the following script. Thank you.

```
from exojax.spec import api

mdb = api.MdbHitemp("/home/kawashima/database/CO/05_HITEMP2019/05_HITEMP2019.par.bz2", nurange=[4200.0, 4210.0], crit=1.e-30)
print(mdb.exact_isotope_name(1))

mdb = api.MdbHitran("/home/kawashima/database/CO/05_hit12.par", nurange=[4200.0, 4210.0], crit=1.e-30)
print(mdb.exact_isotope_name(1))```