### PR TITLE
Simpson rule of the transmission chord integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpyro
 jaxopt
 jax
 hitran-api
--e git+https://github.com/radis/radis.git@develop#egg=radis-0.14
+git+https://github.com/radis/radis.git@develop#egg=radis-0.14
 pygments>=2.15
 pydantic<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpyro
 jaxopt
 jax
 hitran-api
--e git+https://github.com/radis/radis.git@develop#egg=radis
+-e git+https://github.com/radis/radis.git@develop#egg=radis-0.14
 pygments>=2.15
 pydantic<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpyro
 jaxopt
 jax
 hitran-api
--e git+https://github.com/radis/radis.git@develop
+-e git+https://github.com/radis/radis.git@develop#egg=radis
 pygments>=2.15
 pydantic<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpyro
+jaxopt
+jax
+hitran-api
+-e git+https://github.com/radis/radis.git@develop
+pygments>=2.15
+pydantic<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpyro
 jaxopt
 jax
 hitran-api
-git+https://github.com/radis/radis.git@develop#egg=radis-0.14
+radis
 pygments>=2.15
 pydantic<2.0

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,6 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Operating System :: OS Independent",
 ]
-INSTALL_REQUIRES = [
-    'numpyro',
-    'jaxopt',
-    'jax',
-    "hitran-api",
-    'git+https://github.com/radis/radis.git@develop',
-    "pygments>=2.15",
-    "pydantic<2.0",
-]
 
 # END PROJECT SPECIFIC
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -42,6 +33,30 @@ def find_meta(meta, meta_file=read(META_PATH)):
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
 
 
+#def read_requirements():
+#    with open('requirements.txt', 'r') as file:
+#        return file.readlines()
+
+def take_package_name(name):
+    if name.startswith("-e"):
+        return name[name.find("=")+1:name.rfind("-")]
+    else:
+        return name.strip()
+
+def load_requires_from_file(filepath):
+    with open(filepath) as fp:
+        return [take_package_name(pkg_name) for pkg_name in fp.readlines()]
+
+def load_links_from_file(filepath):
+    res = []
+    with open(filepath) as fp:
+        for pkg_name in fp.readlines():
+            if pkg_name.startswith("-e"):
+                res.append(pkg_name.split(" ")[1])
+    return res
+
+
+
 if __name__ == '__main__':
     setup(
         name=NAME,
@@ -51,7 +66,7 @@ if __name__ == '__main__':
             'write_to_template':
             '__version__ = "{version}"\n',
         },
-        version='1.4.1',
+        version='1.4.2',
         author=find_meta('author'),
         author_email=find_meta('email'),
         maintainer=find_meta('author'),
@@ -65,7 +80,8 @@ if __name__ == '__main__':
         python_requires='>=3.9',
         package_dir={'': 'src'},
         include_package_data=True,
