### PR TITLE
small bug in line_strength_numpy

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -18,7 +18,9 @@ from exojax.spec.hitranapi import molecid_hitran
 from exojax.spec.molinfo import isotope_molmass
 from exojax.utils.isotopes import molmass_hitran
 
-from radis.api.exomolapi import MdbExomol as CapiMdbExomol  #MdbExomol in the common API
+from radis.api.exomolapi import (
+    MdbExomol as CapiMdbExomol,
+)  # MdbExomol in the common API
 from radis.api.hitempapi import HITEMPDatabaseManager
 from radis.api.hitranapi import HITRANDatabaseManager
 from radis.api.hdf5 import update_pytables_to_vaex
@@ -26,12 +28,12 @@ from radis.db.classes import get_molecule
 from radis.levels.partfunc import PartFuncTIPS
 import warnings
 
-__all__ = ['MdbExomol', 'MdbHitemp', 'MdbHitran']
+__all__ = ["MdbExomol", "MdbHitemp", "MdbHitran"]
 
 
 class MdbExomol(CapiMdbExomol):
     """molecular database of ExoMol.
-    
+
     MdbExomol is a class for ExoMol.
 
     Attributes:
@@ -39,7 +41,7 @@ class MdbExomol(CapiMdbExomol):
         nurange: nu range [min,max] (cm-1)
         nu_lines (nd array): line center (cm-1)
         Sij0 (nd array): line strength at T=Tref (cm)
-        
+
         logsij0 (jnp array): log line strength at T=Tref
         A (jnp array): Einstein A coeeficient
         gamma_natural (DataFrame or jnp array): gamma factor of the natural broadening
@@ -53,19 +55,22 @@ class MdbExomol(CapiMdbExomol):
         n_Texp_def: default temperature exponent in .def file, used for jlower not given in .broad
         alpha_ref_def: default alpha_ref (gamma0) in .def file, used for jlower not given in .broad
     """
