### PR TITLE
Wavelength order

### DIFF
--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -50,7 +50,8 @@ class OpaPremodit(OpaCalc):
                  auto_trange=None,
                  manual_params=None,
                  dit_grid_resolution=None,
-                 allow_32bit=False):
+                 allow_32bit=False,
+                 wavelength_order="descending"):
         """initialization of OpaPremodit
 
         Note:
@@ -76,17 +77,20 @@ class OpaPremodit(OpaCalc):
             manual_params (optional): premodit parameter set [dE, Tref, Twt]. Defaults to None.
             dit_grid_resolution (float, optional): force to set broadening_parameter_resolution={mode:manual, value: dit_grid_resolution}), ignores broadening_parameter_resolution.
             allow_32bit (bool, optional): If True, allow 32bit mode of JAX. Defaults to False.
-        
+            wavlength order: wavelength order: "ascending" or "descending"
         """
         super().__init__()
-        check_jax64bit(allow_32bit) 
+        check_jax64bit(allow_32bit)
 
         #default setting
         self.method = "premodit"
         self.diffmode = diffmode
         self.warning = True
         self.nu_grid = nu_grid
-        self.wav = nu2wav(self.nu_grid, unit="AA")
+        self.wavelength_order = wavelength_order
+        self.wav = nu2wav(self.nu_grid,
+                          wavelength_order=self.wavelength_order,
+                          unit="AA")
         self.resolution = resolution_eslog(nu_grid)
         self.mdb = mdb
         self.ngrid_broadpar = None
@@ -244,12 +248,12 @@ class OpaPremodit(OpaCalc):
             single_broadening_parameters=self.single_broadening_parameters,
             warning=self.warning)
         self.ready = True
-        
+
         lbd_coeff, multi_index_uniqgrid, elower_grid, \
             ngamma_ref_grid, n_Texp_grid, R, pmarray = self.opainfo
         self.ngrid_broadpar = len(multi_index_uniqgrid)
         self.ngrid_elower = len(elower_grid)
-        
+
     def xsvector(self, T, P):
         from exojax.spec.premodit import xsvector_zeroth
         from exojax.spec.premodit import xsvector_first
@@ -365,7 +369,8 @@ class OpaModit(OpaCalc):
                  Parr=None,
                  Pself_ref=None,
                  dit_grid_resolution=0.2,
-                 allow_32bit=False):
+                 allow_32bit=False,
+                 wavelength_order="descending"):
         """initialization of OpaModit
 
         Note:
@@ -379,17 +384,22 @@ class OpaModit(OpaCalc):
             Pself_ref (1d array, optional): self pressure array in bar. Defaults to None. If None Pself = 0.0.
             dit_grid_resolution (float, optional): dit grid resolution. Defaxults to 0.2.
             allow_32bit (bool, optional): If True, allow 32bit mode of JAX. Defaults to False.
+            wavlength order: wavelength order: "ascending" or "descending"
+            
         Raises:
             ValueError: _description_
         """
         super().__init__()
-        check_jax64bit(allow_32bit) 
-        
+        check_jax64bit(allow_32bit)
+
         #default setting
         self.method = "modit"
         self.warning = True
         self.nu_grid = nu_grid
-        self.wav = nu2wav(self.nu_grid, unit="AA")
+        self.wavelength_order = wavelength_order
+        self.wav = nu2wav(self.nu_grid,
+                          wavelength_order=self.wavelength_order,
+                          unit="AA")
         self.resolution = resolution_eslog(nu_grid)
         self.mdb = mdb
         self.dit_grid_resolution = dit_grid_resolution
@@ -523,7 +533,7 @@ class OpaModit(OpaCalc):
 
 
 class OpaDirect(OpaCalc):
