### PR TITLE
Flux adding method first implementation

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -185,6 +185,7 @@ class MdbExomol(CapiMdbExomol):
     def compute_load_mask(self, df):
 
         #wavelength
+        print(df)
         mask = (df.nu_lines > self.nurange[0]) \
                     * (df.nu_lines < self.nurange[1])
         QTtyp = np.array(self.QT_interp(self.Ttyp))

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -12,6 +12,8 @@ from exojax.spec.rtransfer import rtrun_emis_pureabs_ibased_linsap
 from exojax.spec.rtransfer import rtrun_emis_pureabs_fbased2st
 from exojax.spec.rtransfer import rtrun_emis_pureabs_ibased
 from exojax.spec.rtransfer import rtrun_emis_scat_lart_toonhm
+from exojax.spec.rtransfer import rtrun_emis_scat_fluxadding_toonhm
+
 from exojax.spec.rtransfer import rtrun_trans_pureabs
 from exojax.spec.layeropacity import layer_optical_depth
 from exojax.atm.atmprof import atmprof_gray, atmprof_Guillot, atmprof_powerlow
@@ -264,7 +266,7 @@ class ArtEmisScat(ArtCommon):
                  pressure_btm=1.e2,
                  nlayer=100,
                  nu_grid=None,
-                 rtsolver="toon_hemispheric_mean"):
+                 rtsolver="lart_toon_hemispheric_mean"):
         """initialization of ArtEmisPure
 
         Args:
@@ -301,7 +303,7 @@ class ArtEmisScat(ArtCommon):
         else:
             raise ValueError("the wavenumber grid is not given.")
 
-        if self.rtsolver == "toon_hemispheric_mean":
+        if self.rtsolver == "lart_toon_hemispheric_mean":
 
             spectrum, cumTtilde, Qtilde, trans_coeff, scat_coeff, piB = rtrun_emis_scat_lart_toonhm(
                 dtau, single_scattering_albedo, asymmetric_parameter, sourcef)
@@ -309,11 +311,15 @@ class ArtEmisScat(ArtCommon):
                 from exojax.plot.rtplot import comparison_with_pure_absorption
                 comparison_with_pure_absorption(cumTtilde, Qtilde, spectrum,
                                                 trans_coeff, scat_coeff, piB)
+        elif self.rtsolver == "fluxadding_toon_hemispheric_mean":
 
-            return spectrum
+
         else:
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
-
+    
+        return spectrum
+        
+        
 
 class ArtEmisPure(ArtCommon):
     """Atmospheric RT for emission w/ pure absorption

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -312,7 +312,7 @@ class ArtEmisScat(ArtCommon):
                 comparison_with_pure_absorption(cumTtilde, Qtilde, spectrum,
                                                 trans_coeff, scat_coeff, piB)
         elif self.rtsolver == "fluxadding_toon_hemispheric_mean":
-
+            print("not yet implemented")
 
         else:
             raise ValueError("Unknown radiative transfer solver (rtsolver).")

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -29,6 +29,7 @@ import warnings
 class ArtCommon():
     """Common Atmospheric Radiative Transfer
     """
+
     def __init__(self, pressure_top, pressure_btm, nlayer, nu_grid=None):
         """initialization of art
 
@@ -73,7 +74,7 @@ class ArtCommon():
         Returns:
             1D array: height normalized by radius_btm (Nlayer)
             1D array: layer radius r_n normalized by radius_btm (Nlayer)
-            
+
         Notes:
             Our definitions of the radius_lower, radius_layer, and height are as follows:
             n=0,1,...,N-1
@@ -258,6 +259,7 @@ class ArtEmisScat(ArtCommon):
         pressure_layer: pressure profile in bar
 
     """
+
     def __init__(self,
                  pressure_top=1.e-8,
                  pressure_btm=1.e2,
@@ -309,15 +311,18 @@ class ArtEmisScat(ArtCommon):
                 comparison_with_pure_absorption(cumTtilde, Qtilde, spectrum,
                                                 trans_coeff, scat_coeff, piB)
         elif self.rtsolver == "fluxadding_toon_hemispheric_mean":
-            print("not yet implemented")
-
+            _, Nnus = dtau.shape
+            source_surface = jnp.zeros(Nnus)
+            reflectivity_surface = jnp.zeros(Nnus)
+            incoming_flux = jnp.zeros(Nnus)
+            spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
+                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface, incoming_flux)
         else:
-            print("rtsolver=",self.rtsolver)
+            print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
-    
+
         return spectrum
-        
-        
+
 
 class ArtEmisPure(ArtCommon):
     """Atmospheric RT for emission w/ pure absorption
@@ -326,6 +331,7 @@ class ArtEmisPure(ArtCommon):
         pressure_layer: pressure profile in bar
 
     """