-    def __init__(self,
-                 path,
-                 nurange=[-np.inf, np.inf],
-                 crit=0.,
-                 elower_max=None,
-                 Ttyp=1000.,
-                 bkgdatm='H2',
-                 broadf=True,
-                 gpu_transfer=True,
-                 inherit_dataframe=False,
-                 optional_quantum_states=False,
-                 activation=True,
-                 local_databases="./"):
+
+    def __init__(
+        self,
+        path,
+        nurange=[-np.inf, np.inf],
+        crit=0.0,
+        elower_max=None,
+        Ttyp=1000.0,
+        bkgdatm="H2",
+        broadf=True,
+        gpu_transfer=True,
+        inherit_dataframe=False,
+        optional_quantum_states=False,
+        activation=True,
+        local_databases="./",
+    ):
         """Molecular database for Exomol form.
 
         Args:
@@ -78,7 +83,7 @@ class MdbExomol(CapiMdbExomol):
             gpu_transfer: if True, some instances will be transfered to jnp.array. False is recommended for PreMODIT.
             inherit_dataframe: if True, it makes self.df instance available, which needs more DRAM when pickling.
             optional_quantum_states: if True, all of the fields available in self.df will be loaded. if False, the mandatory fields (i,E,g,J) will be loaded.
-            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available. 
+            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available.
 
 
         Note:
@@ -89,7 +94,7 @@ class MdbExomol(CapiMdbExomol):
         self.exact_molecule_name = self.path.parents[0].stem
         self.database = str(self.path.stem)
         self.bkgdatm = bkgdatm
-        #molecbroad = self.exact_molecule_name + '__' + self.bkgdatm
+        # molecbroad = self.exact_molecule_name + '__' + self.bkgdatm
         self.Tref = Tref_original
         self.gpu_transfer = gpu_transfer
         self.Ttyp = Ttyp
@@ -100,17 +105,19 @@ class MdbExomol(CapiMdbExomol):
         self.activation = activation
         wavenum_min, wavenum_max = self.set_wavenum(nurange)
 
-        super().__init__(str(self.path),
-                         local_databases=local_databases,
-                         molecule=self.simple_molecule_name,
-                         name="EXOMOL-{molecule}",
-                         nurange=[wavenum_min, wavenum_max],
-                         engine="vaex",
-                         crit=crit,
-                         bkgdatm=self.bkgdatm,
-                         broadf=self.broadf,
-                         cache=True,
-                         skip_optional_data=self.skip_optional_data)
+        super().__init__(
+            str(self.path),
+            local_databases=local_databases,
+            molecule=self.simple_molecule_name,
+            name="EXOMOL-{molecule}",
+            nurange=[wavenum_min, wavenum_max],
+            engine="vaex",
+            crit=crit,
+            bkgdatm=self.bkgdatm,
+            broadf=self.broadf,
+            cache=True,
+            skip_optional_data=self.skip_optional_data,
+        )
 
         self.crit = crit
         self.elower_max = elower_max
@@ -123,10 +130,11 @@ class MdbExomol(CapiMdbExomol):
         # data frame instance:
         df = self.load(
             local_files,
-            #columns=[k for k in self.__dict__ if k not in ["logsij0"]],
-            #lower_bound=([("Sij0", 0.0)]),
-            output="vaex")
-        
+            # columns=[k for k in self.__dict__ if k not in ["logsij0"]],
+            # lower_bound=([("Sij0", 0.0)]),
+            output="vaex",
+        )
+
         self.df_load_mask = self.compute_load_mask(df)
 
         if self.activation:
@@ -150,10 +158,10 @@ class MdbExomol(CapiMdbExomol):
         return wavenum_min, wavenum_max
 
     def activate(self, df, mask=None):
-        """activation of moldb, 
-        
+        """activation of moldb,
+
         Notes:
-            activation includes, making instances, computing broadening parameters, natural width, 
+            activation includes, making instances, computing broadening parameters, natural width,
             and transfering instances to gpu arrays when self.gpu_transfer = True
 
         Args:
@@ -164,7 +172,7 @@ class MdbExomol(CapiMdbExomol):
             self.df_load_mask is always applied when the activation.
 
         Examples:
-            
+
             >>> # we would extract the line with delta nu = 2 here
             >>> mdb = api.MdbExomol(emf, nus, optional_quantum_states=True, activation=False)
             >>> load_mask = (mdb.df["v_u"] - mdb.df["v_l"] == 2)
@@ -178,11 +186,11 @@ class MdbExomol(CapiMdbExomol):
             mask = self.df_load_mask
 
         self.instances_from_dataframes(df[mask])
-        try: #old radis <=0.14
+        try:  # old radis <=0.14
             self.compute_broadening(self.jlower.astype(int), self.jupper.astype(int))
         except:
-            self.set_broadening_coef(df[mask],add_columns=False)
-            
+            self.set_broadening_coef(df[mask], add_columns=False)
+
         self.gamma_natural = gn(self.A)
         if self.gpu_transfer:
             self.generate_jnp_arrays()
@@ -251,19 +259,20 @@ class MdbExomol(CapiMdbExomol):
             self.alpha_ref = np.array(self.alpha_ref_def * np.ones_like(jlower))
             self.n_Texp = np.array(self.n_Texp_def * np.ones_like(jlower))
 
-
     def compute_load_mask(self, df):
-        #wavelength
+        # wavelength
         print(df)
-        mask = (df.nu_lines > self.nurange[0]) \
-                    * (df.nu_lines < self.nurange[1])
+        mask = (df.nu_lines > self.nurange[0]) * (df.nu_lines < self.nurange[1])
         QTtyp = np.array(self.QT_interp(self.Ttyp))
         QTref_original = np.array(self.QT_interp(Tref_original))
-        mask *= (line_strength_numpy(self.Ttyp, df.Sij0, df.nu_lines,
-                                     df.elower, QTtyp / QTref_original) >
-                 self.crit)
+        mask *= (
+            line_strength_numpy(
+                self.Ttyp, df.Sij0, df.nu_lines, df.elower, QTtyp / QTref_original
+            )
+            > self.crit
+        )
         if self.elower_max is not None:
-            mask *= (df.elower < self.elower_max)
+            mask *= df.elower < self.elower_max
         return mask
 
     def instances_from_dataframes(self, df_masked):
@@ -317,7 +326,7 @@ class MdbExomol(CapiMdbExomol):
         self.gpp = self.gpp[mask]
 
     def Sij0(self):
-        """Deprecated line_strength_ref. 
+        """Deprecated line_strength_ref.
 
         Returns:
             ndarray: line_strength_ref
@@ -375,28 +384,28 @@ class MdbExomol(CapiMdbExomol):
         """
         print("Tref changed: " + str(self.Tref) + "K->" + str(Tref_new) + "K")
         qr = self.qr_interp(Tref_new)
-        self.line_strength_ref = line_strength_numpy(Tref_new,
-                                                     self.line_strength_ref,
-                                                     self.nu_lines,
-                                                     self.elower, qr,
-                                                     self.Tref)
+        self.line_strength_ref = line_strength_numpy(
+            Tref_new, self.line_strength_ref, self.nu_lines, self.elower, qr, self.Tref
+        )
         self.logsij0 = np.log(self.line_strength_ref)
         self.Tref = Tref_new
 
 
