### PR TITLE
OpaDirect for VALD and fix HITRAN api

### DIFF
--- a/src/exojax/spec/moldb.py
+++ b/src/exojax/spec/moldb.py
@@ -47,7 +47,7 @@ class AdbVald(object):
            For the first time to read the VALD line list, it is converted to HDF/vaex. After the second-time, we use the HDF5 format with vaex instead.
     """
 
-    def __init__(self, path, nurange=[-np.inf, np.inf], margin=0.0, crit=0., Irwin=False, gpu_transfer=True):
+    def __init__(self, path, nurange=[-np.inf, np.inf], margin=0.0, crit=0., Irwin=False, gpu_transfer=True, vmr_fraction=None):
         """Atomic database for VALD3 "Long format".
 
         Args:
@@ -57,16 +57,23 @@ class AdbVald(object):
           crit: line strength lower limit for extraction
           Irwin: if True(1), the partition functions of Irwin1981 is used, otherwise those of Barklem&Collet2016
           gpu_transfer: tranfer data to jnp.array? 
+          vmr_fraction: list of the vmr fractions of hydrogen, H2 molecule, helium. if None, typical quasi-"solar-fraction" will be applied. 
 
         Note:
           (written with reference to moldb.py, but without using feather format)
         """
+
+        self.dbtype = "vald"
 
         # load args
         self.vald3_file = pathlib.Path(path).expanduser()  # VALD3 output
         self.nurange = [np.min(nurange), np.max(nurange)]
         self.margin = margin
         self.crit = crit
+        if vmr_fraction is None:
+            self.vmrH, self.vmrHe, self.vmrHH = [0.0, 0.16, 0.84] #typical quasi-"solar-fraction"
+        else:
+            self.vmrH, self.vmrHe, self.vmrHH = vmr_fraction
 
         # load vald file
         print('Reading VALD file')

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -647,11 +647,11 @@ class OpaDirect(OpaCalc):
             sigmaDM = jit(vmap(doppler_sigma,
                             (None, 0, None)))(self.mdb.nu_lines, Tarr,
                                                 self.mdb.molmass)
-        elif self.mdb.dbtype == "kurucz":
+        elif (self.mdb.dbtype == "kurucz") or (self.mdb.dbtype == "vald"):
             qt_284=vmap(self.mdb.QT_interp_284)(Tarr)
-            qt_K = np.zeros([len(self.mdb.QTmask), len(Tarr)])
+            qt_K = jnp.zeros([len(self.mdb.QTmask), len(Tarr)])
             for i, mask in enumerate(self.mdb.QTmask):
-                qt_K[i] = qt_284[:,mask]  #e.g., qt_284[:,76] #Fe I
+                qt_K = qt_K.at[i].set(qt_284[:,mask]) #e.g., qt_284[:,76] #Fe I
             qt_K = jnp.array(qt_K)     
             vmapvald3 = jit(vmap(gamma_vald3,(0,0,0,0,None,None,None,None,None,None,None,None,None,None,None)))
             PH,PHe,PHH = Parr*self.mdb.vmrH, Parr*self.mdb.vmrHe, Parr*self.mdb.vmrHH 

--- a/tests/integration/adb/adbvald_test.py
+++ b/tests/integration/adb/adbvald_test.py
@@ -1,0 +1,41 @@
+import os
+from exojax.spec.moldb import AdbVald, AdbSepVald
+
+import urllib.request
+from exojax.utils.url import url_developer_data
+
+filepath_VALD3 = '.database/vald2600.gz'
+path_ValdLineList = '.database/vald4214450.gz'
+if not os.path.isfile(filepath_VALD3):
+    try:
+        url = url_developer_data()+'vald2600.gz'
+        urllib.request.urlretrieve(url, filepath_VALD3)
+    except:
+        print('could not connect ', url_developer_data())
+if not os.path.isfile(path_ValdLineList):
+    try:
+        url = url_developer_data()+'vald4214450.gz'
+        urllib.request.urlretrieve(url, path_ValdLineList)
+    except:
+        print('could not connect ', url_developer_data())
+
+def test_adb_vald():
+    adbV = AdbVald(filepath_VALD3, nurange=[9660., 9570.])
+    assert adbV.atomicmass[0] == 55.847
+
+def test_adb_vald_interp():
+    adbV = AdbVald(filepath_VALD3, nurange=[9660., 9570.])
+    T = 1000.0
+    qt_284 = adbV.QT_interp_284(T)
+    assert qt_284[76] == 15.7458 #Fe I
+
+def test_adb_sepvald():
+    adbV = AdbVald(path_ValdLineList,  nurange=[9660., 9570.], crit = 1e-100) 
+    #The crit is defined just in case some weak lines may cause an error that results in a gamma of 0... (220219)
+    asdb = AdbSepVald(adbV)
+    assert asdb.atomicmass[asdb.ielem==26][0] == 55.847
+
+if __name__ == "__main__":
+    test_adb_vald()
+    test_adb_vald_interp()
+    test_adb_sepvald()

--- a/tests/integration/api/api_hitran_hitemp_test.py
+++ b/tests/integration/api/api_hitran_hitemp_test.py
@@ -43,10 +43,7 @@ def test_Hitran_with_error():
                                     100000,
                                     unit='AA',
                                     xsmode="premodit")
-    
-    # After radis/pull/574 will be marged, this error will not rise.
-    with pytest.raises(AttributeError):
-        mdb = api.MdbHitran("CO",nus, with_error=True)
+    mdb = api.MdbHitran("CO",nus, with_error=True)
 
 def test_Hitemp_with_error():
     lambda0 = 22920.0


### PR DESCRIPTION
- I have adapted OpaDirect to VALD. (`spec/moldb.py`, `tests/integration/adb/adbvald_test.py`)
- Thanks to the updates of radis, HITRAN uncertainty codes became available. #398 (`spec/api.py`, `tests/integration/api/api_hitran_hitemp_test.py`)
- _Minor fix:_ fixed the code (for Kurucz and VALD) to allow for autodiffrentiation. (`spec/opacalc.py`)