+
     def __init__(
         self,
         pressure_top=1.e-8,
@@ -435,7 +441,7 @@ class ArtTransPure(ArtCommon):
         self.set_integration_scheme(integration)
 
 
-#rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
+# rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
 #                                radius_midpoint, radius_lower, height)
 
     def set_capable_integration(self):

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -13,6 +13,7 @@ from exojax.spec.rtransfer import rtrun_emis_pureabs_fbased2st
 from exojax.spec.rtransfer import rtrun_emis_pureabs_ibased
 from exojax.spec.rtransfer import rtrun_emis_scat_lart_toonhm
 from exojax.spec.rtransfer import rtrun_emis_scat_fluxadding_toonhm
+from exojax.spec.rtransfer import rtrun_reflect_fluxadding_toonhm
 from exojax.spec.rtransfer import rtrun_trans_pureabs_trapezoid
 from exojax.spec.rtransfer import rtrun_trans_pureabs_simpson
 from exojax.spec.layeropacity import layer_optical_depth
@@ -282,8 +283,10 @@ class ArtReflect(ArtCommon):
             single_scattering_albedo,
             asymmetric_parameter,
             temperature,
-            nu_grid=None,
-            show=False):
+            source_surface, 
+            reflectivity_surface, 
+            incoming_flux,
+            nu_grid=None):
         """run radiative transfer
 
         Args:
@@ -304,11 +307,8 @@ class ArtReflect(ArtCommon):
 
         if self.rtsolver == "fluxadding_toon_hemispheric_mean":
             _, Nnus = dtau.shape
-            source_surface = jnp.zeros(Nnus)
-            reflectivity_surface = jnp.zeros(Nnus)
-            incoming_flux = jnp.zeros(Nnus)
-            #spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-            #                                             asymmetric_parameter, sourcef, source_surface, reflectivity_surface)
+            spectrum = rtrun_reflect_fluxadding_toonhm(dtau, single_scattering_albedo,
+                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface, incoming_flux)
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
@@ -367,7 +367,6 @@ class ArtEmisScat(ArtCommon):
             raise ValueError("the wavenumber grid is not given.")
 
         if self.rtsolver == "lart_toon_hemispheric_mean":
-
             spectrum, cumTtilde, Qtilde, trans_coeff, scat_coeff, piB = rtrun_emis_scat_lart_toonhm(
                 dtau, single_scattering_albedo, asymmetric_parameter, sourcef)
             if show:
@@ -375,11 +374,7 @@ class ArtEmisScat(ArtCommon):
                 comparison_with_pure_absorption(cumTtilde, Qtilde, spectrum,
                                                 trans_coeff, scat_coeff, piB)
         elif self.rtsolver == "fluxadding_toon_hemispheric_mean":
-            _, Nnus = dtau.shape
-            source_surface = jnp.zeros(Nnus)
-            reflectivity_surface = jnp.zeros(Nnus)
-            spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface)
+            spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo, asymmetric_parameter, sourcef)
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -307,8 +307,8 @@ class ArtReflect(ArtCommon):
             source_surface = jnp.zeros(Nnus)
             reflectivity_surface = jnp.zeros(Nnus)
             incoming_flux = jnp.zeros(Nnus)
-            spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface, incoming_flux)
+            #spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
+            #                                             asymmetric_parameter, sourcef, source_surface, reflectivity_surface)
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
@@ -378,9 +378,8 @@ class ArtEmisScat(ArtCommon):
             _, Nnus = dtau.shape
             source_surface = jnp.zeros(Nnus)
             reflectivity_surface = jnp.zeros(Nnus)
-            incoming_flux = jnp.zeros(Nnus)
             spectrum = rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface, incoming_flux)
+                                                         asymmetric_parameter, sourcef, source_surface, reflectivity_surface)
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -350,14 +350,13 @@ def rtrun_emis_scat_lart_toonhm_surface(dtau, single_scattering_albedo,
 @jit
 def rtrun_reflect_fluxadding_toonhm(dtau, single_scattering_albedo,
                                     asymmetric_parameter, source_matrix, source_surface, reflectivity_surface, incoming_flux):
-    """
-    Toon Hemispheric Mean with surface.
-
+    """Radiative Transfer for reflected spectrum the flux adding solver w/ Toon Hemispheric Mean with surface.
+    
     Args:
-        dtau (_type_): _description_
-        single_scattering_albedo (_type_): _description_
-        asymmetric_parameter (_type_): _description_
-        source_matrix (_type_): _description_
+        dtau: layer optical depth (Nlayer, N_nus)
+        single_scattering_albedo: single scattering albedo (Nlayer, N_nus)
+        asymmetric_parameter: assymetric parameter (Nlayer, N_nus)
+        source_matrix: source term (Nlayer, N_nus)
         source_surface: source from the surface (N_nus)
         reflectivity_surface: reflectivity from the surface (N_nus)
         incoming flux: incoming flux F_0^- (N_nus)

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -345,7 +345,7 @@ def rtrun_emis_scat_lart_toonhm_surface(dtau, single_scattering_albedo,
 
     return spectrum, cumTtilde, Qtilde, trans_coeff, scat_coeff, piB
 
-# @jit
+@jit
 def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
                                       asymmetric_parameter, source_matrix, source_surface, reflectivity_surface, incoming_flux):
     """Radiative Transfer for emission spectrum using flux-based two-stream scattering the flux adding solver w/ Toon Hemispheric Mean with surface.
@@ -367,8 +367,8 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
 
     #spectrum = solve_fluxadding_twostream_forloop(
     #    trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
-    spectrum = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
-
+    _, spectrum = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface)
+    
     return spectrum
 
 

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -346,7 +346,7 @@ def rtrun_emis_scat_lart_toonhm_surface(dtau, single_scattering_albedo,
 
 # @jit
 def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-                                      asymmetric_parameter, source_matrix, source_surface, reflectivity_surface):
