### PR TITLE
Olaresponse

### DIFF
--- a/documents/userguide.rst
+++ b/documents/userguide.rst
@@ -37,7 +37,11 @@ Radiative Transfer
 Spectral Operators
 =======================
 
-   N/A
+.. toctree::
+   :maxdepth: 1
+
+   userguide/sop.rst
+
    
 Others
 =======================

--- a/documents/userguide/sop.rst
+++ b/documents/userguide/sop.rst
@@ -1,0 +1,28 @@
+Spectral Operators (sop)
+==========================
+
+In the post-radiative transfer, the observed spectrum differs from the raw spectrum due to several modifications.
+For instance, it might experience rotational broadening due to the planet's rotation, wavelength shifts 
+due to differences in line-of-sight velocities, or the influence of the instrument's profile (IP). 
+In ExoJAX, these responses to the spectrum are termed the "Spectral Operator." 
+Within the spec.specop module, classes like SopRotation and SopInstProfile allow for the easy handling of these responses.
+
+
+SopRotation
+-----------------------
+
+SopInstProfile
+-----------------------
+
+Convolution methods available in sop
+---------------------------------------
+
+- convolution_method="exojax.signal.convolve" : FFT-based convolution
+
+- convolution_method="exojax.signal.ola" : Overlap-and-Add convolution, One can change the nuber of the division by self.ola_ndiv (default=4).
+
+
+
+
+
+

--- a/src/exojax/spec/response.py
+++ b/src/exojax/spec/response.py
@@ -32,11 +32,11 @@ def ipgauss_ola_sampling(nusd, nus, F0, beta, RV, varr_kernel):
     return sampling(nusd, nus, Fgauss, RV)
 
 @jit
-def ipgauss_ola(F0, varr_kernel, beta):
+def ipgauss_ola(folded_F0, varr_kernel, beta):
     """Apply the Gaussian IP response to a spectrum F using OLA.
 
     Args:
-        F0: original spectrum (F0)
+        folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
         varr_kernel: velocity array for the rotational kernel
         beta: STD of a Gaussian broadening (IP+microturbulence)
 
@@ -46,15 +46,14 @@ def ipgauss_ola(F0, varr_kernel, beta):
     x = varr_kernel / beta
     kernel = jnp.exp(-x * x / 2.0)
     kernel = kernel / jnp.sum(kernel, axis=0)
-    print(jnp.shape(F0), jnp.shape(kernel))
-    ndiv, div_length, filter_length = ola_lengths(F0, kernel)
-    F0_hat, kernel_hat = generate_zeropad(F0, kernel)
+    
+    ndiv, div_length, filter_length = ola_lengths(folded_F0, kernel)
+    F0_hat, kernel_hat = generate_zeropad(folded_F0, kernel)
     ola = olaconv(F0_hat, kernel_hat, ndiv, div_length, filter_length)
     
     edge = int((len(kernel) - 1) / 2)
     F = ola[edge:-edge]
-    #F = convolve_same(F0, kernel)
-
+    
     return F
 
 

--- a/src/exojax/spec/response.py
+++ b/src/exojax/spec/response.py
@@ -13,14 +13,14 @@ from exojax.signal.ola import olaconv, ola_lengths, generate_zeropad
 
 
 @jit
-def ipgauss_ola_sampling(nusd, nus, F0, beta, RV, varr_kernel):
+def ipgauss_ola_sampling(nusd, nus, folded_F0, beta, RV, varr_kernel):
     """Apply the Gaussian IP response using OLA + sampling to a spectrum F.
     
     
     Args:
         nusd: sampling wavenumber
         nus: input wavenumber, evenly log-spaced
-        F0: original spectrum (F0)
+        folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
         beta: STD of a Gaussian broadening (IP+microturbulence)
         RV: radial velocity (km/s)
         varr_kernel: velocity array for the rotational kernel
@@ -28,7 +28,7 @@ def ipgauss_ola_sampling(nusd, nus, F0, beta, RV, varr_kernel):
     Return:
         response-applied spectrum (F)
     """
-    Fgauss = ipgauss_ola(F0, varr_kernel, beta)
+    Fgauss = ipgauss_ola(folded_F0, varr_kernel, beta)
     return sampling(nusd, nus, Fgauss, RV)
 
 @jit

--- a/src/exojax/spec/specop.py
+++ b/src/exojax/spec/specop.py
@@ -2,13 +2,17 @@
 """
 from exojax.utils.grids import velocity_grid
 from exojax.spec.spin_rotation import convolve_rigid_rotation
+from exojax.spec.spin_rotation import convolve_rigid_rotation_ola
 from exojax.spec.response import ipgauss, sampling
+from exojax.spec.response import ipgauss_ola, sampling
 from exojax.utils.grids import grid_resolution
+
 
 class SopCommon():
     """Common Spectral Operator
     """
