### PR TITLE
added self.logsij0 for the case of gpu_transfer=False

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -286,6 +286,7 @@ class MdbExomol(CapiMdbExomol):
             self.jlower = df_masked.jlower.values
             self.jupper = df_masked.jupper.values
             self.line_strength_ref = df_masked.Sij0.values
+            self.logsij0 = np.log(self.line_strength_ref)
             self.gpp = df_masked.gup.values
         else:
             raise ValueError("Use vaex dataframe as input.")
@@ -795,6 +796,7 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         self.check_line_existence_in_nurange(df_masked)
         self.nu_lines = df_masked.wav.values
         self.line_strength_ref = df_masked.int.values
+        self.logsij0 = np.log(self.line_strength_ref)
         self.delta_air = df_masked.Pshft.values
         self.A = df_masked.A.values
         self.n_air = df_masked.Tdpair.values
@@ -966,6 +968,7 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         if isinstance(df_load_mask, vaex.dataframe.DataFrameLocal):
             self.nu_lines = df_load_mask.wav.values
             self.line_strength_ref = df_load_mask.int.values
+            self.logsij0 = np.log(self.line_strength_ref)
             self.delta_air = df_load_mask.Pshft.values
             self.A = df_load_mask.A.values
             self.n_air = df_load_mask.Tdpair.values


### PR DESCRIPTION
I am not sure whether this implementation is a bug, but I have realized that mdb.logsij0 is available only for the case of ``gpu_transfer=True``, which I think is a bit confusing when calculating with the lpf mode. So, I have modified the code. The minimum script you can check is as follows. Thank you.
```from exojax.utils.grids import wavenumber_grid
from exojax.spec import api
nus, wav, res = wavenumber_grid(22920.0,
                                23100.0,
                                100000,
                                unit='AA',
                                xsmode="lpf")

mdb = api.MdbExomol("/home/kawashima/database/CO/12C-16O/Li2015",nus,gpu_transfer=True)
print(mdb.logsij0)
mdb = api.MdbExomol("/home/kawashima/database/CO/12C-16O/Li2015",nus,gpu_transfer=False)
print(mdb.logsij0)

mdb = api.MdbHitemp("/home/kawashima/database/CO/05_HITEMP2019",nus,gpu_transfer=True)
print(mdb.logsij0)
mdb = api.MdbHitemp("/home/kawashima/database/CO/05_HITEMP2019",nus,gpu_transfer=False)
print(mdb.logsij0)

mdb = api.MdbHitran("/home/kawashima/database/CO/05_hit12.par",nus,gpu_transfer=True)
print(mdb.logsij0)
mdb = api.MdbHitran("/home/kawashima/database/CO/05_hit12.par",nus,gpu_transfer=False)
print(mdb.logsij0)
```