### PR TITLE
Mask for mdb class

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -537,7 +537,22 @@ class MdbHitemp(HITEMPDatabaseManager):
         #isotope
         self.isoid = df_masked.iso.values
         self.uniqiso = np.unique(self.isoid)
-    
+
+    def apply_mask_mdb(mdb, mask):
+        mdb.nu_lines = mdb.nu_lines[mask]
+        mdb.line_strength_ref = mdb.line_strength_ref[mask]
+        mdb.delta_air = mdb.delta_air[mask]
+        mdb.A = mdb.A[mask]
+        mdb.n_air = mdb.n_air[mask]
+        mdb.gamma_air = mdb.gamma_air[mask]
+        mdb.gamma_self = mdb.gamma_self[mask]
+        mdb.elower = mdb.elower[mask]
+        mdb.gpp = mdb.gpp[mask]
+        #isotope
+        mdb.isoid = mdb.isoid[mask]
+        mdb.uniqiso = np.unique(mdb.isoid)
+        return mdb
+
     def Sij0(self):
         """Deprecated line_strength_ref. 
 
@@ -850,6 +865,21 @@ class MdbHitran(HITRANDatabaseManager):
 
         else:
             raise ValueError("Use vaex dataframe as input.")
+
+    def apply_mask_mdb(mdb, mask):
+        mdb.nu_lines = mdb.nu_lines[mask]
+        mdb.line_strength_ref = mdb.line_strength_ref[mask]
+        mdb.delta_air = mdb.delta_air[mask]
+        mdb.A = mdb.A[mask]
+        mdb.n_air = mdb.n_air[mask]
+        mdb.gamma_air = mdb.gamma_air[mask]
+        mdb.gamma_self = mdb.gamma_self[mask]
+        mdb.elower = mdb.elower[mask]
+        mdb.gpp = mdb.gpp[mask]
+        #isotope
+        mdb.isoid = mdb.isoid[mask]
+        mdb.uniqiso = np.unique(mdb.isoid)
+        return mdb
 
     def Sij0(self):
         """Deprecated line_strength_ref. 

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -240,6 +240,7 @@ class MdbExomol(CapiMdbExomol):
             >>> mdb.apply_mask_mdb(mask)
         """
         self.A = self.A[mask]
+        self.logsij0 = self.logsij0[mask]
         self.nu_lines = self.nu_lines[mask]
         self.gamma_natural = self.gamma_natural[mask]
         self.alpha_ref = self.alpha_ref[mask]

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -228,6 +228,17 @@ class MdbExomol(CapiMdbExomol):
             raise ValueError("Use vaex dataframe as input.")
 
     def apply_mask_mdb(self, mask):
+        """apply mask for mdb class
+
+        Args:
+            mask: mask to be applied
+
+        Examples:
+            >>> mdb = api.MdbExomol(emf, nus)
+            >>> # we would extract the lines with elower > 100.
+            >>> mask = mdb.elower > 100.
+            >>> mdb.apply_mask_mdb(mask)
+        """
         self.A = self.A[mask]
         self.nu_lines = self.nu_lines[mask]
         self.gamma_natural = self.gamma_natural[mask]
@@ -551,6 +562,17 @@ class MdbHitemp(HITEMPDatabaseManager):
         self.uniqiso = np.unique(self.isoid)
 
     def apply_mask_mdb(self, mask):
+        """apply mask for mdb class
+
+        Args:
+            mask: mask to be applied
+
+        Examples:
+            >>> mdb = api.MdbHitemp(emf, nus)
+            >>> # we would extract the lines with n_air > 0.01
+            >>> mask = mdb.n_air > 0.01
+            >>> mdb.apply_mask_mdb(mask)
+        """
         self.nu_lines = self.nu_lines[mask]
         self.line_strength_ref = self.line_strength_ref[mask]
         self.delta_air = self.delta_air[mask]
@@ -878,6 +900,17 @@ class MdbHitran(HITRANDatabaseManager):
             raise ValueError("Use vaex dataframe as input.")
 
     def apply_mask_mdb(self, mask):
+        """apply mask for mdb class
+
+        Args:
+            mask: mask to be applied
+
+        Examples:
+            >>> mdb = api.MdbHitran(emf, nus)
+            >>> # we would extract the lines with n_air > 0.01
+            >>> mask = mdb.n_air > 0.01
+            >>> mdb.apply_mask_mdb(mask)
+        """
         self.nu_lines = self.nu_lines[mask]
         self.line_strength_ref = self.line_strength_ref[mask]
         self.delta_air = self.delta_air[mask]

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -242,6 +242,7 @@ class MdbExomol(CapiMdbExomol):
         self.A = self.A[mask]
         self.logsij0 = self.logsij0[mask]
         self.nu_lines = self.nu_lines[mask]
+        self.dev_nu_lines = self.dev_nu_lines[mask]
         self.gamma_natural = self.gamma_natural[mask]
         self.alpha_ref = self.alpha_ref[mask]
         self.n_Texp = self.n_Texp[mask]

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -227,6 +227,18 @@ class MdbExomol(CapiMdbExomol):
         else:
             raise ValueError("Use vaex dataframe as input.")
 
+    def apply_mask_mdb(self, mask):
+        self.A = self.A[mask]
+        self.nu_lines = self.nu_lines[mask]
+        self.gamma_natural = self.gamma_natural[mask]
+        self.alpha_ref = self.alpha_ref[mask]
+        self.n_Texp = self.n_Texp[mask]
+        self.elower = self.elower[mask]
+        self.jlower = self.jlower[mask]
+        self.jupper = self.jupper[mask]
+        self.line_strength_ref = self.line_strength_ref[mask]
+        self.gpp = self.gpp[mask]
+
     def Sij0(self):
         """Deprecated line_strength_ref. 
 