+                                      asymmetric_parameter, source_matrix, source_surface, reflectivity_surface, incoming_flux):
     """Radiative Transfer for emission spectrum using flux-based two-stream scattering the flux adding solver w/ Toon Hemispheric Mean with surface.
 
     Args:
@@ -356,6 +356,7 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
         source_matrix (_type_): _description_
         source_surface: source from the surface (N_nus)
         reflectivity_surface: reflectivity from the surface (N_nus)
+        incoming_flux: incoming flux at the ToA (N_nus)
 
     Returns:
         _type_: _description_
@@ -364,7 +365,7 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix)
 
     spectrum = solve_fluxadding_twostream_forloop(
-        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface)
+        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
     return spectrum
 
 

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -25,9 +25,9 @@
 from jax import jit
 import jax.numpy as jnp
 from jax.lax import scan
-#from exojax.spec.twostream import solve_lart_twostream_numpy
+# from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
-#from exojax.spec.twostream import solve_fluxadding_twostream_forloop
+# from exojax.spec.twostream import solve_fluxadding_twostream_forloop
 from exojax.spec.twostream import solve_fluxadding_twostream
 from exojax.spec.toon import reduced_source_function_isothermal_layer
 from exojax.spec.toon import params_hemispheric_mean
@@ -238,7 +238,7 @@ def rtrun_trans_pureabs_trapezoid(dtau_chord, radius_lower, radius_top):
         This function gives the sqaure of the transit radius.
         If you would like to obtain the transit radius, take sqaure root of the output.
         If you would like to compute the transit depth, devide the output by the square of stellar radius
-        
+
     Notes:
         We need the edge correction because the trapezoid integration with radius_lower lacks the edge point integration.
         i.e. the integration of the 0-th layer from radius_lower[0] to radius_top.
@@ -248,7 +248,7 @@ def rtrun_trans_pureabs_trapezoid(dtau_chord, radius_lower, radius_top):
     dr = radius_top - radius_lower[0]
     edge_cor = (1.0 - jnp.exp(-dtau_chord[0, :])) * radius_top * dr
 
-    #the negative sign is because the radius_lower is in a descending order
+    # the negative sign is because the radius_lower is in a descending order
     deltaRp2 = -2.0 * jnp.trapz(
         (1.0 - jnp.exp(-dtau_chord)) * radius_lower[:, None],
         x=radius_lower,
@@ -274,7 +274,7 @@ def rtrun_trans_pureabs_simpson(dtau_chord_modpoint, dtau_chord_lower,
         This function gives the sqaure of the transit radius.
         If you would like to obtain the transit radius, take sqaure root of the output.
         If you would like to compute the transit depth, devide the output by the square of stellar radius
-        
+
     Notes:
         We need the edge correction because the trapezoid integration with radius_lower lacks the edge point integration.
         i.e. the integration of the 0-th layer from radius_lower[0] to radius_top.
@@ -307,7 +307,8 @@ def rtrun_emis_scat_lart_toonhm(dtau, single_scattering_albedo,
     trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix)
 
-    diagonal, lower_diagonal, upper_diagonal, vector = settridiag_toohm(dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coeff, reduced_piB)
+    diagonal, lower_diagonal, upper_diagonal, vector = settridiag_toohm(
+        dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coeff, reduced_piB)
     nlayer, Nnus = diagonal.shape
     cumTtilde, Qtilde, spectrum = solve_lart_twostream(diagonal,
                                                        lower_diagonal,
@@ -345,10 +346,12 @@ def rtrun_emis_scat_lart_toonhm_surface(dtau, single_scattering_albedo,
 
     return spectrum, cumTtilde, Qtilde, trans_coeff, scat_coeff, piB
 
-@jit
-def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
-                                      asymmetric_parameter, source_matrix, source_surface, reflectivity_surface, incoming_flux):
-    """Radiative Transfer for emission spectrum using flux-based two-stream scattering the flux adding solver w/ Toon Hemispheric Mean with surface.
+
+# @jit
+# def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
+#                                      asymmetric_parameter, source_matrix, source_surface, reflectivity_surface, incoming_flux):
+    """
+    Toon Hemispheric Mean with surface.
 
     Args:
         dtau (_type_): _description_
@@ -357,7 +360,24 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
         source_matrix (_type_): _description_
         source_surface: source from the surface (N_nus)
         reflectivity_surface: reflectivity from the surface (N_nus)
-        incoming_flux: incoming flux at the ToA (N_nus)
+        
+    Returns:
+        _type_: _description_
+    """
+
+
+@jit
+def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
+                                      asymmetric_parameter, source_matrix, source_surface, reflectivity_surface):
+    """Radiative Transfer for emission spectrum (w/ scattering) using flux-based two-stream scattering the flux adding solver w/ Toon Hemispheric Mean with surface.
+
+    Args:
+        dtau (_type_): _description_
+        single_scattering_albedo (_type_): _description_
+        asymmetric_parameter (_type_): _description_
+        source_matrix (_type_): _description_
+        source_surface: source from the surface (N_nus)
+        reflectivity_surface: reflectivity from the surface (N_nus)
 
     Returns:
         _type_: _description_
@@ -365,10 +385,9 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
     trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix)
 
-    #spectrum = solve_fluxadding_twostream_forloop(
-    #    trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
-    _, spectrum = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface)
-    
+    _, spectrum = solve_fluxadding_twostream(
+        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface)
+
     return spectrum
 
 
@@ -410,7 +429,8 @@ def settridiag_toohm(dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coe
     denom = zeta_plus0**2 - (zeta_minus0 * trans_func0)**2
     omtrans = 1.0 - trans_func0
     fac = (zeta_plus0 * omtrans - zeta_minus0 * trans_func0 * omtrans)
-    vector_top = (zeta_plus0**2 - zeta_minus0**2) / denom * fac * reduced_piB[0, :]
+    vector_top = (zeta_plus0**2 - zeta_minus0**2) / \
+        denom * fac * reduced_piB[0, :]
 
     # tridiagonal elements
     diagonal, lower_diagonal, upper_diagonal, vector = compute_tridiag_diagonals_and_vector(

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jax.lax import scan
 # from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
-from exojax.spec.twostream import solve_fluxadding_twostream_numpy
+from exojax.spec.twostream import solve_fluxadding_twostream_forloop
 from exojax.spec.toon import reduced_source_function_isothermal_layer
 from exojax.spec.toon import params_hemispheric_mean
 from exojax.spec.toon import zetalambda_coeffs
@@ -313,7 +313,7 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
     trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix)
 
-    spectrum = solve_fluxadding_twostream_numpy(
+    spectrum = solve_fluxadding_twostream_forloop(
         trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface)
     return spectrum
 

--- a/src/exojax/spec/rtransfer.py
+++ b/src/exojax/spec/rtransfer.py
@@ -27,7 +27,8 @@ import jax.numpy as jnp
 from jax.lax import scan
 #from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
-from exojax.spec.twostream import solve_fluxadding_twostream_forloop
+#from exojax.spec.twostream import solve_fluxadding_twostream_forloop
+from exojax.spec.twostream import solve_fluxadding_twostream
 from exojax.spec.toon import reduced_source_function_isothermal_layer
 from exojax.spec.toon import params_hemispheric_mean
 from exojax.spec.toon import zetalambda_coeffs
@@ -364,8 +365,10 @@ def rtrun_emis_scat_fluxadding_toonhm(dtau, single_scattering_albedo,
     trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix)
 
-    spectrum = solve_fluxadding_twostream_forloop(
-        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
+    #spectrum = solve_fluxadding_twostream_forloop(
+    #    trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
+    spectrum = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface, incoming_flux)
+
     return spectrum
 
 

--- a/src/exojax/spec/twostream.py
+++ b/src/exojax/spec/twostream.py
@@ -35,7 +35,7 @@ def solve_fluxadding_twostream_forloop(trans_coeff, scat_coeff, reduced_source_f
     return Rphat*incoming_flux + Sphat
 
 
-def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
+def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom):
     """Two-stream RT solver using flux adding
 
     Args:
@@ -44,7 +44,9 @@ def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function,
         reduced_source_function :  pi \mathcal{B} (Nlayer, Nnus)
         reflectivity_bottom (_type_): R^+_N (Nnus)
         source_bottom (_type_): S^+_N (Nnus)
-        incoming_flux: F_star = F_0^- (Nnus)
+
+    Returns:
+        Effective reflectivity (hat(R^plus)), Effective source (hat(S^plus))
     """
     nlayer, _ = trans_coeff.shape
     pihatB = (1.0 - trans_coeff - scat_coeff)*reduced_source_function
@@ -75,8 +77,16 @@ def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function,
         pihatB[nlayer-2::-1]
     ]
     RS, _ = scan(f, [Rphat0, Sphat0], arrin)
-    Rphat, Sphat = RS
-    return Rphat*incoming_flux + Sphat
+    return RS
+
+#def outgoing_reflection_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
+#    Rphat, Sphat = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux)
+#    return Rphat*incoming_flux + Sphat
+
+#def outgoing_emission_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom):
+#    _, Sphat = solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom)
+#    return Sphat
+
 
 
 def solve_lart_twostream_numpy(diagonal, lower_diagonal, upper_diagonal,

--- a/src/exojax/spec/twostream.py
+++ b/src/exojax/spec/twostream.py
@@ -7,7 +7,7 @@ from jax.lax import scan
 
 
 
-def solve_fluxadding_twostream_numpy(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom):
+def solve_fluxadding_twostream_forloop(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
     """_summary_
 
     Args:
@@ -16,8 +16,8 @@ def solve_fluxadding_twostream_numpy(trans_coeff, scat_coeff, reduced_source_fun
         reduced_source_function :  pi \mathcal{B} (Nlayer, Nnus)
         reflectivity_bottom (_type_): R^+_N (Nnus)
         source_bottom (_type_): S^+_N (Nnus)
+        incoming_flux: F_star = F_0^- (Nnus)
     """
-    import numpy as np
     nlayer, _ = trans_coeff.shape
     pihatB = (1.0 - trans_coeff - scat_coeff)*reduced_source_function
 
@@ -33,8 +33,8 @@ def solve_fluxadding_twostream_numpy(trans_coeff, scat_coeff, reduced_source_fun
         Sphat = pihatB[i, :] + trans_coeff[i, :] * \
             (Sphat + pihatB[i, :]*Rphat) / denom
         Rphat = scat_coeff[i, :] + trans_coeff[i, :]**2 * Rphat/denom
-
-    return Sphat
+    print(Rphat)
+    return Rphat*incoming_flux + Sphat
 
 
 def solve_lart_twostream_numpy(diagonal, lower_diagonal, upper_diagonal,

--- a/src/exojax/spec/twostream.py
+++ b/src/exojax/spec/twostream.py
@@ -70,12 +70,10 @@ def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function,
         TQ = [That_each, Qhat_each]
         return TQ, TQ
 
-    # top boundary
-    That0 = upper_diagonal[0, :] / diagonal[0, :]
-    Qhat0 = vector[0, :] / diagonal[0, :]
-
+    
     # main loop
     arrin = [
+        scat_coeff[:nlayer-1:-1]
         diagonal[1:nlayer, :], lower_diagonal[0:nlayer - 1, :],
         upper_diagonal[1:nlayer, :], vector[1:nlayer, :]
     ]

--- a/src/exojax/spec/twostream.py
+++ b/src/exojax/spec/twostream.py
@@ -7,7 +7,7 @@ from jax.lax import scan
 
 
 def solve_fluxadding_twostream_forloop(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
-    """_summary_
+    """Two-stream RT solver using flux adding (using for loop)
 
     Args:
         trans_coeff (_type_): _description_
@@ -36,7 +36,7 @@ def solve_fluxadding_twostream_forloop(trans_coeff, scat_coeff, reduced_source_f
 
 
 def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
-    """_summary_
+    """Two-stream RT solver using flux adding
 
     Args:
         trans_coeff (_type_): _description_
@@ -66,7 +66,7 @@ def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function,
         Rphat_each = scat_coeff_i + trans_coeff_i**2 * Rphat_prev/denom
 
         RS = [Rphat_each, Sphat_each]
-        return RS, RS
+        return RS, 0
 
     # main loop
     arrin = [

--- a/src/exojax/spec/twostream.py
+++ b/src/exojax/spec/twostream.py
@@ -33,7 +33,60 @@ def solve_fluxadding_twostream_forloop(trans_coeff, scat_coeff, reduced_source_f
         Sphat = pihatB[i, :] + trans_coeff[i, :] * \
             (Sphat + pihatB[i, :]*Rphat) / denom
         Rphat = scat_coeff[i, :] + trans_coeff[i, :]**2 * Rphat/denom
-    print(Rphat)
+    return Rphat*incoming_flux + Sphat
+
+
+def solve_fluxadding_twostream(trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux):
+    """_summary_
+
+    Args:
+        trans_coeff (_type_): _description_
+        scat_coeff (_type_): _description_
+        reduced_source_function :  pi \mathcal{B} (Nlayer, Nnus)
+        reflectivity_bottom (_type_): R^+_N (Nnus)
+        source_bottom (_type_): S^+_N (Nnus)
+        incoming_flux: F_star = F_0^- (Nnus)
+    """
+    nlayer, _ = trans_coeff.shape
+    pihatB = (1.0 - trans_coeff - scat_coeff)*reduced_source_function
+
+    # bottom reflection
+    Rphat = scat_coeff[nlayer-1, :] + trans_coeff[nlayer-1, :]**2 * \
+        reflectivity_bottom/(1.0 - scat_coeff[nlayer-1, :]*reflectivity_bottom)
+    Sphat = pihatB[nlayer-1, :] + trans_coeff[nlayer-1, :] * \
+        (source_bottom + pihatB[nlayer-1, :]*reflectivity_bottom) / \
+        (1.0 - scat_coeff[nlayer-1, :]*reflectivity_bottom)
+
+    # arguments of the scanning function f:
+    # carry_i_1 = [That_{i-1}, Qhat_{i-1}]
+    # arr = [diagonal[1:nlayer], lower_diagonal[0:nlayer-1], upper_diagonal[1:nlayer], vector[1,nlayer]]
+
+    def f(carry_i_1, arr):
+        That_i_1, Qhat_i_1 = carry_i_1
+        diagonal_i, lower_diagonal_i_1, upper_diagonal_i, vector_i = arr
+        gamma = diagonal_i - lower_diagonal_i_1 * That_i_1
+        That_each = upper_diagonal_i / gamma
+        Qhat_each = (vector_i + lower_diagonal_i_1 * Qhat_i_1) / gamma
+        TQ = [That_each, Qhat_each]
+        return TQ, TQ
+
+    # top boundary
+    That0 = upper_diagonal[0, :] / diagonal[0, :]
+    Qhat0 = vector[0, :] / diagonal[0, :]
+
+    # main loop
+    arrin = [
+        diagonal[1:nlayer, :], lower_diagonal[0:nlayer - 1, :],
+        upper_diagonal[1:nlayer, :], vector[1:nlayer, :]
+    ]
+    _, stackedTQ = scan(f, [That0, Qhat0], arrin)
+    
+
+    for i in range(0, nlayer-1)[::-1]:  # nlayer - 1 ...
+        denom = 1.0 - scat_coeff[i, :]*Rphat
+        Sphat = pihatB[i, :] + trans_coeff[i, :] * \
+            (Sphat + pihatB[i, :]*Rphat) / denom
+        Rphat = scat_coeff[i, :] + trans_coeff[i, :]**2 * Rphat/denom
     return Rphat*incoming_flux + Sphat
 
 

--- a/src/exojax/test/data.py
+++ b/src/exojax/test/data.py
@@ -4,6 +4,7 @@
 # exomol moldb template used in unit tests
 # exojax.src.test.generate should make this file
 TESTDATA_moldb_CO_HITEMP = "moldb_co_hitemp.pickle"
+TESTDATA_moldb_CO_EXOMOL = "moldb_co_exomol.pickle"
 TESTDATA_moldb_CO_HITEMP_SINGLE_ISOTOPE = "moldb_co_hitemp_single_isotope.pickle"
 TESTDATA_moldb_VALD = "moldb_vald.pickle"
 

--- a/src/exojax/test/generate_mdb.py
+++ b/src/exojax/test/generate_mdb.py
@@ -10,7 +10,7 @@ def gendata_moldb(database):
     """generate test data for CO exomol
     """
     Nx = 10000
-    nus, wav, res = wavenumber_grid(22920.0, 24000.0, Nx, unit='AA')
+    nus, wav, res = wavenumber_grid(22920.0, 24000.0, Nx, unit='AA', xsmode="premodit")
     if database == "exomol":
         from exojax.test.data import TESTDATA_moldb_CO_EXOMOL as filename
         mdbCO = api.MdbExomol('.database/CO/12C-16O/Li2015',

--- a/tests/integration/comparison/twostream/comparison_lart_fluxadd.py
+++ b/tests/integration/comparison/twostream/comparison_lart_fluxadd.py
@@ -1,0 +1,68 @@
+""" short integration tests for PreMODIT spectrum"""
+import pytest
+from jax.config import config
+from exojax.test.emulate_mdb import mock_mdb
+from exojax.spec.opacalc import OpaPremodit
+from exojax.test.emulate_mdb import mock_wavenumber_grid
+from exojax.spec.atmrt import ArtEmisScat
+
+
+def generate_spectrum(db, diffmode, rtsolver, fig=False):
+
+    nu_grid, wav, res = mock_wavenumber_grid()
+    art = ArtEmisScat(pressure_top=1.e-5,
+                      pressure_btm=1.e1,
+                      nlayer=200,
+                      nu_grid=nu_grid,
+                      rtsolver=rtsolver)
+    art.change_temperature_range(400.0, 1500.0)
+    Tarr = art.powerlaw_temperature(1300.0, 0.1)
+    mmr_arr = art.constant_mmr_profile(0.01)
+    gravity = 2478.57
+    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+
+    mdb = mock_mdb(db)
+    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    opa = OpaPremodit(mdb=mdb,
+                      nu_grid=nu_grid,
+                      diffmode=diffmode,
+                      auto_trange=[art.Tlow, art.Thigh])
+
+    xsmatrix = opa.xsmatrix(Tarr, art.pressure)
+    dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
+                                     gravity)
+
+    #almost pure absorption
+    import jax.numpy as jnp
+    single_scattering_albedo = jnp.ones_like(dtau) * 0.99
+    asymmetric_parameter = jnp.ones_like(dtau) * 0.5
+
+    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, Tarr)
+
+    return nu_grid, F0
+    
+    
+
+
+if __name__ == "__main__":
+    config.update("jax_enable_x64", True)
+
+    import matplotlib.pyplot as plt
+    diffmode = 0
+    nus, F0_lart = generate_spectrum("exomol", diffmode, rtsolver="lart_toon_hemispheric_mean")  #
+    nus, F0_fluxadd = generate_spectrum("exomol", diffmode, rtsolver="fluxadding_toon_hemispheric_mean")  #
+    
+
+    fig = plt.figure()
+    ax = fig.add_subplot(211)
+    ax.plot(nus, F0_lart, label="LART/Toon (ExoMol) g=0.5, omega=0.5")
+    ax.plot(nus, F0_fluxadd, label="FluxAdding/Toon (ExoMol) g=0.5, omega=0.5", ls="dashed")
+    plt.legend()
+    ax = fig.add_subplot(212)
+    ax.plot(nus, 1.0-F0_fluxadd/F0_lart, label="diff")
+    ax.set_ylim(-0.01,0.01)
+    plt.xlabel("wavenumber cm-1")
+    plt.legend()
+    plt.savefig("lart_fluxadding_comparison_scat.png")
+    plt.show()

--- a/tests/integration/unittests_long/twostream/twostream_reflection_test.py
+++ b/tests/integration/unittests_long/twostream/twostream_reflection_test.py
@@ -1,0 +1,109 @@
+""" short integration tests for PreMODIT spectrum"""
+import pytest
+from jax.config import config
+from exojax.test.emulate_mdb import mock_mdb
+from exojax.spec.opacalc import OpaPremodit
+from exojax.test.emulate_mdb import mock_wavenumber_grid
+from exojax.spec.atmrt import ArtReflectEmis
+from exojax.spec.atmrt import ArtReflectPure
+
+
+
+@pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
+                                          ("hitemp", 1), ("hitemp", 2)])
+def test_ArtReflectPure_no_scattering_reflected_by_surface(db, diffmode, fig=False):
+
+    nu_grid, wav, res = mock_wavenumber_grid()
+    art = ArtReflectPure(pressure_top=1.e-5,
+                      pressure_btm=1.e0,
+                      nlayer=200,
+                      nu_grid=nu_grid)
+    art.change_temperature_range(400.0, 1500.0)
+    Tarr = art.powerlaw_temperature(1300.0, 0.1)
+    mmr_arr = art.constant_mmr_profile(0.0001)
+    gravity = 2478.57
+    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+
+    mdb = mock_mdb(db)
+    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    opa = OpaPremodit(mdb=mdb,
+                      nu_grid=nu_grid,
+                      diffmode=diffmode,
+                      auto_trange=[art.Tlow, art.Thigh])
+
+    xsmatrix = opa.xsmatrix(Tarr, art.pressure)
+    dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
+                                     gravity)
+
+    #almost pure absorption
+    import jax.numpy as jnp
+    single_scattering_albedo = jnp.ones_like(dtau) * 0.0001
+    asymmetric_parameter = jnp.ones_like(dtau) * 0.0001
+
+    albedo = 0.5
+    incoming_flux = jnp.ones_like(nu_grid)
+    reflectivity_surface = albedo*jnp.ones_like(nu_grid)
+    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, reflectivity_surface, incoming_flux)
+
+    return nu_grid, F0
+    
+    
+@pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
+                                          ("hitemp", 1), ("hitemp", 2)])
+def test_ArtReflectEmis_Emission_plus_stellar_refelction(db, diffmode, fig=False):
+    from exojax.spec.planck import piBarr
+    nu_grid, wav, res = mock_wavenumber_grid()
+    art = ArtReflectEmis(pressure_top=1.e-5,
+                      pressure_btm=1.e0,
+                      nlayer=200,
+                      nu_grid=nu_grid)
+    art.change_temperature_range(400.0, 1500.0)
+    Tarr = art.powerlaw_temperature(1300.0, 0.1)
+    mmr_arr = art.constant_mmr_profile(0.0001)
+    gravity = 2478.57
+    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+
+    mdb = mock_mdb(db)
+    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    opa = OpaPremodit(mdb=mdb,
+                      nu_grid=nu_grid,
+                      diffmode=diffmode,
+                      auto_trange=[art.Tlow, art.Thigh])
+
+    xsmatrix = opa.xsmatrix(Tarr, art.pressure)
+    dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
+                                     gravity)
+
+    #almost pure absorption
+    import jax.numpy as jnp
+    single_scattering_albedo = jnp.ones_like(dtau) * 0.0001
+    asymmetric_parameter = jnp.ones_like(dtau) * 0.0001
+
+    albedo = 0.5
+    incoming_flux = piBarr(jnp.array([1000.0]), nu_grid)[0,:] #1500K incoming
+    reflectivity_surface = albedo*jnp.ones_like(nu_grid)
+    
+    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, Tarr, jnp.zeros_like(nu_grid), reflectivity_surface, incoming_flux)
+
+    return nu_grid, F0
+    
+
+
+if __name__ == "__main__":
+    config.update("jax_enable_x64", True)
+
+    import matplotlib.pyplot as plt
+    diffmode = 0
+    #nus_hitemp, F0_hitemp, Fref_hitemp = test_rt("hitemp", diffmode)
+    nus, F0 = test_ArtReflectEmis_Emission_plus_stellar_refelction("exomol", diffmode)
+    #nus, F0 = test_ArtReflectPure_no_scattering_reflected_by_surface("exomol", diffmode)  #
+    
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot(nus, F0, label="refelected+emission light")
+    plt.xlabel("wavenumber cm-1")
+    plt.legend()
+    plt.show()

--- a/tests/integration/unittests_long/twostream/twostream_reflection_test.py
+++ b/tests/integration/unittests_long/twostream/twostream_reflection_test.py
@@ -8,25 +8,24 @@ from exojax.spec.atmrt import ArtReflectEmis
 from exojax.spec.atmrt import ArtReflectPure
 
 
-
 @pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
                                           ("hitemp", 1), ("hitemp", 2)])
 def test_ArtReflectPure_no_scattering_reflected_by_surface(db, diffmode, fig=False):
 
     nu_grid, wav, res = mock_wavenumber_grid()
     art = ArtReflectPure(pressure_top=1.e-5,
-                      pressure_btm=1.e0,
-                      nlayer=200,
-                      nu_grid=nu_grid)
+                         pressure_btm=1.e0,
+                         nlayer=200,
+                         nu_grid=nu_grid)
     art.change_temperature_range(400.0, 1500.0)
     Tarr = art.powerlaw_temperature(1300.0, 0.1)
     mmr_arr = art.constant_mmr_profile(0.0001)
     gravity = 2478.57
-    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+    # gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
 
     mdb = mock_mdb(db)
-    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
-    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    # mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    # mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
     opa = OpaPremodit(mdb=mdb,
                       nu_grid=nu_grid,
                       diffmode=diffmode,
@@ -36,7 +35,7 @@ def test_ArtReflectPure_no_scattering_reflected_by_surface(db, diffmode, fig=Fal
     dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
                                      gravity)
 
-    #almost pure absorption
+    # almost pure absorption
     import jax.numpy as jnp
     single_scattering_albedo = jnp.ones_like(dtau) * 0.0001
     asymmetric_parameter = jnp.ones_like(dtau) * 0.0001
@@ -44,29 +43,30 @@ def test_ArtReflectPure_no_scattering_reflected_by_surface(db, diffmode, fig=Fal
     albedo = 0.5
     incoming_flux = jnp.ones_like(nu_grid)
     reflectivity_surface = albedo*jnp.ones_like(nu_grid)
-    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, reflectivity_surface, incoming_flux)
+    F0 = art.run(dtau, single_scattering_albedo,
+                 asymmetric_parameter, reflectivity_surface, incoming_flux)
 
     return nu_grid, F0
-    
-    
+
+
 @pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
                                           ("hitemp", 1), ("hitemp", 2)])
 def test_ArtReflectEmis_Emission_plus_stellar_refelction(db, diffmode, fig=False):
     from exojax.spec.planck import piBarr
     nu_grid, wav, res = mock_wavenumber_grid()
     art = ArtReflectEmis(pressure_top=1.e-5,
-                      pressure_btm=1.e0,
-                      nlayer=200,
-                      nu_grid=nu_grid)
+                         pressure_btm=1.e0,
+                         nlayer=200,
+                         nu_grid=nu_grid)
     art.change_temperature_range(400.0, 1500.0)
     Tarr = art.powerlaw_temperature(1300.0, 0.1)
     mmr_arr = art.constant_mmr_profile(0.0001)
     gravity = 2478.57
-    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+    # gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
 
     mdb = mock_mdb(db)
-    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
-    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    # mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    # mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
     opa = OpaPremodit(mdb=mdb,
                       nu_grid=nu_grid,
                       diffmode=diffmode,
@@ -76,19 +76,20 @@ def test_ArtReflectEmis_Emission_plus_stellar_refelction(db, diffmode, fig=False
     dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
                                      gravity)
 
-    #almost pure absorption
+    # almost pure absorption
     import jax.numpy as jnp
     single_scattering_albedo = jnp.ones_like(dtau) * 0.0001
     asymmetric_parameter = jnp.ones_like(dtau) * 0.0001
 
     albedo = 0.5
-    incoming_flux = piBarr(jnp.array([1000.0]), nu_grid)[0,:] #1500K incoming
+    incoming_flux = piBarr(jnp.array([1000.0]), nu_grid)[
+        0, :]  # 1500K incoming
     reflectivity_surface = albedo*jnp.ones_like(nu_grid)
-    
-    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, Tarr, jnp.zeros_like(nu_grid), reflectivity_surface, incoming_flux)
+
+    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter,
+                 Tarr, jnp.zeros_like(nu_grid), reflectivity_surface, incoming_flux)
 
     return nu_grid, F0
-    
 
 
 if __name__ == "__main__":
@@ -96,10 +97,10 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
     diffmode = 0
-    #nus_hitemp, F0_hitemp, Fref_hitemp = test_rt("hitemp", diffmode)
-    nus, F0 = test_ArtReflectEmis_Emission_plus_stellar_refelction("exomol", diffmode)
-    #nus, F0 = test_ArtReflectPure_no_scattering_reflected_by_surface("exomol", diffmode)  #
-    
+    # nus_hitemp, F0_hitemp, Fref_hitemp = test_rt("hitemp", diffmode)
+    nus, F0 = test_ArtReflectEmis_Emission_plus_stellar_refelction(
+        "exomol", diffmode)
+    # nus, F0 = test_ArtReflectPure_no_scattering_reflected_by_surface("exomol", diffmode)  #
 
     fig = plt.figure()
     ax = fig.add_subplot(111)

--- a/tests/integration/unittests_long/twostream/twostream_spectrum_test.py
+++ b/tests/integration/unittests_long/twostream/twostream_spectrum_test.py
@@ -9,7 +9,7 @@ from exojax.spec.atmrt import ArtEmisScat
 
 @pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
                                           ("hitemp", 1), ("hitemp", 2)])
-def test_ArtEmisScat_gives_consistent_results_with_pure_absorption(db, diffmode, fig=False):
+def test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption(db, diffmode, fig=False):
 
     nu_grid, wav, res = mock_wavenumber_grid()
     art = ArtEmisScat(pressure_top=1.e-5,
@@ -44,6 +44,8 @@ def test_ArtEmisScat_gives_consistent_results_with_pure_absorption(db, diffmode,
 
     return nu_grid, F0, F0
     
+    
+
 
 if __name__ == "__main__":
     config.update("jax_enable_x64", True)
@@ -51,7 +53,7 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     diffmode = 0
     #nus_hitemp, F0_hitemp, Fref_hitemp = test_rt("hitemp", diffmode)
-    nus, F0, Fref = test_ArtEmisScat_gives_consistent_results_with_pure_absorption("exomol", diffmode)  #
+    nus, F0, Fref = test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption("exomol", diffmode)  #
     
     fig = plt.figure()
     ax = fig.add_subplot(311)

--- a/tests/integration/unittests_long/twostream/twostream_spectrum_test.py
+++ b/tests/integration/unittests_long/twostream/twostream_spectrum_test.py
@@ -9,6 +9,44 @@ from exojax.spec.atmrt import ArtEmisScat
 
 @pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
                                           ("hitemp", 1), ("hitemp", 2)])
+def test_ArtEmisScat_fluxadding_gives_consistent_results_with_pure_absorption(db, diffmode, fig=False):
+
+    nu_grid, wav, res = mock_wavenumber_grid()
+    art = ArtEmisScat(pressure_top=1.e-5,
+                      pressure_btm=1.e1,
+                      nlayer=200,
+                      nu_grid=nu_grid,
+                      rtsolver="fluxadding_toon_hemispheric_mean")
+    art.change_temperature_range(400.0, 1500.0)
+    Tarr = art.powerlaw_temperature(1300.0, 0.1)
+    mmr_arr = art.constant_mmr_profile(0.01)
+    gravity = 2478.57
+    #gravity = art.constant_gravity_profile(2478.57) #gravity can be profile
+
+    mdb = mock_mdb(db)
+    #mdb = api.MdbExomol('.database/CO/12C-1edt mru 6O/Li2015',nu_grid,inherit_dataframe=False,gpu_transfer=False)
+    #mdb = api.MdbHitemp('CO', art.nu_grid, gpu_transfer=False, isotope=1)
+    opa = OpaPremodit(mdb=mdb,
+                      nu_grid=nu_grid,
+                      diffmode=diffmode,
+                      auto_trange=[art.Tlow, art.Thigh])
+
+    xsmatrix = opa.xsmatrix(Tarr, art.pressure)
+    dtau = art.opacity_profile_lines(xsmatrix, mmr_arr, opa.mdb.molmass,
+                                     gravity)
+
+    #almost pure absorption
+    import jax.numpy as jnp
+    single_scattering_albedo = jnp.ones_like(dtau) * 0.0001
+    asymmetric_parameter = jnp.ones_like(dtau) * 0.0001
+
+    F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, Tarr, show=True)
+
+    return nu_grid, F0
+
+
+@pytest.mark.parametrize("db, diffmode", [("exomol", 1), ("exomol", 2),
+                                          ("hitemp", 1), ("hitemp", 2)])
 def test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption(db, diffmode, fig=False):
 
     nu_grid, wav, res = mock_wavenumber_grid()
@@ -42,7 +80,7 @@ def test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption(db, diff
 
     F0 = art.run(dtau, single_scattering_albedo, asymmetric_parameter, Tarr, show=True)
 
-    return nu_grid, F0, F0
+    return nu_grid, F0
     
     
 
@@ -53,33 +91,19 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     diffmode = 0
     #nus_hitemp, F0_hitemp, Fref_hitemp = test_rt("hitemp", diffmode)
-    nus, F0, Fref = test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption("exomol", diffmode)  #
+    nus, F0_lart = test_ArtEmisScat_LART_gives_consistent_results_with_pure_absorption("exomol", diffmode)  #
+    nus, F0_fluxadd = test_ArtEmisScat_fluxadding_gives_consistent_results_with_pure_absorption("exomol", diffmode)  #
     
-    fig = plt.figure()
-    ax = fig.add_subplot(311)
-    #ax.plot(nus[10300:10700], F0[10300:10700], label="Toon (ExoMol)")
-    ax.plot(nus, F0, label="Toon (ExoMol)")
-    plt.legend()
-    #plt.yscale("log")
-    ax = fig.add_subplot(312)
-    #ax.plot(nus_hitemp, F0_hitemp, label="PreMODIT (HITEMP)", ls="dashed")
-    plt.legend()
-    plt.ylabel("flux (cgs)")
 
-    ax = fig.add_subplot(313)
-    ax.plot(nus[10300:10700],
-            1.0 - F0[10300:10700] / Fref[10300:10700],
-            alpha=0.7,
-            label="dif = (MO - PreMO)/MO Exomol")
-    #ax.plot(nus_hitemp,
-    #        1.0 - F0_hitemp / Fref_hitemp,
-    #        alpha=0.7,
-    #        label="dif = (MO - PreMO)/MO HITEMP")
-    plt.xlabel("wavenumber cm-1")
-    plt.axhline(0.05, color="gray", lw=0.5)
-    plt.axhline(-0.05, color="gray", lw=0.5)
-    plt.axhline(0.01, color="gray", lw=0.5)
-    plt.axhline(-0.01, color="gray", lw=0.5)
-    plt.ylim(-0.07, 0.07)
+    fig = plt.figure()
+    ax = fig.add_subplot(211)
+    ax.plot(nus, F0_lart, label="LART/Toon (ExoMol)")
+    ax.plot(nus, F0_fluxadd, label="FluxAdding/Toon (ExoMol)", ls="dashed")
     plt.legend()
+    ax = fig.add_subplot(212)
+    ax.plot(nus, 1.0-F0_fluxadd/F0_lart, label="diff")
+    ax.set_ylim(-0.01,0.01)
+    plt.xlabel("wavenumber cm-1")
+    plt.legend()
+    plt.savefig("lart_fluxadding_comparison.png")
     plt.show()

--- a/tests/unittests/spec/twostream/twostream_test.py
+++ b/tests/unittests/spec/twostream/twostream_test.py
@@ -1,9 +1,4 @@
 from exojax.spec.twostream import compute_tridiag_diagonals_and_vector
-from exojax.spec.twostream import solve_lart_twostream_numpy
-from exojax.spec.twostream import solve_lart_twostream
-from exojax.spec.twostream import solve_fluxadding_twostream_forloop
-
-
 import jax.numpy as jnp
 import numpy as np
 
@@ -19,15 +14,6 @@ def samples_fluxadding_flux2st():
     return piB, scat_coeff, trans_coeff
 
 
-def test_solve_fluxadding_twostream_forloop():
-    piB, scat_coeff, trans_coeff = samples_fluxadding_flux2st()
-    reduced_source_function = piB  # temp
-    reflectivity_bottom = jnp.array([0.5, 0.5, 0.5])
-    source_bottom = jnp.array([0.1, 0.1, 0.1])
-    incoming_flux = jnp.array([1.0,1.0,1.0])
-    F = solve_fluxadding_twostream_forloop(
-        trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux)
-    return
 
 
 def samples_lart_flux2st():
@@ -63,44 +49,9 @@ def test_scat_lart_flux2st_tridiag_coefficients():
     assert np.array_equal(ref_diag_arr, diagonal)
 
 
-def test_solve_lart_twostream_numpy():
-    """
-    This test does not guarantee that solve_lart_twostream_numpy itself but checks the results are consistent with the fiducial ones
-    """
-    _, _, upper_diagonal_top, diagonal_top, vector_top, piB, scat_coeff, trans_coeff = samples_lart_flux2st(
-    )
-    diagonal, lower_diagonal, upper_diagonal, vector = compute_tridiag_diagonals_and_vector(
-        scat_coeff, trans_coeff, piB, upper_diagonal_top, diagonal_top,
-        vector_top)
-
-    cumTtilde, Qtilde, spectrum = solve_lart_twostream_numpy(
-        diagonal, lower_diagonal, upper_diagonal, vector)
-
-    ref = 0.39861748
-    res = (spectrum[0] - ref)**2
-    assert res < 1.e-15
-
-
-def test_solve_lart_twostream_by_comparing_with_numpy_version():
-    _, _, upper_diagonal_top, diagonal_top, vector_top, piB, scat_coeff, trans_coeff = samples_lart_flux2st(
-    )
-    diagonal, lower_diagonal, upper_diagonal, vector = compute_tridiag_diagonals_and_vector(
-        scat_coeff, trans_coeff, piB, upper_diagonal_top, diagonal_top,
-        vector_top)
-    cumTtilde_np, Qtilde_np, spectrum_np = solve_lart_twostream_numpy(
-        diagonal, lower_diagonal, upper_diagonal, vector)
-    nlayer, Nnus = diagonal.shape
-    cumTtilde, Qtilde, spectrum = solve_lart_twostream(diagonal,
-                                                       lower_diagonal,
-                                                       upper_diagonal, vector,
-                                                       jnp.zeros(Nnus))
-    assert np.array_equal(Qtilde, Qtilde_np)
-
-
 if __name__ == "__main__":
     
-    # test_scat_lart_flux2st_tridiag_coefficients()
+    test_scat_lart_flux2st_tridiag_coefficients()
     # test_solve_lart_twostream_numpy()
     # test_solve_lart_twostream_by_comparing_with_numpy_version()
 
-    test_solve_fluxadding_twostream_forloop()

--- a/tests/unittests/spec/twostream/twostream_test.py
+++ b/tests/unittests/spec/twostream/twostream_test.py
@@ -1,9 +1,33 @@
 from exojax.spec.twostream import compute_tridiag_diagonals_and_vector
 from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
+from exojax.spec.twostream import solve_fluxadding_twostream_numpy
+
 
 import jax.numpy as jnp
 import numpy as np
+
+
+def samples_fluxadding_flux2st():
+    Nlayer = 4
+    B = jnp.array(range(0, Nlayer)) + 1.
+    S = jnp.array(range(0, Nlayer)) + 1.
+    T = (jnp.array(range(0, Nlayer)) + 1) * 2.
+    piB = jnp.array([B, B, B]).T
+    scat_coeff = jnp.array([S, S, S]).T
+    trans_coeff = jnp.array([T, T, T]).T
+    return piB, scat_coeff, trans_coeff
+
+
+def test_solve_fluxadding_twostream_numpy():
+    piB, scat_coeff, trans_coeff = samples_fluxadding_flux2st()
+    reduced_source_function = piB  # temp
+    reflectivity_bottom = jnp.array([0.5, 0.5, 0.5])
+    source_bottom = jnp.array([0.1, 0.1, 0.1])
+    F = solve_fluxadding_twostream_numpy(
+        trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom)
+    print(F)
+    return
 
 
 def samples_lart_flux2st():
@@ -74,6 +98,9 @@ def test_solve_lart_twostream_by_comparing_with_numpy_version():
 
 
 if __name__ == "__main__":
-    #test_scat_lart_flux2st_tridiag_coefficients()
-    test_solve_lart_twostream_numpy()
-    test_solve_lart_twostream_by_comparing_with_numpy_version()
+    
+    # test_scat_lart_flux2st_tridiag_coefficients()
+    # test_solve_lart_twostream_numpy()
+    # test_solve_lart_twostream_by_comparing_with_numpy_version()
+
+    test_solve_fluxadding_twostream_numpy()

--- a/tests/unittests/spec/twostream/twostream_test.py
+++ b/tests/unittests/spec/twostream/twostream_test.py
@@ -1,7 +1,7 @@
 from exojax.spec.twostream import compute_tridiag_diagonals_and_vector
 from exojax.spec.twostream import solve_lart_twostream_numpy
 from exojax.spec.twostream import solve_lart_twostream
-from exojax.spec.twostream import solve_fluxadding_twostream_numpy
+from exojax.spec.twostream import solve_fluxadding_twostream_forloop
 
 
 import jax.numpy as jnp
@@ -14,19 +14,19 @@ def samples_fluxadding_flux2st():
     S = jnp.array(range(0, Nlayer)) + 1.
     T = (jnp.array(range(0, Nlayer)) + 1) * 2.
     piB = jnp.array([B, B, B]).T
-    scat_coeff = jnp.array([S, S, S]).T
-    trans_coeff = jnp.array([T, T, T]).T
+    scat_coeff = jnp.array([S, S, S]).T*0.1
+    trans_coeff = jnp.array([T, T, T]).T*0.1
     return piB, scat_coeff, trans_coeff
 
 
-def test_solve_fluxadding_twostream_numpy():
+def test_solve_fluxadding_twostream_forloop():
     piB, scat_coeff, trans_coeff = samples_fluxadding_flux2st()
     reduced_source_function = piB  # temp
     reflectivity_bottom = jnp.array([0.5, 0.5, 0.5])
     source_bottom = jnp.array([0.1, 0.1, 0.1])
-    F = solve_fluxadding_twostream_numpy(
-        trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom)
-    print(F)
+    incoming_flux = jnp.array([1.0,1.0,1.0])
+    F = solve_fluxadding_twostream_forloop(
+        trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom, incoming_flux)
     return
 
 
@@ -103,4 +103,4 @@ if __name__ == "__main__":
     # test_solve_lart_twostream_numpy()
     # test_solve_lart_twostream_by_comparing_with_numpy_version()
 
-    test_solve_fluxadding_twostream_numpy()
+    test_solve_fluxadding_twostream_forloop()


### PR DESCRIPTION
The flux-adding treatment by Robinson and Crisp (2018). #420

## Emission spectrum with scattering 
- If you use `art`, use `spec.atmrt.ArtEmisScat` with `rtsolver="fluxadding_toon_hemispheric_mean"` (default). 
- You can compare the results with LART solver, by running `tests/integration/comparison/twostream/comparison_lart_fluxadd.py`.
- Both the LART and flux adding converges to the pure absorption case. Run `tests/integration/unittests_long/twostream/twostream_spectrum_test.py`.

## Reflection spectrum (no source terms)
- for `art`, use `spec.atmrt.ArtReflectPure`.
- A sample is `tests/integration/unittests_long/twostream/twostream_reflection_test.py` ([uncomment the 101st line](https://github.com/HajimeKawahara/exojax/blob/41927e2228cf511e13de2286ef0ade4e8809a522/tests/integration/unittests_long/twostream/twostream_reflection_test.py#L101C2-L101C2) and comment out [the 100th line](https://github.com/HajimeKawahara/exojax/blob/41927e2228cf511e13de2286ef0ade4e8809a522/tests/integration/unittests_long/twostream/twostream_reflection_test.py#L100))

## Reflection + Emission
The most general case is that we have an incoming flux and source from atmosphere and reflection at bottom and the source from the bottom. 
- for `art`, use `spec.atmrt.ArtReflectEmis`.
- A sample is `tests/integration/unittests_long/twostream/twostream_reflection_test.py`