-    def __init__(self, mdb, nu_grid):
+    def __init__(self, mdb, nu_grid, wavelength_order="descending"):
         """initialization of OpaDirect (LPF)
 
             
@@ -538,7 +548,10 @@ class OpaDirect(OpaCalc):
         self.method = "lpf"
         self.warning = True
         self.nu_grid = nu_grid
-        self.wav = nu2wav(self.nu_grid, unit="AA")
+        self.wavelength_order = wavelength_order
+        self.wav = nu2wav(self.nu_grid,
+                          wavelength_order=self.wavelength_order,
+                          unit="AA")
         self.mdb = mdb
         self.apply_params()
 

--- a/src/exojax/spec/opacont.py
+++ b/src/exojax/spec/opacont.py
@@ -27,11 +27,14 @@ class OpaCIA(OpaCont):
     """Opacity Continuum Calculator Class for CIA
 
     """
-    def __init__(self, cdb, nu_grid):
+    def __init__(self, cdb, nu_grid, wavelength_order="descending"):
         self.method = "cia"
         self.warning = True
         self.nu_grid = nu_grid
-        self.wav = nu2wav(self.nu_grid, unit="AA")
+        self.wavelength_order = wavelength_order
+        self.wav = nu2wav(self.nu_grid,
+                          wavelenght_order=self.wavelength_order,
+                          unit="AA")
         self.cdb = cdb
 
     def logacia_vector(self, T):

--- a/src/exojax/spec/unitconvert.py
+++ b/src/exojax/spec/unitconvert.py
@@ -1,43 +1,63 @@
 """unit conversion for spectrum."""
 
+from exojax.utils.checkarray import is_sorted
 
-def nu2wav(nus, unit='AA'):
+def nu2wav(nus, wavelength_order, unit='AA'):
     """wavenumber to wavelength (AA)
 
     Args:
-       nus: wavenumber (cm-1)
-       unit: unit of wavelength
+        nus: wavenumber (cm-1)
+        wavlength order: wavelength order: "ascending" or "descending"
+        unit: unit of wavelength
 
     Returns:
        wavelength (AA)
     """
-    if unit == 'nm':
-        return 1.e7/nus[::-1]
-    elif unit == 'AA':
-        return 1.e8/nus[::-1]
-    elif unit == 'um':
-        return 1.e4/nus[::-1]
-    else:
+    conversion_factors = {
+        'nm': 1.e7,
+        'AA': 1.e8,
+        'um': 1.e4
+    }
+
+    if is_sorted(nus) != "ascending":
+        raise ValueError("wavenumber should be in ascending order in ExoJAX.")
+
+    try:
+        if wavelength_order=="ascending":
+            return conversion_factors[unit] / nus[::-1]
+        elif wavelength_order=="descending":
+            return conversion_factors[unit] / nus
+        else:
+            raise ValueError("order should be ascending or descending")
+    except KeyError:
         raise ValueError("unavailable unit")
-        
 
 def wav2nu(wav, unit):
     """wavelength to wavenumber.
 
     Args:
-       wav: wavelength
+       wav: wavelength array in ascending/descending order
        unit: unit of wavelength
 
     Returns:
-       wavenumber (cm-1)
+       wavenumber (cm-1) in ascending order
     """
 
-    if unit == 'nm':
-        return 1.e7/wav[::-1]
-    elif unit == 'AA':
-        return 1.e8/wav[::-1]
-    elif unit == 'um':
-        return 1.e4/wav[::-1]
-    else:
+    conversion_factors = {
+        'nm': 1.e7,
+        'AA': 1.e8,
+        'um': 1.e4
+    }
+
+    order = is_sorted(wav)
+
+    try:
+        if order=="ascending":
+            return conversion_factors[unit] / wav[::-1]
+        elif order=="descending":
+            return conversion_factors[unit] / wav
+        else:
+            raise ValueError("wavelength array should be ascending or descending")
+    except KeyError:
         raise ValueError("unavailable unit")
-        
+

--- a/src/exojax/test/emulate_mdb.py
+++ b/src/exojax/test/emulate_mdb.py
@@ -38,7 +38,8 @@ def mock_wavenumber_grid():
                                     lambda1,
                                     Nx,
                                     unit='AA',
-                                    xsmode="modit")
+                                    xsmode="modit",
+                                    wavelength_order="ascending")
     return nus, wav, res
 
 
@@ -99,8 +100,6 @@ def mock_mdbVALD():
     with open(filename, 'rb') as f:
         mdb = pickle.load(f)
     return mdb
-
-    
 
 
 #if __name__ == "__main__":

--- a/src/exojax/utils/checkarray.py
+++ b/src/exojax/utils/checkarray.py
@@ -1,0 +1,17 @@
+def is_sorted(x):
+    """Check if a list is sorted in ascending or descending order.
+
+    Args:
+        x: List to check.
+
+    Returns:
+        'ascending' if the list is sorted in ascending order,
+        'descending' if the list is sorted in descending order,
+        'unordered' otherwise.
+    """
+    if all(a <= b for a, b in zip(x, x[1:])):
+        return 'ascending'
+    elif all(a >= b for a, b in zip(x, x[1:])):
+        return 'descending'
+    else:
+        return 'unordered'

--- a/src/exojax/utils/grids.py
+++ b/src/exojax/utils/grids.py
@@ -8,7 +8,7 @@ import numpy as np
 import warnings
 
 
-def wavenumber_grid(x0, x1, N, xsmode, unit='cm-1'):
+def wavenumber_grid(x0, x1, N, xsmode, wavelength_order="descending", unit='cm-1'):
     """generating the recommended wavenumber grid based on the cross section
     computation mode.
 