-        install_requires=INSTALL_REQUIRES,
+        install_requires=load_requires_from_file("requirements.txt"),
+        dependency_links=load_links_from_file("requirements.txt"),
         classifiers=CLASSIFIERS,
         zip_safe=False,
         options={'bdist_wheel': {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRES = [
     'jaxopt',
     'jax',
     "hitran-api",
-    'git+https://github.com//radis/radis.git@develop',
+    'git+https://github.com/radis/radis.git@develop',
     "pygments>=2.15",
     "pydantic<2.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ def find_meta(meta, meta_file=read(META_PATH)):
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
 
 
-#def read_requirements():
-#    with open('requirements.txt', 'r') as file:
-#        return file.readlines()
+def read_requirements():
+    with open('requirements.txt', 'r') as file:
+        return file.readlines()
 
 
 
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         python_requires='>=3.9',
         package_dir={'': 'src'},
         include_package_data=True,
-        install_requires=[],
+        install_requires=read_requirements(),
         classifiers=CLASSIFIERS,
         zip_safe=False,
         options={'bdist_wheel': {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRES = [
     'jaxopt',
     'jax',
     "hitran-api",
-    'radis',
+    'git+https://github.com//radis/radis.git@develop',
     "pygments>=2.15",
     "pydantic<2.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -37,23 +37,6 @@ def find_meta(meta, meta_file=read(META_PATH)):
 #    with open('requirements.txt', 'r') as file:
 #        return file.readlines()
 
-def take_package_name(name):
-    if name.startswith("-e"):
-        return name[name.find("=")+1:name.rfind("-")]
-    else:
-        return name.strip()
-
-def load_requires_from_file(filepath):
-    with open(filepath) as fp:
-        return [take_package_name(pkg_name) for pkg_name in fp.readlines()]
-
-def load_links_from_file(filepath):
-    res = []
-    with open(filepath) as fp:
-        for pkg_name in fp.readlines():
-            if pkg_name.startswith("-e"):
-                res.append(pkg_name.split(" ")[1])
-    return res
 
 
 
@@ -80,8 +63,7 @@ if __name__ == '__main__':
         python_requires='>=3.9',
         package_dir={'': 'src'},
         include_package_data=True,
-        install_requires=load_requires_from_file("requirements.txt"),
-        dependency_links=load_links_from_file("requirements.txt"),
+        install_requires=[],
         classifiers=CLASSIFIERS,
         zip_safe=False,
         options={'bdist_wheel': {

--- a/src/exojax/signal/integrate.py
+++ b/src/exojax/signal/integrate.py
@@ -1,0 +1,19 @@
+import jax.numpy as jnp
+
+def simpson(f, f_lower, f_top, h):
+    """Simpson integral for (Nlayer, Nnus) form
+
+    Args:
+        f (2D array): f at the midpoint (Nlayer, Nnus)
+        f_lower (2D array): f at the lower bondary (Nlayer, Nnus)
+        f_top (1D array): f at the ToA  (Nnus)
+        h (1D array): interval (Nlayer)
+
+    Returns:
+        1D array: simson integral value (Nnus)
+    """
+    N=len(f)
+    hh = jnp.roll(h, -1) + h  # h_{n+1} + h_n
+    fac = hh[:N-1,None]*f_lower[:N-1,:]
+    return 2.0/3.0*jnp.sum(h[:,None]*f) + h[0]*f_top/6.0 + h[-1]*f_lower[-1,:]/6.0 + jnp.sum(fac)/6.0
+    

--- a/src/exojax/signal/integrate.py
+++ b/src/exojax/signal/integrate.py
@@ -15,5 +15,5 @@ def simpson(f, f_lower, f_top, h):
     N=len(f)
     hh = jnp.roll(h, -1) + h  # h_{n+1} + h_n
     fac = hh[:N-1,None]*f_lower[:N-1,:]
-    return 2.0/3.0*jnp.sum(h[:,None]*f) + h[0]*f_top/6.0 + h[-1]*f_lower[-1,:]/6.0 + jnp.sum(fac)/6.0
+    return 2.0/3.0*jnp.sum(h[:,None]*f,axis=0) + h[0]*f_top/6.0 + h[-1]*f_lower[-1,:]/6.0 + jnp.sum(fac,axis=0)/6.0
     

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -494,7 +494,6 @@ class ArtTransPure(ArtCommon):
         cgm = chord_geometric_matrix_lower(normalized_height,
                                            normalized_radius_lower)
         dtau_chord_lower = chord_optical_depth(cgm, dtau)
-
         func = self.integration_dict[self.integration]
         if self.integration == "trapezoid":
             return func(dtau_chord_lower, normalized_radius_lower,

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -12,7 +12,7 @@ from exojax.spec.rtransfer import rtrun_emis_pureabs_ibased_linsap
 from exojax.spec.rtransfer import rtrun_emis_pureabs_fbased2st
 from exojax.spec.rtransfer import rtrun_emis_pureabs_ibased
 from exojax.spec.rtransfer import rtrun_emis_scat_lart_toonhm
-from exojax.spec.rtransfer import rtrun_trans_pureabs
+from exojax.spec.rtransfer import rtrun_trans_pureabs_trapezoid
 from exojax.spec.layeropacity import layer_optical_depth
 from exojax.atm.atmprof import atmprof_gray, atmprof_Guillot, atmprof_powerlow
 from exojax.atm.idealgas import number_density
@@ -448,4 +448,4 @@ class ArtTransPure(ArtCommon):
         cgm = chord_geometric_matrix(normalized_height,
                                      normalized_radius_lower)
         tauchord = chord_optical_depth(cgm, dtau)
-        return rtrun_trans_pureabs(tauchord, normalized_radius_lower, normalized_radius_top)
+        return rtrun_trans_pureabs_trapezoid(tauchord, normalized_radius_lower, normalized_radius_top)

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -4,7 +4,7 @@ from jax import jit
 
 
 @jit
-def chord_geometric_matrix(height, radius_lower):
+def chord_geometric_matrix_lower(height, radius_lower):
     """compute chord geometric matrix
 
     Args:
@@ -19,19 +19,16 @@ def chord_geometric_matrix(height, radius_lower):
         n=0,1,...,N-1
         radius_lower[N-1] = radius_btm (i.e. R0)    
         radius_lower[n-1] = radius_lower[n] + height[n]
-        radius_top = radius_lower[0] + height[0]
         
     """
-    radius_top = radius_lower[0] + height[0]  #radius at TOA
-    radius_shifted = jnp.roll(radius_lower, 1)  # r_{k-1}
-    radius_shifted = radius_shifted.at[0].set(radius_top)
+    radius_upper = radius_lower + height
+    fac_left = jnp.sqrt(radius_upper[None, :]**2 - radius_lower[:, None]**2)
     fac_right = jnp.sqrt(radius_lower[None, :]**2 - radius_lower[:, None]**2)
-    fac_left = jnp.sqrt(radius_shifted[None, :]**2 - radius_lower[:, None]**2)
     raw_matrix = 2.0 * (fac_left - fac_right) / height
     return jnp.tril(raw_matrix)
 
 @jit
-def chord_geometric_matrix_midpoint(height, radius_lower, radius_midpoint):
+def chord_geometric_matrix(height, radius_lower, radius_midpoint):
     """compute chord geometric matrix
 
     Args:

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -28,7 +28,7 @@ def chord_geometric_matrix_lower(height, radius_lower):
     return jnp.tril(raw_matrix)
 
 
-#@jit
+@jit
 def chord_geometric_matrix(height, radius_lower):
     """compute chord geometric matrix
 

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -57,7 +57,7 @@ def chord_geometric_matrix(height, radius_lower):
     raw_matrix = 2.0 * (jnp.sqrt(fac_left) - jnp.sqrt(fac_right)) / height
     return jnp.tril(raw_matrix)
 
-
+@jit
 def chord_optical_depth(chord_geometric_matrix, dtau):
     """chord optical depth vector from a chord geometric matrix and dtau
     

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -54,7 +54,7 @@ def chord_geometric_matrix(height, radius_lower):
     raw_matrix = 2.0 * (fac_left - fac_right) / height
     
     ratio = radius_midpoint/height
-    deep_element_correction = 2.0*(jnp.sqrt(0.25 - ratio) - ratio)
+    deep_element_correction = jnp.sqrt(1.0 - 4.0*ratio) - 2.0*ratio
     
     return jnp.tril(raw_matrix) + jnp.diag(deep_element_correction)
 

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -27,7 +27,8 @@ def chord_geometric_matrix_lower(height, radius_lower):
     raw_matrix = 2.0 * (fac_left - fac_right) / height
     return jnp.tril(raw_matrix)
 
-@jit
+
+#@jit
 def chord_geometric_matrix(height, radius_lower):
     """compute chord geometric matrix
 
@@ -47,16 +48,15 @@ def chord_geometric_matrix(height, radius_lower):
         
     """
     radius_upper = radius_lower + height
-    radius_midpoint = radius_lower + height/2.0
-    
-    fac_left = jnp.sqrt(radius_upper[None, :]**2 - radius_midpoint[:, None]**2)
-    fac_right = jnp.sqrt(radius_lower[None, :]**2 - radius_midpoint[:, None]**2)
-    raw_matrix = 2.0 * (fac_left - fac_right) / height
-    
-    ratio = radius_midpoint/height
-    deep_element_correction = jnp.sqrt(1.0 - 4.0*ratio) - 2.0*ratio
-    
-    return jnp.tril(raw_matrix) + jnp.diag(deep_element_correction)
+    radius_midpoint = radius_lower + height / 2.0
+
+    fac_left = radius_upper[None, :]**2 - radius_midpoint[:, None]**2
+    fac_right = radius_lower[None, :]**2 - radius_midpoint[:, None]**2
+    deep_element_correction = radius_lower**2 - radius_midpoint**2
+    fac_right = fac_right - jnp.diag(deep_element_correction)
+    raw_matrix = 2.0 * (jnp.sqrt(fac_left) - jnp.sqrt(fac_right)) / height
+    return jnp.tril(raw_matrix)
+
 
 def chord_optical_depth(chord_geometric_matrix, dtau):
     """chord optical depth vector from a chord geometric matrix and dtau

--- a/src/exojax/spec/opachord.py
+++ b/src/exojax/spec/opachord.py
@@ -30,6 +30,34 @@ def chord_geometric_matrix(height, radius_lower):
     raw_matrix = 2.0 * (fac_left - fac_right) / height
     return jnp.tril(raw_matrix)
 
+@jit
+def chord_geometric_matrix_midpoint(height, radius_lower, radius_midpoint):
+    """compute chord geometric matrix
+
+    Args:
+        height (1D array): (normalized) height of the layers from top atmosphere, Nlayer
+        radius_lower (1D array): (normalized) radius at the lower boundary from top to bottom (R0), (Nlayer)
+
+    Returns:
+        2D array: chord geometric matrix (Nlayer, Nlayer), lower triangle matrix
+
+    Notes:
+        Our definitions of the radius_lower and height (and radius_top, internally defined) are as follows:
+        n=0,1,...,N-1
+        radius_lower[N-1] = radius_btm (i.e. R0)    
+        radius_lower[n-1] = radius_lower[n] + height[n]
+        radius_top = radius_lower[0] + height[0]
+        
+    """
+    radius_top = radius_lower[0] + height[0]  #radius at TOA
+    radius_shifted = jnp.roll(radius_lower, 1)  # r_{k-1}
+    radius_shifted = radius_shifted.at[0].set(radius_top)
+    fac_right = jnp.sqrt(radius_lower[None, :]**2 - radius_midpoint[:, None]**2)
+    fac_left = jnp.sqrt(radius_shifted[None, :]**2 - radius_midpoint[:, None]**2)
+    diag_correction = jnp.diag(jnp.sqrt(radius_lower**2 - radius_midpoint**2))
+    raw_matrix = 2.0 * (fac_left - fac_right + diag_correction) / height
+    return jnp.tril(raw_matrix)
+
 
 def chord_optical_depth(chord_geometric_matrix, dtau):
     """chord optical depth vector from a chord geometric matrix and dtau

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -245,10 +245,10 @@ def rtrun_trans_pureabs_trapezoid(dtau_chord, radius_lower, radius_top):
         (1.0 - jnp.exp(-dtau_chord)) * radius_lower[:, None],
         x=radius_lower,
         axis=0) + edge_cor
-
     return deltaRp2 + radius_lower[-1]**2
 
 
+@jit
 def rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
                                 radius_lower, height):
     """Radiative transfer for transmission spectrum assuming pure absorption with the Simpson integration (signals.integration.simpson)
@@ -273,7 +273,7 @@ def rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
         We assume tau = 0 at the radius_top. then, the edge correction should be (1-T_0)*(delta r_0), but usually negligible though.
 
     """
-    radius_midpoint = radius_lower + 0.5*height
+    radius_midpoint = radius_lower + 0.5 * height
     _, Nnus = jnp.shape(dtau_chord_modpoint)
     f = 2.0 * (1.0 - jnp.exp(-dtau_chord_modpoint)) * radius_midpoint[:, None]
     f_lower = 2.0 * (1.0 - jnp.exp(-dtau_chord_lower)) * radius_lower[:, None]

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -213,14 +213,14 @@ def coeffs_linsap(dtau_per_mu, trans):
     return beta, gamma
 
 
-@jit
-def rtrun_trans_pureabs(dtau_chord, radius_lower):
+#@jit
+def rtrun_trans_pureabs(dtau_chord, radius_lower):#,radius_top):
     """Radiative transfer for transmission spectrum assuming pure absorption 
 
     Args:
         dtau_chord (2D array): chord opacity (Nlayer, N_wavenumber)
         radius_lower (1D array): (normalized) radius at the lower boundary, underline(r) (Nlayer). 
-
+        radius_top (float): (normalized) radius at the ToA
     Notes:
         The n-th radius is defined as the lower boundary of the n-th layer. So, radius[0] corresponds to R0.   
 
@@ -233,10 +233,17 @@ def rtrun_trans_pureabs(dtau_chord, radius_lower):
         If you would like to compute the transit depth, devide the output by the square of stellar radius
 
     """
-    deltaRp2 = 2.0 * jnp.trapz(
-        (1.0 - jnp.exp(-dtau_chord)) * radius_lower[::-1, None],
-        x=radius_lower[::-1],
-        axis=0)
+    #edge_correction_at_ToA = (radius_top - radius_lower[0])*(1.0 - jnp.exp(-dtau_chord[0,:]))
+    #deltaRp2 = 2.0 * jnp.trapz(
+    #    (1.0 - jnp.exp(-dtau_chord)) * radius_lower[::-1, None],
+    #    x=radius_lower[::-1],
+    #    axis=0) #+ edge_correction_at_ToA
+    print(radius_lower)
+    deltaRp2 = - 2.0 * jnp.trapz(
+        (1.0 - jnp.exp(-dtau_chord)) * radius_lower[:, None],
+        x=radius_lower,
+        axis=0) #+ edge_correction_at_ToA
+
     return deltaRp2 + radius_lower[-1]**2
 
 

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -8,9 +8,16 @@
     -- scattering
     --- 2stream
     ---- LART: rtrun_emis_scat_lart_toonhm
-    - intensity-based emission
-    - transmision: rtrun_trans_pureabs
+    ---- flux-adding: not yet
 
+    - intensity-based emission
+    -- pure absorption 
+    --- isothermal: rtrun_emis_pureabs_ibased
+    --- linear source approximation: rtrun_emis_pureabs_ibased_linsap
+
+    - transmision: 
+    -- trapezoid integration: rtrun_trans_pureabs_trapezoid
+    -- simpson integration: rtrun_trans_pureabs_simpson
 
 
 
@@ -18,7 +25,7 @@
 from jax import jit
 import jax.numpy as jnp
 from jax.lax import scan
-from exojax.spec.twostream import solve_lart_twostream_numpy
+#from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
 
 from exojax.spec.toon import reduced_source_function_isothermal_layer

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -250,15 +250,15 @@ def rtrun_trans_pureabs_trapezoid(dtau_chord, radius_lower, radius_top):
 
 
 def rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
-                                radius_midpoint, radius_lower, height):
+                                radius_lower, height):
     """Radiative transfer for transmission spectrum assuming pure absorption with the Simpson integration (signals.integration.simpson)
 
     Args:
         dtau_chord_midpoint (2D array): chord opatical depth at the midpoint (Nlayer, N_wavenumber)
         dtau_chord_lower (2D array): chord opatical depth at the lower boundary (Nlayer, N_wavenumber)
-        radius_midpoint (1D array) (1D array): (normalized) radius at the midpoint
         radius_lower (1D array): (normalized) radius at the lower boundary, underline(r) (Nlayer). R0 = radius_lower[-1] corresponds to the most bottom of the layers.
         height (1D array): (normalized) height of the layers
+
     Returns:
         1D array: transit squared radius normalized by radius_lower[-1], i.e. it returns (radius/radius_lower[-1])**2
 
@@ -273,7 +273,8 @@ def rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
         We assume tau = 0 at the radius_top. then, the edge correction should be (1-T_0)*(delta r_0), but usually negligible though.
 
     """
-    Nlayer, Nnus = jnp.shape(dtau_chord_modpoint)
+    radius_midpoint = radius_lower + 0.5*height
+    _, Nnus = jnp.shape(dtau_chord_modpoint)
     f = 2.0 * (1.0 - jnp.exp(-dtau_chord_modpoint)) * radius_midpoint[:, None]
     f_lower = 2.0 * (1.0 - jnp.exp(-dtau_chord_lower)) * radius_lower[:, None]
     f_top = jnp.zeros(Nnus)

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -75,9 +75,9 @@ if __name__ == "__main__":
     wav_exojax = nu2wav(nus_hitran, unit="um", wavelength_order="ascending")
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
+    #ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
     #plt.yscale("log")
-    ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
+    #ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
     ax.plot(wav_exojax[::-1], Rp_simpson * Rs / RJ, label="ExoJAX simpson", lw=1)
     
     plt.legend()

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -57,11 +57,11 @@ def compare_with_kawashima_code():
     xsmatrix = opa.xsmatrix(Tarr, art.pressure)
     dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
                                      gravity)
-    art.set_integration_scheme("trapezoid")
-    Rp2_trapezoid = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
     art.set_integration_scheme("simpson")
     Rp2_simpson = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
-    print(Rp2_simpson)
+    art.set_integration_scheme("trapezoid")
+    Rp2_trapezoid = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
+    
     return nu_grid, np.sqrt(Rp2_trapezoid) * radius_btm / Rs, np.sqrt(Rp2_simpson) * radius_btm / Rs
 
 
@@ -75,9 +75,9 @@ if __name__ == "__main__":
     wav_exojax = nu2wav(nus_hitran, unit="um", wavelength_order="ascending")
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    #ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
-    #plt.yscale("log")
-    #ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
+    ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
+    plt.yscale("log")
+    ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
     ax.plot(wav_exojax[::-1], Rp_simpson * Rs / RJ, label="ExoJAX simpson", lw=1)
     
     plt.legend()

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -77,7 +77,9 @@ if __name__ == "__main__":
     ax = fig.add_subplot(111)
     ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
     #plt.yscale("log")
-    ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX", ls="dotted")
+    ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
+    ax.plot(wav_exojax[::-1], Rp_simpson * Rs / RJ, label="ExoJAX simpson", lw=1)
+    
     plt.legend()
 
     plt.xlabel("wavenumber cm-1")

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -74,18 +74,19 @@ if __name__ == "__main__":
     from exojax.spec.unitconvert import nu2wav
     wav_exojax = nu2wav(nus_hitran, unit="um", wavelength_order="ascending")
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(211)
     ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
-    plt.yscale("log")
+    #plt.yscale("log")
     ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX trapezoid", ls="dotted")
     ax.plot(wav_exojax[::-1], Rp_simpson * Rs / RJ, label="ExoJAX simpson", lw=1)
-    
     plt.legend()
-
+    plt.ylabel("Rp (RJ)")
+    ax = fig.add_subplot(212)
+    ax.plot(wav_exojax[::-1], (1.0 - Rp_trapezoid/Rp_simpson) * Rs / RJ, label="Delta R/R (simpson, trapezoid)")
     plt.xlabel("wavenumber cm-1")
     #plt.ylim(-0.07, 0.07)
     plt.legend()
-    plt.ylabel("Rp (RJ)")
+    plt.ylabel("ratio")
 
     plt.savefig("comparison.png")
     plt.show()

--- a/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
+++ b/tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py
@@ -57,9 +57,12 @@ def compare_with_kawashima_code():
     xsmatrix = opa.xsmatrix(Tarr, art.pressure)
     dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
                                      gravity)
-
-    Rp2 = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
-    return nu_grid, np.sqrt(Rp2) * radius_btm / Rs
+    art.set_integration_scheme("trapezoid")
+    Rp2_trapezoid = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
+    art.set_integration_scheme("simpson")
+    Rp2_simpson = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
+    print(Rp2_simpson)
+    return nu_grid, np.sqrt(Rp2_trapezoid) * radius_btm / Rs, np.sqrt(Rp2_simpson) * radius_btm / Rs
 
 
 if __name__ == "__main__":
@@ -67,14 +70,14 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     wav, rprs = read_kawashima_data()
     diffmode = 1
-    nus_hitran, Rp_hitran = compare_with_kawashima_code()
+    nus_hitran, Rp_trapezoid, Rp_simpson = compare_with_kawashima_code()
     from exojax.spec.unitconvert import nu2wav
     wav_exojax = nu2wav(nus_hitran, unit="um", wavelength_order="ascending")
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.plot(wav, rprs * Rs / RJ, label="Kawashima")
     #plt.yscale("log")
-    ax.plot(wav_exojax[::-1], Rp_hitran * Rs / RJ, label="ExoJAX", ls="dotted")
+    ax.plot(wav_exojax[::-1], Rp_trapezoid * Rs / RJ, label="ExoJAX", ls="dotted")
     plt.legend()
 
     plt.xlabel("wavenumber cm-1")

--- a/tests/unittests/atm/layer_test.py
+++ b/tests/unittests/atm/layer_test.py
@@ -35,8 +35,8 @@ def test_atmoshperic_height_for_isothermal_with_analytic():
     gravity_btm = 2478.57730044555
     radius_btm = 7149200000.0
     mmw = mu_fid * np.ones_like(art.pressure)
-
-    _, normalized_radius_layer, normalized_radius_lower = art.atmosphere_height(
+    
+    normalized_height, normalized_radius_lower = art.atmosphere_height(
         Tarr, mmw, radius_btm, gravity_btm)
 
     #theoretical value

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -7,11 +7,14 @@ config.update('jax_enable_x64', True)
 
 def test_compare_simpson_with_manual_computation():
     """ test simpson integral
-
-    f = 0.01, (0.3), 1.0, (1.3), 2.0, (2.7), 3.0
-    h = 0.7, 0.8, 0.9
+    
+    Notes:
+        Settings
+        Nlayer = 3, Nnus = 1
+        f = 0.01, (0.3), 1.0, (1.3), 2.0, (2.7), 3.0
+        h = 0.7, 0.8, 0.9
     """
-    f_lower = jnp.array([[1.0,2.0,3.0]]).T 
+    f_lower = jnp.array([[1.0,2.0,3.0]]).T #(Nlayer, Nnus)
     print(jnp.shape(f_lower))
     f_top = jnp.array([0.01])
     f = jnp.array([[0.3, 1.3, 2.7]]).T

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -1,0 +1,8 @@
+def test_simpson():
+    
+    
+    return
+
+if __name__ == "__main__":
+    test_simpson()
+

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -1,10 +1,11 @@
 import pytest
 import jax.numpy as jnp
+from exojax.signal.integrate import simpson
 from jax.config import config
 
 config.update('jax_enable_x64', True)
 
-def test_simpson():
+def test_compare_simpson_with_manual_computation():
     """ test simpson integral
 
     f = 0.01, (0.3), 1.0, (1.3), 2.0, (2.7), 3.0
@@ -24,13 +25,7 @@ def test_simpson():
 
     assert integral[0] == pytest.approx(ref_integral[0])
 
-def simpson(f, f_lower, f_top, h):
-    N=len(f)
-    hh = jnp.roll(h, -1) + h  # h_{n+1} + h_n
-    fac = hh[:N-1,None]*f_lower[:N-1,:]
-    return 2.0/3.0*jnp.sum(h[:,None]*f) + h[0]*f_top/6.0 + h[-1]*f_lower[-1,:]/6.0 + jnp.sum(fac)/6.0
-    
 
 if __name__ == "__main__":
-    test_simpson()
+    test_compare_simpson_with_manual_computation()
 

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -1,7 +1,35 @@
+import pytest
+import jax.numpy as jnp
+from jax.config import config
+
+config.update('jax_enable_x64', True)
+
 def test_simpson():
+    """ test simpson integral
+
+    f = 0.01, (0.3), 1.0, (1.3), 2.0, (2.7), 3.0
+    h = 0.7, 0.8, 0.9
+    """
+    f_lower = jnp.array([[1.0,2.0,3.0]]).T 
+    print(jnp.shape(f_lower))
+    f_top = jnp.array([0.01])
+    f = jnp.array([[0.3, 1.3, 2.7]]).T
+    h = jnp.array([0.7,0.8,0.9])
+    simpson0 = h[0]*(f_top + 4.0*f[0,:] + f_lower[0,:])/6.0
+    simpson1 = h[1]*(f_lower[0,:] + 4.0*f[1,:] + f_lower[1,:])/6.0
+    simpson2 = h[2]*(f_lower[1,:] + 4.0*f[2,:] + f_lower[2,:])/6.0
+    ref_integral = simpson0 + simpson1 + simpson2
+
+    integral = simpson(f, f_lower, f_top, h)
+
+    assert integral[0] == pytest.approx(ref_integral[0])
+
+def simpson(f, f_lower, f_top, h):
+    N=len(f)
+    hh = jnp.roll(h, -1) + h  # h_{n+1} + h_n
+    fac = hh[:N-1,None]*f_lower[:N-1,:]
+    return 2.0/3.0*jnp.sum(h[:,None]*f) + h[0]*f_top/6.0 + h[-1]*f_lower[-1,:]/6.0 + jnp.sum(fac)/6.0
     
-    
-    return
 
 if __name__ == "__main__":
     test_simpson()

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -15,7 +15,6 @@ def test_compare_simpson_with_manual_computation():
         h = 0.7, 0.8, 0.9
     """
     f_lower = jnp.array([[1.0,2.0,3.0]]).T #(Nlayer, Nnus)
-    print(jnp.shape(f_lower))
     f_top = jnp.array([0.01])
     f = jnp.array([[0.3, 1.3, 2.7]]).T
     h = jnp.array([0.7,0.8,0.9])

--- a/tests/unittests/signal/simpson_integral_test.py
+++ b/tests/unittests/signal/simpson_integral_test.py
@@ -1,9 +1,11 @@
 import pytest
+import numpy as np
 import jax.numpy as jnp
 from exojax.signal.integrate import simpson
 from jax.config import config
 
 config.update('jax_enable_x64', True)
+
 
 def test_compare_simpson_with_manual_computation():
     """ test simpson integral
@@ -14,20 +16,24 @@ def test_compare_simpson_with_manual_computation():
         f = 0.01, (0.3), 1.0, (1.3), 2.0, (2.7), 3.0
         h = 0.7, 0.8, 0.9
     """
-    f_lower = jnp.array([[1.0,2.0,3.0]]).T #(Nlayer, Nnus)
-    f_top = jnp.array([0.01])
-    f = jnp.array([[0.3, 1.3, 2.7]]).T
-    h = jnp.array([0.7,0.8,0.9])
-    simpson0 = h[0]*(f_top + 4.0*f[0,:] + f_lower[0,:])/6.0
-    simpson1 = h[1]*(f_lower[0,:] + 4.0*f[1,:] + f_lower[1,:])/6.0
-    simpson2 = h[2]*(f_lower[1,:] + 4.0*f[2,:] + f_lower[2,:])/6.0
+    f_lower = jnp.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]).T  #(Nlayer, Nnus)
+    f_top = jnp.array([0.01, 0.01])
+    f = jnp.array([[0.3, 1.3, 2.7], [0.3, 1.3, 2.7]]).T
+    h = jnp.array([0.7, 0.8, 0.9])
+    simpson0 = h[0] * (f_top + 4.0 * f[0, :] + f_lower[0, :]) / 6.0
+    simpson1 = h[1] * (f_lower[0, :] + 4.0 * f[1, :] + f_lower[1, :]) / 6.0
+    simpson2 = h[2] * (f_lower[1, :] + 4.0 * f[2, :] + f_lower[2, :]) / 6.0
     ref_integral = simpson0 + simpson1 + simpson2
-
     integral = simpson(f, f_lower, f_top, h)
 
-    assert integral[0] == pytest.approx(ref_integral[0])
+    #comparison with jnp.trapz
+    #fx =jnp.array([[0.01,1.0,2.0,3.0]]).T
+    #x = jnp.array([0.0,h[0],jnp.sum(h[0:2]),jnp.sum(h[0:3])])
+    #print("TRAPZ",jnp.trapz(fx,x=x,axis=0))
+    #print("SIMPSON",integral)
+
+    assert np.all(integral == pytest.approx(ref_integral))
 
 
 if __name__ == "__main__":
     test_compare_simpson_with_manual_computation()
-

--- a/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
+++ b/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
@@ -37,7 +37,16 @@ def test_chord_geometric_matrix_lower():
     ref[2,1]=_manual_coeff(radius_upper, radius_lower, height, 2, 1)
     ref[2,2]=_manual_coeff(radius_upper, radius_lower, height, 2, 2)
     assert np.all(ref == cgm)
-    
+
+def test_chord_geometric_matrix():
+    Nlayer = 3
+    height = jnp.array([0.15, 0.1, 0.1])
+    radius_lower = jnp.array([1.2, 1.1, 1.0])  
+    radius_mid = radius_lower + height/2.0
+    radius_upper = radius_lower + height
+    cgm = chord_geometric_matrix(height, radius_lower)
+    print(cgm)
+
 def _manual_coeff(radius_upper, radius_lower, height, n, k):
     return 2*(jnp.sqrt(radius_upper[k]**2 - radius_lower[n]**2) - jnp.sqrt(radius_lower[k]**2 - radius_lower[n]**2))/height[k]
 
@@ -78,5 +87,6 @@ def test_first_layer_height_from_compute_normalized_radius_profile():
 if __name__ == "__main__":
     #test_check_parallel_Ax_tauchord()
     #test_first_layer_height_from_compute_normalized_radius_profile()
-    test_chord_geometric_matrix_lower()
+    #test_chord_geometric_matrix_lower()
+    test_chord_geometric_matrix()
     #test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque()

--- a/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
+++ b/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
@@ -4,7 +4,7 @@ import numpy as np
 from exojax.atm.atmprof import normalized_layer_height
 from exojax.spec.opachord import chord_geometric_matrix
 from exojax.spec.opachord import chord_optical_depth
-from exojax.spec.rtransfer import rtrun_trans_pureabs
+from exojax.spec.rtransfer import rtrun_trans_pureabs_trapezoid
 from jax.config import config
 
 config.update("jax_enable_x64", True)
@@ -16,7 +16,7 @@ def test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque():
     dtau_chord = jnp.ones((Nlayer, Nnu)) * jnp.inf
     radius = jnp.array([1.4, 1.3, 1.2, 1.1, 1.0])
 
-    Rp2 = rtrun_trans_pureabs(dtau_chord, radius)
+    Rp2 = rtrun_trans_pureabs_trapezoid(dtau_chord, radius)
 
     assert np.all(Rp2 == radius[0]**2 * np.ones(Nnu))
 

--- a/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
+++ b/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
@@ -45,6 +45,14 @@ def test_chord_geometric_matrix():
     radius_mid = radius_lower + height/2.0
     radius_upper = radius_lower + height
     cgm = chord_geometric_matrix(height, radius_lower)
+    ref = np.zeros((Nlayer,Nlayer))
+    ref[0,0]=2*jnp.sqrt(radius_upper[0]**2 - radius_mid[0]**2)/height[0]
+    ref[1,0]=_manual_coeff(radius_upper, radius_mid, height, 1, 0)
+    ref[1,1]=_manual_coeff(radius_upper, radius_mid, height, 1, 1)
+    ref[2,0]=_manual_coeff(radius_upper, radius_mid, height, 2, 0)
+    ref[2,1]=_manual_coeff(radius_upper, radius_mid, height, 2, 1)
+    ref[2,2]=_manual_coeff(radius_upper, radius_mid, height, 2, 2)
+    print(ref)
     print(cgm)
 
 def _manual_coeff(radius_upper, radius_lower, height, n, k):

--- a/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
+++ b/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
@@ -3,7 +3,9 @@ import jax.numpy as jnp
 import numpy as np
 from exojax.atm.atmprof import normalized_layer_height
 from exojax.spec.opachord import chord_geometric_matrix
+from exojax.spec.opachord import chord_geometric_matrix_midpoint
 from exojax.spec.opachord import chord_optical_depth
+
 from exojax.spec.rtransfer import rtrun_trans_pureabs_trapezoid
 from jax.config import config
 
@@ -22,9 +24,9 @@ def test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque():
 
 # this test code requires gpu 
 def test_chord_geometric_matrix():
-    Nlayer = 5
+    Nlayer = 3
     height = 0.1 * jnp.ones(Nlayer)
-    radius = jnp.array([1.4, 1.3, 1.2, 1.1, 1.0])  #radius[-1] = radius_btm
+    radius = jnp.array([1.2, 1.1, 1.0])  #radius[-1] = radius_btm
 
     cgm = chord_geometric_matrix(height, radius)
     print(jnp.sum(cgm))

--- a/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
+++ b/tests/unittests/spec/transmission/transmission_pure_absorption_test.py
@@ -25,13 +25,22 @@ def test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque():
 # this test code requires gpu 
 def test_chord_geometric_matrix():
     Nlayer = 3
-    height = 0.1 * jnp.ones(Nlayer)
-    radius = jnp.array([1.2, 1.1, 1.0])  #radius[-1] = radius_btm
-
-    cgm = chord_geometric_matrix(height, radius)
+    height = 0.1 * jnp.array([0.15, 0.1, 0.1])
+    radius_lower = jnp.array([1.2, 1.1, 1.0])  #radius[-1] = radius_btm
+    radius_top = radius_lower[0] + height[0]
+    cgm = chord_geometric_matrix(height, radius_lower)
+    ref = np.zeros((Nlayer,Nlayer))
+    ref[0,0]=2*jnp.sqrt(radius_top**2 - radius_lower[0]**2)/height[0]
+    ref[1,0]=_manual_coeff(radius_top, radius_lower[0], radius_lower[1], height[1])
+    ref[1,1]=_manual_coeff(radius_lower[0], radius_lower[1], radius_lower[1], height[1])
+    
+    print(ref)
+    print(cgm)
     print(jnp.sum(cgm))
     #assert jnp.sum(cgm) == pytest.approx(86.49373)
 
+def _manual_coeff(r_k_minus_1, r_k, r_n, h):
+    return 2*(jnp.sqrt(r_k_minus_1**2 - r_n**2) - jnp.sqrt(r_k**2 - r_n**2))/h
 
 def test_check_parallel_Ax_tauchord():
     A = jnp.array([[7, 0, 0], [4, 5, 0], [1, 2, 3]])
@@ -68,7 +77,7 @@ def test_first_layer_height_from_compute_normalized_radius_profile():
 
 
 if __name__ == "__main__":
-    test_check_parallel_Ax_tauchord()
-    test_first_layer_height_from_compute_normalized_radius_profile()
+    #test_check_parallel_Ax_tauchord()
+    #test_first_layer_height_from_compute_normalized_radius_profile()
     test_chord_geometric_matrix()
-    test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque()
+    #test_transmission_pure_absorption_equals_to_Rp_sqaured_for_opaque()


### PR DESCRIPTION
I implemented the Simpson integration version of the transmission spectroscopy.  #421

The demo: `tests/integration/comparison/transmission/comparison_with_kawashima_transmission.py`

I haven't checked what extent the Simpson integration version can reduce the computation time in terms of the number of the layers when fixing the uncertainty @sh-tada 
## comparison
![comparison](https://github.com/HajimeKawahara/exojax/assets/15956904/7dd7de0d-c111-4b27-9190-485d662f04fb)

