### PR TITLE
Added Tref as an input patameter to line_strength function

### DIFF
--- a/documents/tutorials/Comparing_HITEMP_and_ExoMol.ipynb
+++ b/documents/tutorials/Comparing_HITEMP_and_ExoMol.ipynb
@@ -208,9 +208,9 @@
    "outputs": [],
    "source": [
     "Sij_HITEMP=line_strength(Tfix,mdbCO_HITEMP.logsij0,mdbCO_HITEMP.nu_lines,\\\n",
-    "         mdbCO_HITEMP.elower,qt_HITEMP)\n",
+    "         mdbCO_HITEMP.elower,qt_HITEMP,mdbCO_HITEMP.Tref)\n",
     "Sij_Li2015=line_strength(Tfix,mdbCO_Li2015.logsij0,mdbCO_Li2015.nu_lines,\\\n",
-    "                mdbCO_Li2015.elower,qt_Li2015)"
+    "                mdbCO_Li2015.elower,qt_Li2015,mdbCO_Li2015.Tref)"
    ]
   },
   {

--- a/documents/tutorials/Comparing_HITEMP_and_ExoMol.rst
+++ b/documents/tutorials/Comparing_HITEMP_and_ExoMol.rst
@@ -97,9 +97,9 @@ we need to use float32 for jax.
 .. code:: ipython3
 
     Sij_HITEMP=line_strength(Tfix,mdbCO_HITEMP.logsij0,mdbCO_HITEMP.nu_lines,\
-             mdbCO_HITEMP.elower,qt_HITEMP)
+             mdbCO_HITEMP.elower,qt_HITEMP,mdbCO_HITEMP.Tref)
     Sij_Li2015=line_strength(Tfix,mdbCO_Li2015.logsij0,mdbCO_Li2015.nu_lines,\
-                    mdbCO_Li2015.elower,qt_Li2015)
+                    mdbCO_Li2015.elower,qt_Li2015,mdbCO_Li2015.Tref)
 
 Then, compute the Lorentz gamma factor (pressure+natural broadening)
 

--- a/documents/tutorials/opacity.ipynb
+++ b/documents/tutorials/opacity.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)"
+    "Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdbCO.Tref)"
    ]
   },
   {

--- a/documents/tutorials/opacity.rst
+++ b/documents/tutorials/opacity.rst
@@ -68,7 +68,7 @@ we need to use float32 for jax.
 
 .. code:: ipython3
 
-    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)
+    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdbCO.Tref)
 
 Then, compute the Lorentz gamma factor (pressure+natural broadening)
 

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -380,6 +380,7 @@ class MdbExomol(CapiMdbExomol):
                                                      self.nu_lines,
                                                      self.elower, qr,
                                                      self.Tref)
+        self.logsij0 = np.log(self.line_strength_ref)
         self.Tref = Tref_new
 
 
@@ -618,6 +619,7 @@ class MdbCommonHitempHitran():
                                                      self.nu_lines,
                                                      self.elower, qr,
                                                      self.Tref)
+        self.logsij0 = np.log(self.line_strength_ref)
         self.Tref = Tref_new
 
     def check_line_existence_in_nurange(self, df_load_mask):

--- a/src/exojax/spec/hitran.py
+++ b/src/exojax/spec/hitran.py
@@ -12,11 +12,11 @@ def line_strength(T, logsij0, nu_lines, elower, qT):
 
 
 @jit
-def line_strength(T, logsij0, nu_lines, elower, qr):
+def line_strength(T, logsij0, nu_lines, elower, qr, Tref):
     """Line strength as a function of temperature, JAX/XLA compatible
 
    Notes:
-      Use Tref=296.0 (default) in moldb
+      Tref=296.0 (default) in moldb, but it might have been changed by OpaPremodit.
 
    Args:
       T: temperature (K)
@@ -24,11 +24,11 @@ def line_strength(T, logsij0, nu_lines, elower, qr):
       nu_lines: line center wavenumber (cm-1)
       elower: elower
       qr: partition function ratio qr(T) = Q(T)/Q(Tref)
+      Tref: reference temperature
 
    Returns:
       Sij(T): Line strength (cm)
    """