-class MdbCommonHitempHitran():
-    def __init__(self,
-                 path="CO",
-                 nurange=[-np.inf, np.inf],
-                 crit=0.,
-                 elower_max=None,
-                 Ttyp=1000.,
-                 isotope=1,
-                 gpu_transfer=False,
-                 inherit_dataframe=False,
-                 activation=True,
-                 parfile=None,
-                 with_error=False):
+class MdbCommonHitempHitran:
+    def __init__(
+        self,
+        path="CO",
+        nurange=[-np.inf, np.inf],
+        crit=0.0,
+        elower_max=None,
+        Ttyp=1000.0,
+        isotope=1,
+        gpu_transfer=False,
+        inherit_dataframe=False,
+        activation=True,
+        parfile=None,
+        with_error=False,
+    ):
         """Molecular database for HITRAN/HITEMP form.
 
         Args:
@@ -405,10 +414,10 @@ class MdbCommonHitempHitran():
             crit: line strength lower limit for extraction
             elower_max: maximum lower state energy, Elower (cm-1)
             Ttyp: typical temperature to calculate Sij(T) used in crit
-            isotope: isotope number, 0 or None = use all isotopes. 
+            isotope: isotope number, 0 or None = use all isotopes.
             gpu_transfer: tranfer data to jnp.array?
             inherit_dataframe: if True, it makes self.df instance available, which needs more DRAM when pickling.
-            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available. 
+            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available.
             parfile: if not none, provide path, then directly load parfile
             with_error: if True, uncertainty indices become available.
         """
@@ -425,8 +434,7 @@ class MdbCommonHitempHitran():
         self.set_molmass()
         self.gpu_transfer = gpu_transfer
         self.activation = activation
-        self.load_wavenum_min, self.load_wavenum_max = self.set_wavenum(
-            nurange)
+        self.load_wavenum_min, self.load_wavenum_max = self.set_wavenum(nurange)
         self.with_error = with_error
 
     def QT_for_select_line(self, Ttyp):
@@ -455,10 +463,10 @@ class MdbCommonHitempHitran():
         return wavenum_min, wavenum_max
 
     def activate(self, df, mask=None):
-        """activation of moldb, 
-        
+        """activation of moldb,
+
         Notes:
-            activation includes, making instances, computing broadening parameters, natural width, 
+            activation includes, making instances, computing broadening parameters, natural width,
             and transfering instances to gpu arrays when self.gpu_transfer = True
 
         Args:
@@ -469,7 +477,7 @@ class MdbCommonHitempHitran():
             self.df_load_mask is always applied when the activation.
 
         Examples:
-            
+
             >>> # we would extract the line with delta nu = 2 here
             >>> mdb = api.MdbExomol(emf, nus, optional_quantum_states=True, activation=False)
             >>> load_mask = (mdb.df["v_u"] - mdb.df["v_l"] == 2)
@@ -484,7 +492,8 @@ class MdbCommonHitempHitran():
 
         self.instances_from_dataframes(df[mask])
         self.gQT, self.T_gQT = hitranapi.make_partition_function_grid_hitran(
-            self.molecid, self.uniqiso)
+            self.molecid, self.uniqiso
+        )
 
         if self.gpu_transfer:
             self.generate_jnp_arrays()
@@ -494,17 +503,14 @@ class MdbCommonHitempHitran():
         if self.isotope is None:
             self.molmass = molmass_isotope[self.simple_molecule_name][0]
         else:
-            self.molmass = molmass_isotope[self.simple_molecule_name][
-                self.isotope]
+            self.molmass = molmass_isotope[self.simple_molecule_name][self.isotope]
 
     def compute_load_mask(self, df, qrtyp):
-        #wavelength
-        mask = (df.wav > self.load_wavenum_min) \
-                    * (df.wav < self.load_wavenum_max)
-        mask *= (line_strength_numpy(self.Ttyp, df.int, df.wav, df.El, qrtyp) >
-                 self.crit)
+        # wavelength
+        mask = (df.wav > self.load_wavenum_min) * (df.wav < self.load_wavenum_max)
+        mask *= line_strength_numpy(self.Ttyp, df.int, df.wav, df.El, qrtyp) > self.crit
         if self.elower_max is not None:
-            mask *= (df.elower < self.elower_max)
+            mask *= df.elower < self.elower_max
         return mask
 
     def apply_mask_mdb(self, mask):
@@ -528,16 +534,15 @@ class MdbCommonHitempHitran():
         self.gamma_self = self.gamma_self[mask]
         self.elower = self.elower[mask]
         self.gpp = self.gpp[mask]
-        #isotope
+        # isotope
         self.isoid = self.isoid[mask]
         self.uniqiso = np.unique(self.isoid)
         if self.with_error:
-            #uncertainties
+            # uncertainties
             self.ierr = self.ierr[mask]
 
     def Sij0(self):
-        """old line strength definition    
-        """
+        """old line strength definition"""
         msg = "Sij0 instance was replaced to line_strength_ref."
         raise ValueError(msg)
 
@@ -551,8 +556,7 @@ class MdbCommonHitempHitran():
         Returns:
            Q(idx, T) interpolated in jnp.array
         """
-        isotope_index = _isotope_index_from_isotope_number(
-            isotope, self.uniqiso)
+        isotope_index = _isotope_index_from_isotope_number(isotope, self.uniqiso)
         return _QT_interp(isotope_index, T, self.T_gQT, self.gQT)
 
     def qr_interp(self, isotope, T):
@@ -565,8 +569,7 @@ class MdbCommonHitempHitran():
         Returns:
             qr(T)=Q(T)/Q(Tref) interpolated in jnp.array
         """