-    def __init__(self, nu_grid, resolution, vrmax):
+
+    def __init__(self, nu_grid, resolution, vrmax, convolution_method):
         """initialization of Sop
 
         Args:
@@ -16,27 +20,38 @@ class SopCommon():
             resolution (float): wavenumber grid resolution, defined by nu/delta nu
             vrmax (float): velocity maximum to be applied in km/s
         """
-        self.convolution_method = "exojax.signal.convolve"
+        self.convolution_method_list = [
+            "exojax.signal.convolve", "exojax.signal.olaconv"]
+        self.convolution_method = convolution_method
         self.nu_grid = nu_grid
         self.vrmax = vrmax
         self.resolution = resolution
-        self.generate_vrarray()   
+        self.generate_vrarray()
         self.resolution = grid_resolution('ESLOG', self.nu_grid)
+        self.ola_ndiv = 4
 
     def generate_vrarray(self):
         self.vrarray = velocity_grid(self.resolution, self.vrmax)
+
+    def check_reducible(self, spectrum):
+        div_length = int(float(len(spectrum))/float(self.ola_ndiv))
+        if len(spectrum) != self.ola_ndiv*div_length:
+            raise ValueError("len(spectrum) can be reduced by self.ola_ndiv ="+str(self.ola_ndiv))
+        return div_length
 
 
 class SopRotation(SopCommon):
     """Spectral operator on rotation
     """
+
     def __init__(self,
                  nu_grid,
                  resolution,
                  vsini_max=100.0,
+                 convolution_method="exojax.signal.convolve"
                  ):
-        super().__init__(nu_grid, resolution, vsini_max)
-        
+        super().__init__(nu_grid, resolution, vsini_max, convolution_method)
+
     def rigid_rotation(self, spectrum, vsini, u1, u2):
         """apply a rigid rotation
 
@@ -52,22 +67,29 @@ class SopRotation(SopCommon):
         Returns:
             nd array: rotatinoal broaden spectrum
         """
-        if self.convolution_method == "exojax.signal.convolve":
+        if self.convolution_method == self.convolution_method_list[0]:  # "exojax.signal.convolve"
             return convolve_rigid_rotation(spectrum, self.vrarray, vsini, u1, u2)
+        elif self.convolution_method == self.convolution_method_list[1]:  # "exojax.signal.olaconv"
+            div_length = self.check_reducible(spectrum)
+            folded_spectrum = spectrum.reshape((self.ola_ndiv, div_length))
+            return convolve_rigid_rotation_ola(folded_spectrum, self.vrarray, vsini, u1, u2)
         else:
             raise ValueError("No convolution_method")
 
+    
 
 class SopInstProfile(SopCommon):
     """Spectral operator on Instrumental profile and sampling
     """
+
     def __init__(self,
                  nu_grid,
                  resolution,
                  vrmax=100.0,
+                 convolution_method="exojax.signal.convolve"
                  ):
-        super().__init__(nu_grid, resolution, vrmax)
-    
+        super().__init__(nu_grid, resolution, vrmax, convolution_method)
+
     def ipgauss(self, spectrum, standard_deviation):
         """Gaussian Instrumental Profile
 
@@ -81,8 +103,12 @@ class SopInstProfile(SopCommon):
         Returns:
             array: IP applied spectrum
         """
-        if self.convolution_method == "exojax.signal.convolve":
+        if self.convolution_method == self.convolution_method_list[0]:  # "exojax.signal.convolve"
             return ipgauss(spectrum, self.vrarray, standard_deviation)
+        elif self.convolution_method == self.convolution_method_list[1]:  # "exojax.signal.olaconv"
+            div_length = self.check_reducible(spectrum)
+            folded_spectrum = spectrum.reshape((self.ola_ndiv, div_length))
+            return ipgauss_ola(folded_spectrum, self.vrarray, standard_deviation)
         else:
             raise ValueError("No convolution_method")
 