@@ -17,6 +17,7 @@ def wavenumber_grid(x0, x1, N, xsmode, unit='cm-1'):
         x1: end wavenumber (cm-1) or wavelength (nm) or (AA)
         N: the number of the wavenumber grid (even number)
         xsmode: cross section computation mode (lpf, dit, modit, premodit)
+        wavlength order: wavelength order: "ascending" or "descending"
         unit: unit of the input grid
         
     Note:
@@ -30,14 +31,32 @@ def wavenumber_grid(x0, x1, N, xsmode, unit='cm-1'):
         wav: corresponding wavelength grid (AA) in ascending order (wav). wav[-1] corresponds to nus[0]
         resolution: spectral resolution
     """
-    print("xsmode = ",xsmode)
+    print("xsmode = ", xsmode)
     _check_even_number(N)
     grid_mode = check_scale_xsmode(xsmode)
     grid, unit = _set_grid(x0, x1, N, unit, grid_mode)
     nu_grid = _set_nus(unit, grid)
-    wav = nu2wav(nu_grid, unit="AA")
+
+    _warning_wavelength_order(wavelength_order)
+
+    wav = nu2wav(nu_grid, wavelength_order=wavelength_order, unit="AA")
     resolution = grid_resolution(grid_mode, nu_grid)
     return nu_grid, wav, resolution
+
+def _warning_wavelength_order(wavelength_order):
+    """this is temporary special warning on wavelenght order
+
+    Args:
+        wavlength order: wavelength order: "ascending" or "descending"
+    """
+    print("======================================================================")
+    print("We changed the policy of the order of wavenumber/wavelength grids")
+    print("wavenumber grid shluld be in ascending order and now ")
+    print("users can specify the order of the wavelength grid by themselves.")
+    print("Your wavelength grid is in *** ", wavelength_order, " *** order")
+    print("This might causes the bug if you update ExoJAX. ")
+    print("Note that the older ExoJAX assumes ascending order as wavelength grid.")
+    print("======================================================================")
 
 
 def _set_grid(x0, x1, N, unit, grid_mode):
@@ -176,3 +195,5 @@ def check_eslog_wavenumber_grid(nus,
     val2 = np.max(np.abs(w))
 
     return (val1 < crit1 and val2 < crit2)
+
+

--- a/tests/endtoend/reverse/reverse_modit.py
+++ b/tests/endtoend/reverse/reverse_modit.py
@@ -38,7 +38,7 @@ filename = pkg_resources.resource_filename(
 dat = pd.read_csv(filename, delimiter=",", names=("wavenumber", "flux"))
 nusd = dat['wavenumber'].values
 flux = dat['flux'].values
-wavd = nu2wav(nusd)
+wavd = nu2wav(nusd, wavelength_order="ascending")
 sigmain = 0.05
 norm = 20000
 nflux = flux / norm + np.random.normal(0, sigmain, len(wavd))
@@ -49,7 +49,8 @@ nu_grid, wav, res = wavenumber_grid(np.min(wavd) - 10.0,
                                     np.max(wavd) + 10.0,
                                     Nx,
                                     unit='AA',
-                                    xsmode='modit')
+                                    xsmode='modit',
+                                    wavelength_order="ascending")
 
 # Atmospheric RT setting
 Tlow = 400.0

--- a/tests/endtoend/reverse/reverse_precompute_grid.py
+++ b/tests/endtoend/reverse/reverse_precompute_grid.py
@@ -35,13 +35,12 @@ from numpyro.infer import MCMC, NUTS
 import numpyro
 import numpyro.distributions as dist
 
-
 filename = pkg_resources.resource_filename(
     'exojax', 'data/testdata/' + SAMPLE_SPECTRA_CH4_NEW)
 dat = pd.read_csv(filename, delimiter=",", names=("wavenumber", "flux"))
 nusd = dat['wavenumber'].values
 flux = dat['flux'].values
-wavd = nu2wav(nusd)
+wavd = nu2wav(nusd, wavelength_order="ascending")
 #plt.plot(wavd, flux)
 #plt.show()
 
@@ -55,7 +54,8 @@ nu_grid, wav, res = wavenumber_grid(np.min(wavd) - 10.0,
                                     np.max(wavd) + 10.0,
                                     Nx,
                                     unit='AA',
-                                    xsmode='premodit')
+                                    xsmode='premodit',
+                                    wavelength_order="ascending")
 
 Tlow = 400.0
 Thigh = 1500.0
@@ -94,6 +94,7 @@ g = gravity_jupiter(Rp=0.88, Mp=33.2)
 alpha = 0.1
 MMR_CH4 = 0.0059
 
+
 # raw spectrum model given T0
 def raw_spectrum_model(T0):
     #T-P model
@@ -112,6 +113,7 @@ def raw_spectrum_model(T0):
     F0 = art.run(dtau, Tarr) / norm
     return F0
 
+
 # compute F0 grid given T0 grid
 Ngrid = 200  # delta T = 1 K
 T0_grid = jnp.linspace(1200, 1400, Ngrid)
@@ -124,6 +126,7 @@ for T0 in tqdm.tqdm(T0_grid, desc="computing grid"):
 F0_grid = jnp.array(F0_grid).T
 
 vmapinterp = vmap(jnp.interp, (None, None, 0))
+
 
 def model_c(nu1, y1):
     A = numpyro.sample('A', dist.Uniform(0.5, 2.0))

--- a/tests/endtoend/reverse/reverse_premodit.py
+++ b/tests/endtoend/reverse/reverse_premodit.py
@@ -44,7 +44,7 @@ filename = pkg_resources.resource_filename(
 dat = pd.read_csv(filename, delimiter=",", names=("wavenumber", "flux"))
 nusd = dat['wavenumber'].values
 flux = dat['flux'].values
-wavd = nu2wav(nusd)
+wavd = nu2wav(nusd, wavelength_order="ascending")
 
 sigmain = 0.05
 norm = 20000
@@ -55,7 +55,7 @@ nu_grid, wav, res = wavenumber_grid(np.min(wavd) - 10.0,
                                     np.max(wavd) + 10.0,
                                     Nx,
                                     unit='AA',
-                                    xsmode='premodit')
+                                    xsmode='premodit', wavelength_order="ascending")
 
 Tlow = 400.0
 Thigh = 1500.0

--- a/tests/endtoend/reverse/reverse_premodit_blackjax.py
+++ b/tests/endtoend/reverse/reverse_premodit_blackjax.py
@@ -41,7 +41,7 @@ filename = pkg_resources.resource_filename(
 dat = pd.read_csv(filename, delimiter=",", names=("wavenumber", "flux"))
 nusd = dat['wavenumber'].values
 flux = dat['flux'].values
-wavd = nu2wav(nusd)
+wavd = nu2wav(nusd, wavelength_order="ascending")
 
 sigmain = 0.05
 norm = 20000
@@ -52,7 +52,7 @@ nu_grid, wav, res = wavenumber_grid(np.min(wavd) - 10.0,
                                     np.max(wavd) + 10.0,
                                     Nx,
                                     unit='AA',
-                                    xsmode='premodit')
+                                    xsmode='premodit', wavelength_order="ascending")
 
 Tlow = 400.0
 Thigh = 1500.0

--- a/tests/endtoend/reverse/reverse_premodit_transmission.py
+++ b/tests/endtoend/reverse/reverse_premodit_transmission.py
@@ -44,7 +44,7 @@ filename = pkg_resources.resource_filename(
 dat = pd.read_csv(filename, delimiter=",", names=("wavenumber", "flux"))
 nusd = dat['wavenumber'].values
 flux = dat['flux'].values
-wavd = nu2wav(nusd)
+wavd = nu2wav(nusd, wavelength_order="ascending")
 
 sigmain = 0.05
 norm = 20000
@@ -55,7 +55,7 @@ nu_grid, wav, res = wavenumber_grid(np.min(wavd) - 10.0,
                                     np.max(wavd) + 10.0,
                                     Nx,
                                     unit='AA',
-                                    xsmode='premodit')
+                                    xsmode='premodit', wavelength_order="ascending")
 
 Tlow = 400.0
 Thigh = 1500.0

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     diffmode = 1
     nus_hitran, Rp_hitran = compare_with_kawashima_code()
     from exojax.spec.unitconvert import nu2wav
-    wav_exojax = nu2wav(nus_hitran, unit="um")
+    wav_exojax = nu2wav(nus_hitran, unit="um", wavelength_order="ascending")
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.plot(wav, rprs * Rs / RJ, label="Kawashima")

--- a/tests/unittests/utils/grids_test.py
+++ b/tests/unittests/utils/grids_test.py
@@ -5,15 +5,27 @@ from exojax.utils.grids import velocity_grid
 from exojax.utils.grids import delta_velocity_from_resolution
 from exojax.utils.grids import check_eslog_wavenumber_grid
 from exojax.utils.grids import check_scale_xsmode
+from exojax.utils.checkarray import is_sorted
 
+@pytest.mark.parametrize("order", ["ascending", "descending"])
+def test_wavenumber_grid_order(order):
+    Nx = 4000
+    nus, wav_revert, res = wavenumber_grid(29200.0,
+                                           29300.,
+                                           Nx,
+                                           unit='AA',
+                                           xsmode="lpf",
+                                           wavelength_order=order)
+    assert is_sorted(wav_revert) == order
 
 def test_wavenumber_grid():
     Nx = 4000
-    nus, wav, res = wavenumber_grid(29200.0,
-                                    29300.,
-                                    Nx,
-                                    unit='AA',
-                                    xsmode="lpf")
+    nus, wav_revert, res = wavenumber_grid(29200.0,
+                                           29300.,
+                                           Nx,
+                                           unit='AA',
+                                           xsmode="lpf",
+                                           wavelength_order="ascending")
     dif = np.log(nus[1:]) - np.log(nus[:-1])
     refval = 8.54915417e-07
     assert np.all(dif == pytest.approx(refval * np.ones_like(dif)))
@@ -39,11 +51,26 @@ def test_velocity_grid():
 
 
 def test_check_eslog_wavenumber_grid():
-    nus, wav, res = wavenumber_grid(22999, 23000, 1000, unit='AA', xsmode="modit")
+    nus, wav, res = wavenumber_grid(22999,
+                                    23000,
+                                    1000,
+                                    unit='AA',
+                                    xsmode="modit",
+                                    wavelength_order="descending")
     assert check_eslog_wavenumber_grid(nus)
-    nus, wav, res = wavenumber_grid(22999, 23000, 10000, unit='AA', xsmode="modit")
+    nus, wav, res = wavenumber_grid(22999,
+                                    23000,
+                                    10000,
+                                    unit='AA',
+                                    xsmode="modit",
+                                    wavelength_order="descending")
     assert check_eslog_wavenumber_grid(nus)
-    nus, wav, res = wavenumber_grid(22999, 23000, 100000, unit='AA', xsmode="modit")
+    nus, wav, res = wavenumber_grid(22999,
+                                    23000,
+                                    100000,
+                                    unit='AA',
+                                    xsmode="modit",
+                                    wavelength_order="descending")
     assert check_eslog_wavenumber_grid(nus)
     nus = np.linspace(1.e8 / 23000., 1.e8 / 22999., 1000)
     assert not check_eslog_wavenumber_grid(nus)
@@ -64,6 +91,15 @@ def test_check_scale_xsmode():
     assert check_scale_xsmode("PREMODIT") == "ESLOG"
     assert check_scale_xsmode("PRESOLAR") == "ESLOG"
     assert check_scale_xsmode("DIT") == "ESLIN"
+
+
+def test_is_sorted():
+    import numpy as np
+    a = np.array([1, 2, 3])
+    assert is_sorted(a) == "ascending"
+    assert is_sorted(a[::-1]) == "descending"
+    a = np.array([1, 3, 2])
+    assert is_sorted(a) == "unordered"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
addressed #391 

tentative new policy on the order of wavenumber/wavelength
- wavenumber grid should be in ascending
- users can choose the order of wavelength grids via `wavelength_order` in `utils.grids.wavenumber_grid` or `spec/unitconvert/nu2wav` but the default order is **descending** (the old one assumed **ascending**) 