-        isotope_index = _isotope_index_from_isotope_number(
-            isotope, self.uniqiso)
+        isotope_index = _isotope_index_from_isotope_number(isotope, self.uniqiso)
         return _qr_interp(isotope_index, T, self.T_gQT, self.gQT, self.Tref)
 
     def qr_interp_lines(self, T):
@@ -582,8 +585,9 @@ class MdbCommonHitempHitran():
         Note:
             Nlines=len(self.nu_lines)
         """
-        return _qr_interp_lines(T, self.isoid, self.uniqiso, self.T_gQT,
-                                self.gQT, self.Tref)
+        return _qr_interp_lines(
+            T, self.isoid, self.uniqiso, self.T_gQT, self.gQT, self.Tref
+        )
 
     def exact_isotope_name(self, isotope):
         """exact isotope name
@@ -595,8 +599,8 @@ class MdbCommonHitempHitran():
             str: exact isotope name such as (12C)(16O)
         """
         from exojax.utils.molname import exact_molecule_name_from_isotope
-        return exact_molecule_name_from_isotope(
-            self.simple_molecule_name, isotope)
+
+        return exact_molecule_name_from_isotope(self.simple_molecule_name, isotope)
 
     def change_reference_temperature(self, Tref_new):
         """change the reference temperature Tref and recompute Sij0
@@ -604,42 +608,49 @@ class MdbCommonHitempHitran():
         Args:
             Tref_new (float): new Tref in Kelvin
         """
-        print("Change the reference temperature from " + str(self.Tref) +
-              "K to " + str(Tref_new) + " K.")
+        print(
+            "Change the reference temperature from "
+            + str(self.Tref)
+            + "K to "
+            + str(Tref_new)
+            + " K."
+        )
         if self.isotope is None or self.isotope == 0:
             msg1 = "Currently all isotope mode is not fully compatible to change_reference_temperature."
-            msg2 = "QT used in change_reference_temperature is assumed isotope=1 instead."
+            msg2 = (
+                "QT used in change_reference_temperature is assumed isotope=1 instead."
+            )
             warnings.warn(msg1 + msg2, UserWarning)
             qr = self.qr_interp(1, Tref_new)
         else:
             qr = self.qr_interp(self.isotope, Tref_new)
 
-        self.line_strength_ref = line_strength_numpy(Tref_new,
-                                                     self.line_strength_ref,
-                                                     self.nu_lines,
-                                                     self.elower, qr,
-                                                     self.Tref)
+        self.line_strength_ref = line_strength_numpy(
+            Tref_new, self.line_strength_ref, self.nu_lines, self.elower, qr, self.Tref
+        )
         self.logsij0 = np.log(self.line_strength_ref)
         self.Tref = Tref_new
 
     def check_line_existence_in_nurange(self, df_load_mask):
         if len(df_load_mask) == 0:
             raise ValueError("No line found in ", self.nurange, "cm-1")
-        
+
     def add_error(self):
-        """uncertainty codes of HITRAN or HITEMP database  
+        """uncertainty codes of HITRAN or HITEMP database
         ref.: Table 2 and 5 in HITRAN 2004 (Rothman et al. 2005)
 
         Returns:
             Uncertainty indices for 6 critical parameters
         """