@@ -98,5 +124,3 @@ class SopInstProfile(SopCommon):
             array: inst sampled spectrum 
         """
         return sampling(nu_grid_sampling, self.nu_grid, spectrum, radial_velocity)
-
-

--- a/tests/unittests/signal/ola_test.py
+++ b/tests/unittests/signal/ola_test.py
@@ -108,7 +108,7 @@ def test_olaconv(fig=False):
     #assert maxresidual < 1.e-6 #fp32
 
     if fig:
-        edge = int((Nf - 1) / 2)
+        edge = int((len(f) - 1) / 2)
         plt.plot(x, label="input")
         plt.plot(oac[edge:-edge], label="oaconvolve")
         plt.plot(ola[edge:-edge], ls="dashed", label="OLA test")

--- a/tests/unittests/spec/response/response_test.py
+++ b/tests/unittests/spec/response/response_test.py
@@ -74,23 +74,23 @@ def test_ipgauss_ola_sampling(fig=False):
     F0 = np.ones_like(nus)
     F0[5000 - 50:5000 + 50] = 0.5
     RV = 10.0
-    beta = 20.0
+    beta = 2.0
     nusd, wav, resolution_inst = wavenumber_grid(4003.0,
                                                4007.0,
                                                2500,
                                                xsmode="lpf")
                                                #settings before HMC
-    vsini_max = 100.0
+    vsini_max = 10.0
     vr_array = velocity_grid(resolution, vsini_max)
 
     input_matrix = F0.reshape((5,2000))
-
+    print(jnp.shape(input_matrix),jnp.shape(vr_array))
     F = ipgauss_ola_sampling(nusd, nus, input_matrix, beta, RV, vr_array)
 
     F_naive = _ipgauss_sampling_naive(nusd, nus, F0, beta, RV)
     res = np.max(np.abs(1.0 - F_naive/F))
     print(res)
-    assert res < 1.e-4 #0.1% allowed
+    assert res < 3.e-3 
     if fig:
         import matplotlib.pyplot as plt
         plt.plot(nusd,F)

--- a/tests/unittests/spec/response/response_test.py
+++ b/tests/unittests/spec/response/response_test.py
@@ -171,7 +171,7 @@ def test_SopInstProfile_ola(fig=False):
                                                250,
                                                xsmode="lpf")
     
-    SopInst = SopInstProfile(nus, resolution, convolution_method="exojax.signal.olaconv")
+    SopInst = SopInstProfile(nus, resolution, convolution_method="exojax.signal.ola")
     
     F = SopInst.ipgauss(F0, beta)
     F = SopInst.sampling(F, RV, nusd)

--- a/tests/unittests/spec/response/response_test.py
+++ b/tests/unittests/spec/response/response_test.py
@@ -155,8 +155,42 @@ def test_ipgauss_variable_sampling_using_constant_beta_array(fig=False):
         plt.show()
 
 
+def test_SopInstProfile_ola(fig=False):
+    from exojax.spec.specop import SopInstProfile
+    
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               10000,
+                                               xsmode="premodit")
+    F0 = np.ones_like(nus)
+    F0[5000 - 50:5000 + 50] = 0.5
+    RV = 4.0
+    beta = 4.0
+    nusd, wav, resolution_inst = wavenumber_grid(4003.0,
+                                               4007.0,
+                                               250,
+                                               xsmode="lpf")
+    
+    SopInst = SopInstProfile(nus, resolution, convolution_method="exojax.signal.olaconv")
+    
+    F = SopInst.ipgauss(F0, beta)
+    F = SopInst.sampling(F, RV, nusd)
+    F_naive = _ipgauss_sampling_naive(nusd, nus, F0, beta, RV)
+    res = np.max(np.abs(1.0 - F_naive/F))
+    print(res)
+    if fig:
+        import matplotlib.pyplot as plt
+        plt.plot(nusd,F)
+        plt.plot(nusd,F_naive,ls="dashed")
+        plt.show()
+
+    assert res < 1.e-3 #0.1% allowed
+
+
 if __name__ == "__main__":
     #test_ipgauss_sampling(fig=True)
     #test_ipgauss_variable_sampling_using_constant_beta_array(fig=True)
     #test_SopInstProfile()
-    test_ipgauss_ola_sampling(fig=True)
+    #test_ipgauss_ola_sampling(fig=True)
+    test_SopInstProfile_ola(fig=True)
+    

--- a/tests/unittests/spec/response/spin_rotation_test.py
+++ b/tests/unittests/spec/response/spin_rotation_test.py
@@ -112,7 +112,7 @@ def test_SopRotation_ola(N=10000, fig=False):
     F0[2500 - 50:2500 + 50] = 0.5
     vsini = 4.0
     
-    sos = SopRotation(nus, resolution, vsini, convolution_method = "exojax.signal.olaconv" )    
+    sos = SopRotation(nus, resolution, vsini, convolution_method = "exojax.signal.ola" )    
     Frot = sos.rigid_rotation(F0, vsini, u1=0.1, u2=0.1)
     Frot_ = _convolve_rigid_rotation_np(resolution, F0, vsini, u1=0.1, u2=0.1)
 

--- a/tests/unittests/spec/response/spin_rotation_test.py
+++ b/tests/unittests/spec/response/spin_rotation_test.py
@@ -31,7 +31,7 @@ def _convolve_rigid_rotation_np(resolution, F0, vsini, u1=0.0, u2=0.0):
     #No OLA
     input_length = len(F0)
     filter_length = len(kernel)
-    fft_length = input_length + filter_length - 1
+    #fft_length = input_length + filter_length - 1
     convolved_signal = np.convolve(F0, kernel, mode="same")
     return convolved_signal
 


### PR DESCRIPTION
addressed #417. 
I implemented the OLA version of `convolve_rigid_rotation` (`convolve_rigid_rotation_ola`) and `ipgauss_sampling` (`ipgauss_ola_sampling`).

The input spectrum should be reshaped to (ndiv, div_length). for instance, when the spectrum has the shape of 40000, maybe (4,10000) or (8, 5000) etc.

I hope this solves #417. I will postpone UI for them to the next PR. 