-    Tref = Tref_original  # reference tempearture (K)
     expow = logsij0 - hcperk * (elower / T - elower / Tref)
     fac = (1.0 - jnp.exp(-hcperk * nu_lines / T)) / (
         1.0 - jnp.exp(-hcperk * nu_lines / Tref))

--- a/src/exojax/spec/hitran.py
+++ b/src/exojax/spec/hitran.py
@@ -5,10 +5,10 @@ from exojax.utils.constants import hcperk, Tref_original
 from exojax.utils.constants import Patm
 
 
-def line_strength(T, logsij0, nu_lines, elower, qT):
+def line_strength(T, logsij0, nu_lines, elower, qT, Tref):
     """(alias, deprecated) use hitran.line_strength, will be removed. 
    """
-    return line_strength(T, logsij0, nu_lines, elower, qT)
+    return line_strength(T, logsij0, nu_lines, elower, qT, Tref)
 
 
 @jit

--- a/src/exojax/spec/lpf.py
+++ b/src/exojax/spec/lpf.py
@@ -86,7 +86,7 @@ def vald(adb, Tarr, PH, PHe, PHH):
 
 def vald_each(Tarr, PH, PHe, PHH, \
             qt_284_T, QTmask, \
-             logsij0, nu_lines, ielem, iion, dev_nu_lines, elower, eupper, atomicmass, ionE, gamRad, gamSta, vdWdamp, ):
+              logsij0, nu_lines, ielem, iion, dev_nu_lines, elower, eupper, atomicmass, ionE, gamRad, gamSta, vdWdamp, Tref, ):
     """Compute VALD line information required for LPF for separated each species
     
     Args:

--- a/src/exojax/spec/lpf.py
+++ b/src/exojax/spec/lpf.py
@@ -36,9 +36,9 @@ def exomol(mdb, Tarr, Parr, molmass):
     """
 
     qt = vmap(mdb.qr_interp)(Tarr)
-    SijM = jit(vmap(line_strength, (0, None, None, None, 0)))(Tarr, mdb.logsij0,
+    SijM = jit(vmap(line_strength, (0, None, None, None, 0, 0)))(Tarr, mdb.logsij0,
                                                      mdb.dev_nu_lines,
-                                                     mdb.elower, qt)
+                                                              mdb.elower, qt, mdb.Tref)
     gammaLMP = jit(vmap(gamma_exomol,
                         (0, 0, None, None)))(Parr, Tarr, mdb.n_Texp,
                                              mdb.alpha_ref)
@@ -70,8 +70,8 @@ def vald(adb, Tarr, PH, PHe, PHH):
     qt = qt_284[:, adb.QTmask]
 
     # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0)))\
-        (Tarr, adb.logsij0, adb.nu_lines, adb.elower, qt)
+    SijM = jit(vmap(line_strength,(0,None,None,None,0,0)))\
+        (Tarr, adb.logsij0, adb.nu_lines, adb.elower, qt, adb.Tref)
 
     # Compute gamma parameters for the pressure and natural broadenings
     gammaLM = jit(vmap(gamma_vald3,(0,0,0,0,None,None,None,None,None,None,None,None,None,None,None)))\