-        is_place = lambda x,i: (x // 10**(i)) % 10 #extract the digits for 10**i place (0<=i<=5)
-        self.nu_lines_err = is_place(self.ierr,5) #0-9
-        self.line_strength_ref_err = is_place(self.ierr,4) #0-8
-        self.gamma_air_err = is_place(self.ierr,3) #0-8
-        self.gamma_self_err = is_place(self.ierr,2) #0-8
-        self.n_air_err = is_place(self.ierr,1)
-        self.delta_air_err = is_place(self.ierr,0) #0-9
+        is_place = (
+            lambda x, i: (x // 10 ** (i)) % 10
+        )  # extract the digits for 10**i place (0<=i<=5)
+        self.nu_lines_err = is_place(self.ierr, 5)  # 0-9
+        self.line_strength_ref_err = is_place(self.ierr, 4)  # 0-8
+        self.gamma_air_err = is_place(self.ierr, 3)  # 0-8
+        self.gamma_self_err = is_place(self.ierr, 2)  # 0-8
+        self.n_air_err = is_place(self.ierr, 1)
+        self.delta_air_err = is_place(self.ierr, 0)  # 0-9
 
 
 class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
@@ -660,18 +671,21 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         gpp (jnp array): statistical weight
         n_air (jnp array): air temperature exponent
     """
-    def __init__(self,
-                 path,
-                 nurange=[-np.inf, np.inf],
-                 crit=0.,
-                 elower_max=None,
-                 Ttyp=1000.,
-                 isotope=1,
-                 gpu_transfer=False,
-                 inherit_dataframe=False,
-                 activation=True,
-                 parfile=None,
-                 with_error=False):
+
+    def __init__(
+        self,
+        path,
+        nurange=[-np.inf, np.inf],
+        crit=0.0,
+        elower_max=None,
+        Ttyp=1000.0,
+        isotope=1,
+        gpu_transfer=False,
+        inherit_dataframe=False,
+        activation=True,
+        parfile=None,
+        with_error=False,
+    ):
         """Molecular database for HITRAN/HITEMP form.
 
         Args:
@@ -680,27 +694,29 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
             crit: line strength lower limit for extraction
             elower_max: maximum lower state energy, Elower (cm-1)
             Ttyp: typical temperature to calculate Sij(T) used in crit
-            isotope: isotope number, 0 or None = use all isotopes. 
+            isotope: isotope number, 0 or None = use all isotopes.
             gpu_transfer: tranfer data to jnp.array?
             inherit_dataframe: if True, it makes self.df instance available, which needs more DRAM when pickling.
-            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available. 
+            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available.
             parfile: if not none, provide path, then directly load parfile
             with_error: if True, uncertainty indices become available.
         """
 
         self.dbtype = "hitran"
-        MdbCommonHitempHitran.__init__(self,
-                                       path=path,
-                                       nurange=nurange,
-                                       crit=crit,
-                                       elower_max=elower_max,
-                                       Ttyp=Ttyp,
-                                       isotope=isotope,
-                                       gpu_transfer=gpu_transfer,
-                                       inherit_dataframe=inherit_dataframe,
-                                       activation=activation,
-                                       parfile=parfile,
-                                       with_error=with_error)
+        MdbCommonHitempHitran.__init__(
+            self,
+            path=path,
+            nurange=nurange,
+            crit=crit,
+            elower_max=elower_max,
+            Ttyp=Ttyp,
+            isotope=isotope,
+            gpu_transfer=gpu_transfer,
+            inherit_dataframe=inherit_dataframe,
+            activation=activation,
+            parfile=parfile,
+            with_error=with_error,
+        )
 
         HITEMPDatabaseManager.__init__(
             self,
@@ -715,22 +731,23 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
 
         if parfile is not None:
             from radis.api.hitranapi import hit2df
+
             df = hit2df(parfile, engine="vaex", cache="regen")
             if isotope is None:
                 mask = None
             elif isotope == 0:
                 mask = None
             elif isotope > 0:
-                mask = (df["iso"] == isotope)
+                mask = df["iso"] == isotope
         else:
             # Get list of all expected local files for this database:
             local_files, urlnames = self.get_filenames()
 
             # Get missing files
             download_files = self.get_missing_files(local_files)
-            download_files = self.keep_only_relevant(download_files,
-                                                     self.load_wavenum_min,
-                                                     self.load_wavenum_max)
+            download_files = self.keep_only_relevant(
+                download_files, self.load_wavenum_min, self.load_wavenum_max
+            )
             # do not re-download files if they exist in another format :
 
             converted = []
@@ -738,14 +755,11 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
                 if exists(f.replace(".hdf5", ".h5")):
                     update_pytables_to_vaex(f.replace(".hdf5", ".h5"))
                     converted.append(f)
-                download_files = [
-                    f for f in download_files if f not in converted
-                ]
+                download_files = [f for f in download_files if f not in converted]
             # do not re-download remaining files that exist. Let user decide what to do.
             # (download & re-parsing is a long solution!)
             download_files = [
-                f for f in download_files
-                if not exists(f.replace(".hdf5", ".h5"))
+                f for f in download_files if not exists(f.replace(".hdf5", ".h5"))
             ]
 
             # Download files
@@ -761,18 +775,17 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
                 self.clean_download_files()
 
             # Load and return
-            files_loaded = self.keep_only_relevant(local_files,
-                                                   self.load_wavenum_min,
-                                                   self.load_wavenum_max)
-            columns = None,
+            files_loaded = self.keep_only_relevant(
+                local_files, self.load_wavenum_min, self.load_wavenum_max
+            )
+            columns = (None,)
             output = "vaex"
 
             isotope_dfform = _convert_proper_isotope(self.isotope)
             df = self.load(
                 files_loaded,  # filter other files,
                 columns=columns,
-                within=[("iso", isotope_dfform)]
-                if isotope_dfform is not None else [],
+                within=[("iso", isotope_dfform)] if isotope_dfform is not None else [],
                 output=output,
             )
             mask = None
@@ -806,19 +819,19 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         self.gamma_self = df_masked.selbrd.values
         self.elower = df_masked.El.values
         self.gpp = df_masked.gp.values
-        #isotope
+        # isotope
         self.isoid = df_masked.iso.values
         self.uniqiso = np.unique(self.isoid)
         if self.with_error:
-            #uncertainties
+            # uncertainties
             self.ierr = df_masked.ierr.values.to_numpy().astype(np.int64)
 
     def generate_jnp_arrays(self):
         """(re)generate jnp.arrays.
-        
+
         Note:
            We have nd arrays and jnp arrays. We usually apply the mask to nd arrays and then generate jnp array from the corresponding nd array. For instance, self._A is nd array and self.A is jnp array.
-        
+
         """
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
@@ -853,19 +866,22 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         gpp (jnp array): statistical weight
         n_air (jnp array): air temperature exponent
     """
-    def __init__(self,
-                 path,
-                 nurange=[-np.inf, np.inf],
-                 crit=0.,
-                 elower_max=None,
-                 Ttyp=1000.,
-                 isotope=0,
-                 gpu_transfer=False,
-                 inherit_dataframe=False,
-                 activation=True,
-                 parfile=None,
-                 nonair_broadening=False,
-                 with_error=False):
+
+    def __init__(
+        self,
+        path,
+        nurange=[-np.inf, np.inf],
+        crit=0.0,
+        elower_max=None,
+        Ttyp=1000.0,
+        isotope=0,
+        gpu_transfer=False,
+        inherit_dataframe=False,
+        activation=True,
+        parfile=None,
+        nonair_broadening=False,
+        with_error=False,
+    ):
         """Molecular database for HITRAN/HITEMP form.
 
         Args:
@@ -874,26 +890,28 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
             crit: line strength lower limit for extraction
             elower_max: maximum lower state energy, Elower (cm-1)
             Ttyp: typical temperature to calculate Sij(T) used in crit
-            isotope: isotope number. 0 or None= use all isotopes. 
+            isotope: isotope number. 0 or None= use all isotopes.
             gpu_transfer: tranfer data to jnp.array?
             inherit_dataframe: if True, it makes self.df instance available, which needs more DRAM when pickling.
-            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available. 
+            activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df instance available.
             nonair_broadening: If True, background atmospheric broadening parameters(n and gamma) other than air will also be downloaded (e.g. h2, he...)
             with_error: if True, uncertainty indices become available. (Please set drop_non_numeric=False in radis.api.hitranapi)
         """
         self.dbtype = "hitran"
-        MdbCommonHitempHitran.__init__(self,
-                                       path=path,
-                                       nurange=nurange,
-                                       crit=crit,
-                                       elower_max=elower_max,
-                                       Ttyp=Ttyp,
-                                       isotope=isotope,
-                                       gpu_transfer=gpu_transfer,
-                                       inherit_dataframe=inherit_dataframe,
-                                       activation=activation,
-                                       parfile=parfile,
-                                       with_error=with_error)
+        MdbCommonHitempHitran.__init__(
+            self,
+            path=path,
+            nurange=nurange,
+            crit=crit,
+            elower_max=elower_max,
+            Ttyp=Ttyp,
+            isotope=isotope,
+            gpu_transfer=gpu_transfer,
+            inherit_dataframe=inherit_dataframe,
+            activation=activation,
+            parfile=parfile,
+            with_error=with_error,
+        )
 
         # HITRAN ONLY FUNCTIONALITY
         if nonair_broadening:
@@ -903,29 +921,32 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
             self.nonair_broadening = False
             extra_params = None
 
-        HITRANDatabaseManager.__init__(self,
-                                       molecule=self.simple_molecule_name,
-                                       name="HITRAN-{molecule}",
-                                       local_databases=self.path.parent,
-                                       engine="default",
-                                       verbose=True,
-                                       parallel=True,
-                                       extra_params=extra_params)
+        HITRANDatabaseManager.__init__(
+            self,
+            molecule=self.simple_molecule_name,
+            name="HITRAN-{molecule}",
+            local_databases=self.path.parent,
+            engine="default",
+            verbose=True,
+            parallel=True,
+            extra_params=extra_params,
+        )
 
         # Get list of all expected local files for this database:
         local_file = self.get_filenames()
 
         # Download files
-        if with_error: 
+        if with_error:
             # to distinguish hdf5 files with error and without error.
-            local_file = [local_file[0].split('.hdf5')[0] + '_werr.hdf5']
+            local_file = [local_file[0].split(".hdf5")[0] + "_werr.hdf5"]
         download_files = self.get_missing_files(local_file)
         if download_files:
-            self.download_and_parse(download_files,
-                                    cache=True,
-                                    parse_quanta=True,
-                                    add_HITRAN_uncertainty_code=with_error
-                                    )
+            self.download_and_parse(
+                download_files,
+                cache=True,
+                parse_quanta=True,
+                add_HITRAN_uncertainty_code=with_error,
+            )
 
         if len(download_files) > 0:
             self.clean_download_files()
@@ -938,14 +959,14 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         df = self.load(
             local_file,
             columns=columns,
-            within=[("iso",
-                     isotope_dfform)] if isotope_dfform is not None else [],
+            within=[("iso", isotope_dfform)] if isotope_dfform is not None else [],
             # for relevant files, get only the right range :
-            #lower_bound=[("wav", load_wavenum_min)]
-            #if load_wavenum_min is not None else [],
-            #upper_bound=[("wav", load_wavenum_max)]
-            #if load_wavenum_max is not None else [],
-            output=output)
+            # lower_bound=[("wav", load_wavenum_min)]
+            # if load_wavenum_min is not None else [],
+            # upper_bound=[("wav", load_wavenum_max)]
+            # if load_wavenum_max is not None else [],
+            output=output,
+        )
 
         self.isoid = df.iso
         self.uniqiso = np.unique(df.iso.values)
@@ -978,35 +999,35 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
             self.gamma_self = df_load_mask.selbrd.values
             self.elower = df_load_mask.El.values
             self.gpp = df_load_mask.gp.values
-            #isotope
+            # isotope
             self.isoid = df_load_mask.iso.values
             self.uniqiso = np.unique(self.isoid)
             if self.with_error:
-                #uncertainties
+                # uncertainties
                 self.ierr = df_load_mask.ierr.values
 
-            if hasattr(df_load_mask, 'n_h2') and self.nonair_broadening:
+            if hasattr(df_load_mask, "n_h2") and self.nonair_broadening:
                 self.n_h2 = df_load_mask.n_h2.values
                 self.gamma_h2 = df_load_mask.gamma_h2.values
 
-            if hasattr(df_load_mask, 'n_he') and self.nonair_broadening:
+            if hasattr(df_load_mask, "n_he") and self.nonair_broadening:
                 self.n_he = df_load_mask.n_he.values
                 self.gamma_he = df_load_mask.gamma_he.values
 
-            if hasattr(df_load_mask, 'n_co2') and self.nonair_broadening:
+            if hasattr(df_load_mask, "n_co2") and self.nonair_broadening:
                 self.n_co2 = df_load_mask.n_co2.values
                 self.gamma_co2 = df_load_mask.gamma_co2.values
 
-            if hasattr(df_load_mask, 'n_h2o') and self.nonair_broadening:
+            if hasattr(df_load_mask, "n_h2o") and self.nonair_broadening:
                 self.n_h2o = df_load_mask.n_h2o.values
                 self.gamma_h2o = df_load_mask.gamma_h2o.values
 
     def generate_jnp_arrays(self):
         """(re)generate jnp.arrays.
-        
+
         Note:
            We have nd arrays and jnp arrays. We usually apply the mask to nd arrays and then generate jnp array from the corresponding nd array. For instance, self._A is nd array and self.A is jnp array.
-        
+
         """
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
@@ -1022,25 +1043,25 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         if self.with_error:
             self.ierr = jnp.array(self.ierr)
 
-        if hasattr(self.df_load_mask, 'n_h2') and self.nonair_broadening:
+        if hasattr(self.df_load_mask, "n_h2") and self.nonair_broadening:
             self.n_h2 = jnp.array(self.n_h2)
             self.gamma_h2 = jnp.array(self.gamma_h2)
 
-        if hasattr(self.df_load_mask, 'n_he') and self.nonair_broadening:
+        if hasattr(self.df_load_mask, "n_he") and self.nonair_broadening:
             self.n_he = jnp.array(self.n_he)
             self.gamma_he = jnp.array(self.gamma_he)
 
-        if hasattr(self.df_load_mask, 'n_co2') and self.nonair_broadening:
+        if hasattr(self.df_load_mask, "n_co2") and self.nonair_broadening:
             self.n_co2 = jnp.array(self.n_co2)
             self.gamma_co2 = jnp.array(self.gamma_co2)
 
-        if hasattr(self.df_load_mask, 'n_h2o') and self.nonair_broadening:
+        if hasattr(self.df_load_mask, "n_h2o") and self.nonair_broadening:
             self.n_h2o = jnp.array(self.n_h2o)
             self.gamma_h2o = jnp.array(self.gamma_h2o)
 
 
 def _convert_proper_isotope(isotope):
-    """covert isotope (int) to proper type for df 
+    """covert isotope (int) to proper type for df
 
     Args:
         isotope (int or other type): isotope
@@ -1061,13 +1082,13 @@ def _convert_proper_isotope(isotope):
 def _isotope_index_from_isotope_number(isotope, uniqiso):
     """isotope index given HITRAN/HITEMP isotope number
 
-        Args:
-            isotope (int): isotope number
-            uniqiso (nd int array): unique isotope array 
+    Args:
+        isotope (int): isotope number
+        uniqiso (nd int array): unique isotope array
 
-        Returns:
-            int: isotope_index for T_gQT and gQT  
-        """
+    Returns:
+        int: isotope_index for T_gQT and gQT
+    """
     isotope_index = np.where(uniqiso == isotope)[0][0]
     return isotope_index
 
@@ -1075,21 +1096,21 @@ def _isotope_index_from_isotope_number(isotope, uniqiso):
 def _QT_interp(isotope_index, T, T_gQT, gQT):
     """interpolated partition function.
 
-        Note:
-            isotope_index is NOT isotope (number for HITRAN). 
-            isotope_index is index for gQT and T_gQT.
-            _isotope_index_from_isotope_number can be used 
-            to get isotope index from isotope.
-            
-        Args:
-            isotope index: isotope index, index from 0 to len(uniqiso) - 1
-            T: temperature
-            gQT: jnp array of partition function grid
-            T_gQT: jnp array of temperature grid for gQT
+    Note:
+        isotope_index is NOT isotope (number for HITRAN).
+        isotope_index is index for gQT and T_gQT.
+        _isotope_index_from_isotope_number can be used
+        to get isotope index from isotope.
 
-        Returns:
-            Q(idx, T) interpolated in jnp.array
-        """
+    Args:
+        isotope index: isotope index, index from 0 to len(uniqiso) - 1
+        T: temperature
+        gQT: jnp array of partition function grid
+        T_gQT: jnp array of temperature grid for gQT
+
+    Returns:
+        Q(idx, T) interpolated in jnp.array
+    """
 
     return jnp.interp(T, T_gQT[isotope_index], gQT[isotope_index])
 
@@ -1097,44 +1118,45 @@ def _QT_interp(isotope_index, T, T_gQT, gQT):
 def _qr_interp(isotope_index, T, T_gQT, gQT, Tref):
     """interpolated partition function ratio.
 
-        Note:
-            isotope_index is NOT isotope (number for HITRAN). 
-            isotope_index is index for gQT and T_gQT.
-            _isotope_index_from_isotope_number can be used 
-            to get isotope index from isotope.
-    
-        Args:
-            isotope index: isotope index, index from 0 to len(uniqiso) - 1
-            T: temperature
-            gQT: jnp array of partition function grid
-            T_gQT: jnp array of temperature grid for gQT
-            Tref: reference temperature in K
+    Note:
+        isotope_index is NOT isotope (number for HITRAN).
+        isotope_index is index for gQT and T_gQT.
+        _isotope_index_from_isotope_number can be used
+        to get isotope index from isotope.
 
-        Returns:
-            qr(T)=Q(T)/Q(Tref) interpolated in jnp.array
-        """
+    Args:
+        isotope index: isotope index, index from 0 to len(uniqiso) - 1
+        T: temperature
+        gQT: jnp array of partition function grid
+        T_gQT: jnp array of temperature grid for gQT
+        Tref: reference temperature in K
+
+    Returns:
+        qr(T)=Q(T)/Q(Tref) interpolated in jnp.array
+    """
     return _QT_interp(isotope_index, T, T_gQT, gQT) / _QT_interp(
-        isotope_index, Tref, T_gQT, gQT)
+        isotope_index, Tref, T_gQT, gQT
+    )
 
 
 def _qr_interp_lines(T, isoid, uniqiso, T_gQT, gQT, Tref):
     """Partition Function ratio using HAPI partition data.
-        (This function works for JAX environment.)
+    (This function works for JAX environment.)
 
-        Args:
-            T: temperature (K)
-            isoid:
-            uniqiso:
-            gQT: jnp array of partition function grid
-            T_gQT: jnp array of temperature grid for gQT
-            Tref: reference temperature in K
+    Args:
+        T: temperature (K)
+        isoid:
+        uniqiso:
+        gQT: jnp array of partition function grid
+        T_gQT: jnp array of temperature grid for gQT
+        Tref: reference temperature in K
 
-        Returns:
-            Qr_line, partition function ratio array for lines [Nlines]
+    Returns:
+        Qr_line, partition function ratio array for lines [Nlines]
 
-        Note:
-            Nlines=len(self.nu_lines)
-        """
+    Note:
+        Nlines=len(self.nu_lines)
+    """
     qr_line = jnp.zeros(len(isoid))
     for isotope in uniqiso:
         mask_idx = np.where(isoid == isotope)

--- a/src/exojax/spec/hitran.py
+++ b/src/exojax/spec/hitran.py
@@ -51,7 +51,7 @@ def line_strength_numpy(T, Sij0, nu_lines, elower, qr, Tref=Tref_original):
         / qr
         * np.exp(-hcperk * elower * (1.0 / T - 1.0 / Tref))
         * np.expm1(-hcperk * nu_lines / T)
-        / np.expm1(-hcperk * nu_lines / Tref_original)
+        / np.expm1(-hcperk * nu_lines / Tref)
     )
 
 


### PR DESCRIPTION
I found a small bug in `line_strength_numpy` but currently looks no impact.

in hitran.py
```
    return (
        Sij0
        / qr
        * np.exp(-hcperk * elower * (1.0 / T - 1.0 / Tref))
        * np.expm1(-hcperk * nu_lines / T)
        # / np.expm1(-hcperk * nu_lines / Tref_original) # before the PR
        / np.expm1(-hcperk * nu_lines / Tref) #after the PR
    )
```
