### PR TITLE
vmap index for  line strength

### DIFF
--- a/src/exojax/spec/hitran.py
+++ b/src/exojax/spec/hitran.py
@@ -5,33 +5,30 @@ from exojax.utils.constants import hcperk, Tref_original
 from exojax.utils.constants import Patm
 
 
-def line_strength(T, logsij0, nu_lines, elower, qT, Tref):
-    """(alias, deprecated) use hitran.line_strength, will be removed. 
-   """
-    return line_strength(T, logsij0, nu_lines, elower, qT, Tref)
 
 
 @jit
 def line_strength(T, logsij0, nu_lines, elower, qr, Tref):
     """Line strength as a function of temperature, JAX/XLA compatible
 
-   Notes:
-      Tref=296.0 (default) in moldb, but it might have been changed by OpaPremodit.
+    Notes:
+       Tref=296.0 (default) in moldb, but it might have been changed by OpaPremodit.
 
-   Args:
-      T: temperature (K)
-      logsij0: log(Sij(Tref)) (Tref=296K)
-      nu_lines: line center wavenumber (cm-1)
-      elower: elower
-      qr: partition function ratio qr(T) = Q(T)/Q(Tref)
-      Tref: reference temperature
+    Args:
+       T: temperature (K)
+       logsij0: log(Sij(Tref)) (Tref=296K)
+       nu_lines: line center wavenumber (cm-1)
+       elower: elower
+       qr: partition function ratio qr(T) = Q(T)/Q(Tref)
+       Tref: reference temperature
 
-   Returns:
-      Sij(T): Line strength (cm)
-   """
+    Returns:
+       Sij(T): Line strength (cm)
+    """
     expow = logsij0 - hcperk * (elower / T - elower / Tref)
     fac = (1.0 - jnp.exp(-hcperk * nu_lines / T)) / (
-        1.0 - jnp.exp(-hcperk * nu_lines / Tref))
+        1.0 - jnp.exp(-hcperk * nu_lines / Tref)
+    )
     # expow=logsij0-hcperk*elower*(1.0/T-1.0/Tref)
     # fac=jnp.expm1(-hcperk*nu_lines/T)/jnp.expm1(-hcperk*nu_lines/Tref)
     return jnp.exp(expow) / qr * fac
@@ -40,20 +37,24 @@ def line_strength(T, logsij0, nu_lines, elower, qr, Tref):
 def line_strength_numpy(T, Sij0, nu_lines, elower, qr, Tref=Tref_original):
     """Line strength as a function of temperature, numpy version
 
-        Args:
-            T: temperature (K)
-            Sij0: line strength at Tref=296K
-            elower: elower
-            nu_lines: line center wavenumber 
-            qr : partition function ratio qr(T) = Q(T)/Q(Tref)
-            Tref: reference temeparture
+    Args:
+        T: temperature (K)
+        Sij0: line strength at Tref=296K
+        elower: elower
+        nu_lines: line center wavenumber
+        qr : partition function ratio qr(T) = Q(T)/Q(Tref)
+        Tref: reference temeparture
 
-        Returns:
-            line strength at Ttyp
-        """
-    return Sij0 / qr \
-        * np.exp(-hcperk*elower * (1./T - 1./Tref)) \
-        * np.expm1(-hcperk*nu_lines/T) / np.expm1(-hcperk*nu_lines/Tref_original)
+    Returns:
+        line strength at Ttyp
+    """
+    return (
+        Sij0
+        / qr
+        * np.exp(-hcperk * elower * (1.0 / T - 1.0 / Tref))
+        * np.expm1(-hcperk * nu_lines / T)
+        / np.expm1(-hcperk * nu_lines / Tref_original)
+    )
 
 
 @jit
@@ -72,9 +73,9 @@ def gamma_hitran(P, T, Pself, n_air, gamma_air_ref, gamma_self_ref):
        gamma: pressure gamma factor (cm-1)
     """
     Tref = Tref_original  # reference tempearture (K)
-    gamma = (Tref / T)**n_air * (gamma_air_ref *
-                                 ((P - Pself) / Patm) + gamma_self_ref *
-                                 (Pself / Patm))
+    gamma = (Tref / T) ** n_air * (
+        gamma_air_ref * ((P - Pself) / Patm) + gamma_self_ref * (Pself / Patm)
+    )
     return gamma
 
 

--- a/src/exojax/spec/lpf.py
+++ b/src/exojax/spec/lpf.py
@@ -36,7 +36,7 @@ def exomol(mdb, Tarr, Parr, molmass):
     """
 
     qt = vmap(mdb.qr_interp)(Tarr)