@@ -119,8 +119,8 @@ def vald_each(Tarr, PH, PHe, PHH, \
     qt = qt_284_T[:, QTmask]
 
     # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0)))\
-        (Tarr, logsij0, nu_lines, elower, qt)
+    SijM = jit(vmap(line_strength,(0,None,None,None,0,0)))\
+        (Tarr, logsij0, nu_lines, elower, qt, Tref)
     SijM = jnp.nan_to_num(SijM, nan=0.0)
 
     # Compute gamma parameters for the pressure and natural broadenings

--- a/src/exojax/spec/modit.py
+++ b/src/exojax/spec/modit.py
@@ -164,9 +164,9 @@ def exomol(mdb, Tarr, Parr, R, molmass):
         normalized sigmaD matrix
     """
     qt = vmap(mdb.qr_interp)(Tarr)
-    SijM = jit(vmap(line_strength, (0, None, None, None, 0)))(Tarr, mdb.logsij0,
+    SijM = jit(vmap(line_strength, (0, None, None, None, 0, 0)))(Tarr, mdb.logsij0,
                                                      mdb.dev_nu_lines,
-                                                     mdb.elower, qt)
+                                                                 mdb.elower, qt, mdb.Tref)
     gammaLMP = jit(vmap(gamma_exomol,
                         (0, 0, None, None)))(Parr, Tarr, mdb.n_Texp,
                                              mdb.alpha_ref)
@@ -236,9 +236,9 @@ def hitran(mdb, Tarr, Parr, Pself, R, molmass):
        normalized sigmaD matrix
     """
     qt = vmap(mdb.qr_interp_lines)(Tarr)
-    SijM = jit(vmap(line_strength, (0, None, None, None, 0)))(Tarr, mdb.logsij0,
+    SijM = jit(vmap(line_strength, (0, None, None, None, 0, 0)))(Tarr, mdb.logsij0,
                                                      mdb.dev_nu_lines,
-                                                     mdb.elower, qt)
+                                                              mdb.elower, qt, mdb.Tref)
     gammaLMP = jit(vmap(gamma_hitran,
                         (0, 0, 0, None, None, None)))(Parr, Tarr, Pself,
                                                       mdb.n_air, mdb.gamma_air,
@@ -329,8 +329,8 @@ def vald_each(Tarr, PH, PHe, PHH, R, qt_284_T, QTmask, \
     qt = qt_284_T[:, QTmask]
 
     # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0)))\
-        (Tarr, logsij0, dev_nu_lines, elower, qt)
+    SijM = jit(vmap(line_strength,(0,None,None,None,0,0)))\
+        (Tarr, logsij0, dev_nu_lines, elower, qt, Tref)
 
     # Compute gamma parameters for the pressure and natural broadenings
     gammaLM = jit(vmap(gamma_vald3,(0,0,0,0,None,None,None,None,None,None,None,None,None,None,None)))\

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -453,7 +453,7 @@ class OpaModit(OpaCalc):
 
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
         Sij = line_strength(T, self.mdb.logsij0, self.mdb.nu_lines,
-                            self.mdb.elower, qt)
+                            self.mdb.elower, qt, self.mdb.Tref)
 
         ngammaL_grid = ditgrid_log_interval(
             ngammaL, dit_grid_resolution=self.dit_grid_resolution)
@@ -592,7 +592,7 @@ class OpaDirect(OpaCalc):
                                       self.mdb.A)
         sigmaD = doppler_sigma(self.mdb.nu_lines, T, self.mdb.molmass)
         Sij = line_strength(T, self.mdb.logsij0, self.mdb.nu_lines,
-                            self.mdb.elower, qt)
+                            self.mdb.elower, qt, self.mdb.Tref)
         return xsvector_lpf(numatrix, sigmaD, gammaL, Sij)
 
     def xsmatrix(self, Tarr, Parr):
@@ -620,7 +620,7 @@ class OpaDirect(OpaCalc):
         from exojax.spec.lpf import xsmatrix as xsmatrix_lpf
 
         numatrix = self.opainfo
-        vmaplinestrengh = jit(vmap(line_strength, (0, None, None, None, 0)))
+        vmaplinestrengh = jit(vmap(line_strength, (0, None, None, None, 0, 0)))
         if self.mdb.dbtype == "hitran":
             vmapqt = vmap(self.mdb.qr_interp, (None, 0))
             qt = vmapqt(self.mdb.isotope, Tarr)
@@ -630,7 +630,7 @@ class OpaDirect(OpaCalc):
                                  self.mdb.gamma_self) + gamma_natural(
                                      self.mdb.A)
             SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines,
-                                   self.mdb.elower, qt)
+                                   self.mdb.elower, qt, self.mdb.Tref)
             sigmaDM = jit(vmap(doppler_sigma,
                             (None, 0, None)))(self.mdb.nu_lines, Tarr,
                                                 self.mdb.molmass)
@@ -643,7 +643,7 @@ class OpaDirect(OpaCalc):
             gammaLMN = gamma_natural(self.mdb.A)
             gammaLM = gammaLMP + gammaLMN[None, :]
             SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines,
-                                   self.mdb.elower, qt)
+                                   self.mdb.elower, qt, self.mdb.Tref)
             sigmaDM = jit(vmap(doppler_sigma,
                             (None, 0, None)))(self.mdb.nu_lines, Tarr,
                                                 self.mdb.molmass)
