### PR TITLE
removed negative value assert (hotfix to v1.3)

### DIFF
--- a/src/exojax/spec/set_ditgrid.py
+++ b/src/exojax/spec/set_ditgrid.py
@@ -48,7 +48,7 @@ def ditgrid_linear_interval(input_variable, dit_grid_resolution=0.1, weight = No
     if weight is None:
         weight = 1.0
 
-    assert np.min(weight * input_variable) > 0.0, "There exists negative or zero value. Consider to use np.abs."        
+    #assert np.min(weight * input_variable) > 0.0, "There exists negative or zero value. Consider to use np.abs."        
     wxmin = np.min(weight * input_variable)
     wxmax = np.max(weight * input_variable)
     wxmax = np.nextafter(wxmax, np.inf, dtype=wxmax.dtype)


### PR DESCRIPTION
We found a bug, which affects HITEMP/H2O opacity.
- in set_grid.py the negative value was not allowed for the density grid. So, users could have removed the negative temperature exponent of the HITEMP/H2O. But, this modification could have removed some important H2O lines.

the following is the comparison, @ykawashima made: The blue lines removed the lines with n_air < 0.01, yellow clipped to n_air = 0, green no restriction for HITEMP H2O. 
![image](https://github.com/HajimeKawahara/exojax/assets/15956904/4dedb718-278c-4d4b-94ab-f7ef251d1c2d)