@@ -538,20 +550,19 @@ class MdbHitemp(HITEMPDatabaseManager):
         self.isoid = df_masked.iso.values
         self.uniqiso = np.unique(self.isoid)
 
-    def apply_mask_mdb(mdb, mask):
-        mdb.nu_lines = mdb.nu_lines[mask]
-        mdb.line_strength_ref = mdb.line_strength_ref[mask]
-        mdb.delta_air = mdb.delta_air[mask]
-        mdb.A = mdb.A[mask]
-        mdb.n_air = mdb.n_air[mask]
-        mdb.gamma_air = mdb.gamma_air[mask]
-        mdb.gamma_self = mdb.gamma_self[mask]
-        mdb.elower = mdb.elower[mask]
-        mdb.gpp = mdb.gpp[mask]
+    def apply_mask_mdb(self, mask):
+        self.nu_lines = self.nu_lines[mask]
+        self.line_strength_ref = self.line_strength_ref[mask]
+        self.delta_air = self.delta_air[mask]
+        self.A = self.A[mask]
+        self.n_air = self.n_air[mask]
+        self.gamma_air = self.gamma_air[mask]
+        self.gamma_self = self.gamma_self[mask]
+        self.elower = self.elower[mask]
+        self.gpp = self.gpp[mask]
         #isotope
-        mdb.isoid = mdb.isoid[mask]
-        mdb.uniqiso = np.unique(mdb.isoid)
-        return mdb
+        self.isoid = self.isoid[mask]
+        self.uniqiso = np.unique(self.isoid)
 
     def Sij0(self):
         """Deprecated line_strength_ref. 
@@ -866,20 +877,19 @@ class MdbHitran(HITRANDatabaseManager):
         else:
             raise ValueError("Use vaex dataframe as input.")
 
-    def apply_mask_mdb(mdb, mask):
-        mdb.nu_lines = mdb.nu_lines[mask]
-        mdb.line_strength_ref = mdb.line_strength_ref[mask]
-        mdb.delta_air = mdb.delta_air[mask]
-        mdb.A = mdb.A[mask]
-        mdb.n_air = mdb.n_air[mask]
-        mdb.gamma_air = mdb.gamma_air[mask]
-        mdb.gamma_self = mdb.gamma_self[mask]
-        mdb.elower = mdb.elower[mask]
-        mdb.gpp = mdb.gpp[mask]
+    def apply_mask_mdb(self, mask):
+        self.nu_lines = self.nu_lines[mask]
+        self.line_strength_ref = self.line_strength_ref[mask]
+        self.delta_air = self.delta_air[mask]
+        self.A = self.A[mask]
+        self.n_air = self.n_air[mask]
+        self.gamma_air = self.gamma_air[mask]
+        self.gamma_self = self.gamma_self[mask]
+        self.elower = self.elower[mask]
+        self.gpp = self.gpp[mask]
         #isotope
-        mdb.isoid = mdb.isoid[mask]
-        mdb.uniqiso = np.unique(mdb.isoid)
-        return mdb
+        self.isoid = self.isoid[mask]
+        self.uniqiso = np.unique(self.isoid)
 
     def Sij0(self):
         """Deprecated line_strength_ref. 


### PR DESCRIPTION
I have added ``apply_mask_mdb`` functions to MdbExomol/Hitemp/Hitran classes so that the user can apply their own mask after the mdb extraction.

For HITEMP and HITRAN, I applied the mask to the instance variables written in ``instances_from_dataframes``. For ExoMol, I applied the mask to gamma_natural, alpha_ref, n_Texp, and logsij0 in addition to those written in ``instances_from_dataframes``. (Is that sufficient? I have confirmed that the spectrum calculation works.)

You can check the update with the following script. Thank you.
```
import numpy as np
from exojax.utils.grids import wavenumber_grid
from exojax.spec import api
nus,wav,res=wavenumber_grid(6910,6990,100000,unit='cm-1',xsmode="premodit")

# ExoMol                                                                                                                      
mdb = api.MdbExomol("/home/kawashima/database/H2O/1H2-16O/POKAZATEL",nus)
print(len(mdb.elower), np.min(mdb.elower))

mask = mdb.elower > 100.
mdb.apply_mask_mdb(mask)
print(len(mdb.elower), np.min(mdb.elower))

# HITEMP                                                                                                                      
mdb = api.MdbHitemp("/home/kawashima/database/H2O/01_HITEMP2010",nus)
print(len(mdb.n_air), np.min(mdb.n_air))

mask = mdb.n_air > 0.01
mdb.apply_mask_mdb(mask)
print(len(mdb.n_air), np.min(mdb.n_air))

# HITRAN                                                                                                                      
mdb = api.MdbHitran("/home/kawashima/database/H2O/01_hit12.par",nus)
print(len(mdb.n_air), np.min(mdb.n_air))

mask = mdb.n_air > 0.01
mdb.apply_mask_mdb(mask)
print(len(mdb.n_air), np.min(mdb.n_air))
```