@@ -660,7 +660,7 @@ class OpaDirect(OpaCalc):
                                 self.mdb.atomicmass, self.mdb.ionE, \
                                 self.mdb.gamRad, self.mdb.gamSta, self.mdb.vdWdamp, 1.0)
             SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines, \
-                                    self.mdb.elower, qt_K.T)  
+                                    self.mdb.elower, qt_K.T, self.mdb.Tref)
             sigmaDM = jit(vmap(doppler_sigma,(None,0,None)))\
                 (self.mdb.nu_lines, Tarr, self.mdb.atomicmass)
 

--- a/src/exojax/test/generate_xs.py
+++ b/src/exojax/test/generate_xs.py
@@ -57,7 +57,7 @@ def gendata_xs_modit_exomol():
     dv_lines = mdbCO.nu_lines / R
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
-    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
 
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
     xsv = xsvector(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij,
@@ -107,7 +107,7 @@ def gendata_xs_modit_hitemp(airmode=False):
     dv_lines = mdbCO.nu_lines / R
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
-    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
     cont_nu, index_nu, R, pmarray = init_modit(mdbCO.nu_lines, nu_grid)
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
 

--- a/tests/endtoend/metals/opacity_Fe_test.py
+++ b/tests/endtoend/metals/opacity_Fe_test.py
@@ -74,7 +74,7 @@ def test_opacity_Fe_vald3(T, P):
     PHH = P * H_He_HH_VMR[2]
     qt = np.ones_like(adbFe.A) * np.float32(adbFe.qr_interp('Fe 1', T))
     # ↑Unlike the case of HITRAN (using Qr_HAPI), we ignored the isotopes.
-    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt)
+    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt, adbFe.Tref)
     sigmaD = doppler_sigma(adbFe.nu_lines, T, Amol)
     gammaL = atomll.gamma_vald3(T, PH, PHH, PHe, adbFe.ielem, adbFe.iion,
                                 adbFe.dev_nu_lines, adbFe.elower, adbFe.eupper, adbFe.atomicmass, adbFe.ionE,
@@ -96,7 +96,7 @@ def test_opacity_Fe_uns(T, P):
     PHH = P * H_He_HH_VMR[2]
     qt = np.ones_like(adbFe.A) * np.float32(adbFe.qr_interp('Fe 1', T))
     # ↑Unlike the case of HITRAN (using Qr_HAPI), we ignored the isotopes.
-    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt)
+    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt, adbFe.Tref)
     sigmaD = doppler_sigma(adbFe.nu_lines, T, Amol)
     gammaL = atomll.gamma_uns(T, PH, PHH, PHe, adbFe.ielem, adbFe.iion,
                               adbFe.dev_nu_lines, adbFe.elower, adbFe.eupper, adbFe.atomicmass, adbFe.ionE,
@@ -117,7 +117,7 @@ def test_opacity_Fe_KA3(T, P):
     PHH = P * H_He_HH_VMR[2]
     qt = np.ones_like(adbFe.A) * np.float32(adbFe.qr_interp('Fe 1', T))
     # ↑Unlike the case of HITRAN (using Qr_HAPI), we ignored the isotopes.
-    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt)
+    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt, adbFe.Tref)
     sigmaD = doppler_sigma(adbFe.nu_lines, T, Amol)
     gammaL = atomll.gamma_KA3(T, PH, PHH, PHe, adbFe.ielem, adbFe.iion,
                               adbFe.dev_nu_lines, adbFe.elower, adbFe.eupper, adbFe.atomicmass, adbFe.ionE,
@@ -138,7 +138,7 @@ def test_opacity_Fe_KA4(T, P):
     PHH = P * H_He_HH_VMR[2]
     qt = np.ones_like(adbFe.A) * np.float32(adbFe.qr_interp('Fe 1', T))
     # ↑Unlike the case of HITRAN (using Qr_HAPI), we ignored the isotopes.
-    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt)
+    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt, adbFe.Tref)
     sigmaD = doppler_sigma(adbFe.nu_lines, T, Amol)
     gammaL = atomll.gamma_KA4(T, PH, PHH, PHe, adbFe.ielem, adbFe.iion,
                               adbFe.dev_nu_lines, adbFe.elower, adbFe.eupper, adbFe.atomicmass, adbFe.ionE,
@@ -159,7 +159,7 @@ def test_opacity_Fe_KA3s(T, P):
     PHH = P * H_He_HH_VMR[2]
     qt = np.ones_like(adbFe.A) * np.float32(adbFe.qr_interp('Fe 1', T))
     # ↑Unlike the case of HITRAN (using Qr_HAPI), we ignored the isotopes.
-    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt)
+    Sij = line_strength(T, adbFe.logsij0, adbFe.nu_lines, adbFe.elower, qt, adbFe.Tref)
     sigmaD = doppler_sigma(adbFe.nu_lines, T, Amol)
     gammaL = atomll.gamma_KA3s(T, PH, PHH, PHe, adbFe.ielem, adbFe.iion,
                                adbFe.dev_nu_lines, adbFe.elower, adbFe.eupper, adbFe.atomicmass, adbFe.ionE,

--- a/tests/integration/comparison/premodit/comp_lsd_test.py
+++ b/tests/integration/comparison/premodit/comp_lsd_test.py
@@ -78,7 +78,7 @@ def compare_line_shape_density(mdb,nu_grid,Ttest=1000.0,Ttyp=2000.0):
     Slsd=np.sum(Slsd,axis=1)
     cont_inilsd_nu, index_inilsd_nu = npgetix(mdb.nu_lines, nu_grid)
     logsij0 = jnp.array(np.log(mdb.line_strength_ref))
-    S=line_strength(Ttest, logsij0, mdb.nu_lines, mdb.elower, qT)
+    S=line_strength(Ttest, logsij0, mdb.nu_lines, mdb.elower, qT, mdb.Tref)
     Slsd_direct = np.zeros_like(nu_grid,dtype=np.float64)
     Slsd_direct = npadd1D(Slsd_direct, S, cont_inilsd_nu, index_inilsd_nu)
     return Slsd, Slsd_direct

--- a/tests/integration/modit_scanfft/modit_scanfft_test.py
+++ b/tests/integration/modit_scanfft/modit_scanfft_test.py
@@ -30,7 +30,7 @@ def test_xs_exomol():
     dv_lines = mdbCO.nu_lines / R
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
-    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
 
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
     xsv = xsvector_scanfft(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij, nus,

--- a/tests/integration/premodit/line_strength_comparison_exomol.py
+++ b/tests/integration/premodit/line_strength_comparison_exomol.py
@@ -83,7 +83,7 @@ from exojax.spec.initspec import init_modit
 mdb.change_reference_temperature(Tref_original)
 qt = mdb.qr_interp(Ttest)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 gammaL = gamma_exomol(P, Ttest, mdb.n_Texp, mdb.alpha_ref)
 
 dv_lines = mdb.nu_lines / R
@@ -96,7 +96,7 @@ Slsd_modit = inc2D_givenx(lsd_array, Sij, cont, index, jnp.log(ngammaL),
 Smodit = (np.sum(Slsd_modit, axis=1))
 
 ## also, xs
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 cont_nu, index_nu, R, pmarray = init_modit(mdb.nu_lines, nus)
 ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
 xsv_modit = xsvector(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij, nus,

--- a/tests/integration/premodit/line_strength_comparison_exomol_water.py
+++ b/tests/integration/premodit/line_strength_comparison_exomol_water.py
@@ -70,7 +70,7 @@ Spremodit = (np.sum(Slsd_premodit, axis=1))
 mdb.change_reference_temperature(Tref_original)
 qt = mdb.qr_interp(T)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
-Sij = line_strength(T, mdb.logsij0, mdb.nu_lines, mdb.elower, qt)
+Sij = line_strength(T, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 gammaL = gamma_exomol(P, T, mdb.n_Texp, mdb.alpha_ref)
 dv_lines = mdb.nu_lines / R
 ngammaL = gammaL / dv_lines

--- a/tests/integration/premodit/line_strength_comparison_hitemp.py
+++ b/tests/integration/premodit/line_strength_comparison_hitemp.py
@@ -85,7 +85,7 @@ from exojax.spec.initspec import init_modit
 mdb.change_reference_temperature(Tref_original)
 qt = mdb.qr_interp(mdb.isotope, Ttest)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 gammaL = gamma_hitran(P, Ttest, 0.0, mdb.n_air, mdb.gamma_air,
                       mdb.gamma_self) + gamma_natural(mdb.A)
 
@@ -99,7 +99,7 @@ Slsd_modit = inc2D_givenx(lsd_array, Sij, cont, index, jnp.log(ngammaL),
 Smodit = (np.sum(Slsd_modit, axis=1))
 
 ## also, xs
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 cont_nu, index_nu, R, pmarray = init_modit(mdb.nu_lines, nus)
 ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
 xsv_modit = xsvector(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij, nus,

--- a/tests/manual_check/comparison/dit_hitran_CO.py
+++ b/tests/manual_check/comparison/dit_hitran_CO.py
@@ -36,7 +36,7 @@ for idx, iso in enumerate(mdbCO.uniqiso):
     mask = mdbCO.isoid == iso
     qt[mask] = qr[idx]
 
-Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
 gammaL = gamma_hitran(Pfix, Tfix, Pfix, mdbCO.n_air,
                       mdbCO.gamma_air, mdbCO.gamma_self)
 # + gamma_natural(A) #uncomment if you inclide a natural width

--- a/tests/manual_check/comparison/hi_dynamic_range/errCO_DIT.py
+++ b/tests/manual_check/comparison/hi_dynamic_range/errCO_DIT.py
@@ -39,7 +39,7 @@ def comperr(Nnu,plotfig=False):
         mask=mdbCO.isoid==iso
         qt[mask]=qr[idx]
         
-    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)
+    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdbCO.Tref)
     gammaL = gamma_hitran(Pfix,Tfix,Pfix, mdbCO.n_air, mdbCO.gamma_air, mdbCO.gamma_self)
     #+ gamma_natural(A) #uncomment if you inclide a natural width
     sigmaD=doppler_sigma(mdbCO.nu_lines,Tfix,Mmol)

--- a/tests/manual_check/comparison/hi_dynamic_range/errCO_MODIT.py
+++ b/tests/manual_check/comparison/hi_dynamic_range/errCO_MODIT.py
@@ -43,7 +43,7 @@ def comperr(Nnu,plotfig=False):
         mask=mdbCO.isoid==iso
         qt[mask]=qr[idx]
         
-    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)
+    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdbCO.Tref)
     gammaL = gamma_hitran(Pfix,Tfix,Pfix, mdbCO.n_air, mdbCO.gamma_air, mdbCO.gamma_self)
     #+ gamma_natural(A) #uncomment if you inclide a natural width
     sigmaD=doppler_sigma(mdbCO.nu_lines,Tfix,Mmol)

--- a/tests/manual_check/comparison/hi_dynamic_range/errCO_REDIT.py
+++ b/tests/manual_check/comparison/hi_dynamic_range/errCO_REDIT.py
@@ -37,7 +37,7 @@ def comperr(Nnu,plotfig=False):
         mask=mdbCO.isoid==iso
         qt[mask]=qr[idx]
         
-    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)
+    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdb.Tref)
     gammaL = gamma_hitran(Pfix,Tfix,Pfix, mdbCO.n_air, mdbCO.gamma_air, mdbCO.gamma_self)
     #+ gamma_natural(A) #uncomment if you inclide a natural width
 

--- a/tests/manual_check/comparison/modit_hitran_CO.py
+++ b/tests/manual_check/comparison/modit_hitran_CO.py
@@ -39,7 +39,7 @@ for idx, iso in enumerate(mdbCO.uniqiso):
     mask = mdbCO.isoid == iso
     qt[mask] = qr[idx]
 
-Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
 gammaL = gamma_hitran(Pfix, Tfix, Pfix, mdbCO.n_air,
                       mdbCO.gamma_air, mdbCO.gamma_self)
 # + gamma_natural(A) #uncomment if you inclide a natural width

--- a/tests/manual_check/xs/Ttyp_demo.py
+++ b/tests/manual_check/xs/Ttyp_demo.py
@@ -22,7 +22,7 @@ def demo(Tfix,Ttyp,crit=1.e-40):
     Mmol=28.010446441149536 # molecular weight
     Pfix=1.e-3 # we compute P=1.e-3 bar
     qt=mdbCO.qr_interp(Tfix)
-    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt)
+    Sij=line_strength(Tfix,mdbCO.logsij0,mdbCO.nu_lines,mdbCO.elower,qt,mdbCO.Tref)
     gammaL = gamma_exomol(Pfix,Tfix,mdbCO.n_Texp,mdbCO.alpha_ref)\
         + gamma_natural(mdbCO.A)
     # thermal doppler sigma

