### PR TITLE
Fixed error for float values in MdbExomol and added the use of broadf

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -108,6 +108,7 @@ class MdbExomol(CapiMdbExomol):
                          engine="vaex",
                          crit=crit,
                          bkgdatm=self.bkgdatm,
+                         broadf=self.broadf,
                          cache=True,
                          skip_optional_data=self.skip_optional_data)
 
@@ -176,7 +177,7 @@ class MdbExomol(CapiMdbExomol):
             mask = self.df_load_mask
 
         self.instances_from_dataframes(df[mask])
-        self.compute_broadening(self.jlower, self.jupper)
+        self.compute_broadening(self.jlower.astype(int), self.jupper.astype(int))
         self.gamma_natural = gn(self.A)
         if self.gpu_transfer:
             self.generate_jnp_arrays()


### PR DESCRIPTION
I fixed minor bugs in MdbExomol.
- Convert values of jlower / jupper to integers: compute_broadening() only accepts integers, but I found SO2 has float values.
-  Added the use of the option of `broadf`: If this is False, the default broadening parameters in .def file are used in radis. We can avoid downloading the .def file with this option after I fix a code in radis. (e.g. There is no .def file for OH.)