-    SijM = jit(vmap(line_strength, (0, None, None, None, 0, 0)))(Tarr, mdb.logsij0,
+    SijM = jit(vmap(line_strength, (0, None, None, None, 0, None)))(Tarr, mdb.logsij0,
                                                      mdb.dev_nu_lines,
                                                               mdb.elower, qt, mdb.Tref)
     gammaLMP = jit(vmap(gamma_exomol,
@@ -70,7 +70,7 @@ def vald(adb, Tarr, PH, PHe, PHH):
     qt = qt_284[:, adb.QTmask]
 
     # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0,0)))\
+    SijM = jit(vmap(line_strength,(0,None,None,None,0,None)))\
         (Tarr, adb.logsij0, adb.nu_lines, adb.elower, qt, adb.Tref)
 
     # Compute gamma parameters for the pressure and natural broadenings
@@ -119,7 +119,7 @@ def vald_each(Tarr, PH, PHe, PHH, \
     qt = qt_284_T[:, QTmask]
 
     # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0,0)))\
+    SijM = jit(vmap(line_strength,(0,None,None,None,0,None)))\
         (Tarr, logsij0, nu_lines, elower, qt, Tref)
     SijM = jnp.nan_to_num(SijM, nan=0.0)
 

--- a/tests/integration/api/api_premodit_to_direct.py
+++ b/tests/integration/api/api_premodit_to_direct.py
@@ -1,0 +1,64 @@
+
+"""
+Uses OpaDIrect after calling PreModit #437 made by @ykawashima (see #437, #438, #439) 
+"""
+
+from exojax.utils.grids import wavenumber_grid
+from exojax.spec import api
+from exojax.spec import molinfo
+from exojax.spec.lpf import auto_xsection
+from exojax.spec.hitran import line_strength, doppler_sigma, gamma_hitran, gamma_natural, line_strength_numpy
+from exojax.spec.exomol import gamma_exomol
+from exojax.spec.opacalc import OpaPremodit, OpaDirect
+from jax.config import config
+config.update("jax_enable_x64", True)
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+nus, wav, res = wavenumber_grid(22980.0,
+                                23030.0,
+                                100000,
+                                unit='AA',
+                                xsmode="premodit")
+
+mdb = api.MdbHitemp(".database/CO/05_HITEMP2019",nus,crit=1.e-30,Ttyp=1000.,gpu_transfer=True,isotope=1)
+
+P = 1.e-3
+T = 1000.
+vmr = 1.
+Ppart = P * vmr
+Mmol = molinfo.molmass("CO")
+
+logsij0 = np.log(mdb.line_strength_ref)
+sigmaD = doppler_sigma(mdb.nu_lines,T,Mmol)
+qt = mdb.qr_interp(mdb.isotope, T)
+gammaL = gamma_hitran(P,T, Ppart, mdb.n_air, mdb.gamma_air, mdb.gamma_self) + gamma_natural(mdb.A)
+Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt, mdb.Tref)
+#Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt)                                                                                                          
+xsv0 = auto_xsection(np.array(nus),mdb.nu_lines,sigmaD,gammaL,Sij,memory_size=30)
+
+opa = OpaPremodit(mdb=mdb,
+                  nu_grid=np.array(nus),
+                  diffmode=2,
+                  auto_trange=[500., 1500.],
+                  dit_grid_resolution=1.0,
+                  allow_32bit=True)
+
+opad = OpaDirect(mdb=mdb,
+                 nu_grid=np.array(nus))
+
+logsij0 = np.log(mdb.line_strength_ref)
+qt = mdb.qr_interp(mdb.isotope, T)
+Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt, mdb.Tref)
+#Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt)                                                                                                          
+xsv = auto_xsection(np.array(nus),mdb.nu_lines,sigmaD,gammaL,Sij,memory_size=30)
+
+fig, ax = plt.subplots()
+ax.plot(1.0e8/np.array(nus), xsv0, c='C0')
+ax.plot(1.0e8/np.array(nus), xsv, c='C1')
+ax.plot(1.0e8/np.array(nus), opa.xsvector(T, P), c='C2',ls="dashed")
+ax.plot(1.0e8/np.array(nus), opad.xsvector(T, P), c='C3',ls="dotted")
+ax.set_xlim(22985, 23025)
+ax.set_yscale('log')
+plt.show()


### PR DESCRIPTION
Some correction for vmap(line_strength).
I think we should put `None` instead of 0 as the Tref argument in vmapped line_strength
Yui's code in https://github.com/HajimeKawahara/exojax/pull/437 is now included in tests/integration/api/api_premodit_to_direct.py
Looks fine but confirm it?