--- a/tests/unittests/spec/modit/modit_test.py
+++ b/tests/unittests/spec/modit/modit_test.py
@@ -31,7 +31,7 @@ def test_xs_exomol():
     dv_lines = mdbCO.nu_lines / R
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
-    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt)
+    Sij = line_strength(Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref)
 
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
     xsv = xsvector(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij, nus,


### PR DESCRIPTION
I have added Tref as an input parameter to [line_strength function](https://github.com/HajimeKawahara/exojax/blob/ae3f78da85ecabc5e3fb60aad0d6dacdd8d7c831/src/exojax/spec/hitran.py#L14-L37) to avoid any confusion. (I noticed that if one calls the line_strength function after OpaPremodit changed the reference temperature, one gets incorrect line strength since the change in Tref is currently not considered.)

The test script you can check with is as follows. To run this script in the develop branch to check the difference, please comment out lines 32& 48 and uncomment 33&49. Thank you!
```from exojax.utils.grids import wavenumber_grid
from exojax.spec import api
from exojax.spec import molinfo
from exojax.spec.lpf import auto_xsection
from exojax.spec.hitran import line_strength, doppler_sigma, gamma_hitran, gamma_natural, line_strength_numpy
from exojax.spec.exomol import gamma_exomol
from exojax.spec.opacalc import OpaPremodit, OpaDirect
from jax.config import config
config.update("jax_enable_x64", True)

import numpy as np
import matplotlib.pyplot as plt

nus, wav, res = wavenumber_grid(22980.0,
                                23030.0,
                                100000,
                                unit='AA',
                                xsmode="premodit")

mdb = api.MdbHitemp("/home/kawashima/database/CO/05_HITEMP2019",nus,crit=1.e-30,Ttyp=1000.,gpu_transfer=True,isotope=1)

P = 1.e-3
T = 1000.
vmr = 1.
Ppart = P * vmr
Mmol = molinfo.molmass("CO")

logsij0 = np.log(mdb.line_strength_ref)
sigmaD = doppler_sigma(mdb.nu_lines,T,Mmol)
qt = mdb.qr_interp(mdb.isotope, T)
gammaL = gamma_hitran(P,T, Ppart, mdb.n_air, mdb.gamma_air, mdb.gamma_self) + gamma_natural(mdb.A)
Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt, mdb.Tref)
#Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt)                                                                                                          
xsv0 = auto_xsection(np.array(nus),mdb.nu_lines,sigmaD,gammaL,Sij,memory_size=30)

opa = OpaPremodit(mdb=mdb,
                  nu_grid=np.array(nus),
                  diffmode=2,
                  auto_trange=[500., 1500.],
                  dit_grid_resolution=1.0,
                  allow_32bit=True)

opad = OpaDirect(mdb=mdb,
                 nu_grid=np.array(nus))

logsij0 = np.log(mdb.line_strength_ref)
qt = mdb.qr_interp(mdb.isotope, T)
Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt, mdb.Tref)
#Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt)                                                                                                          
xsv = auto_xsection(np.array(nus),mdb.nu_lines,sigmaD,gammaL,Sij,memory_size=30)

fig, ax = plt.subplots()
ax.plot(1.0e8/np.array(nus), xsv0, c='C0')
ax.plot(1.0e8/np.array(nus), xsv, c='C1')
ax.plot(1.0e8/np.array(nus), opa.xsvector(T, P), c='C2')
ax.plot(1.0e8/np.array(nus), opad.xsvector(T, P), c='C3')
ax.set_xlim(22985, 23025)
ax.set_yscale('log')
plt.show()
```