### PR TITLE
Raise error when none of the lines in opa.mdb are within opa.nu_grid for opa=OpaPremodit

### DIFF
--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -5,7 +5,7 @@ Notes:
 
 """
 
-__all__ = ['OpaPremodit', 'OpaModit', 'OpaDirect']
+__all__ = ["OpaPremodit", "OpaModit", "OpaDirect"]
 
 from exojax.spec import initspec
 from exojax.spec.lbderror import optimal_params
@@ -16,6 +16,7 @@ from exojax.utils.instfunc import resolution_eslog
 from exojax.utils.constants import Patm
 from exojax.utils.constants import Tref_original
 from exojax.utils.jaxstatus import check_jax64bit
+from exojax.utils.checkarray import is_outside_range
 import jax.numpy as jnp
 from jax import jit
 from jax import vmap
@@ -23,9 +24,9 @@ import numpy as np
 import warnings
 
 
-class OpaCalc():
-    """Common Opacity Calculator Class
-    """
+class OpaCalc:
+    """Common Opacity Calculator Class"""
+
     def __init__(self):
         self.opainfo = None
         self.method = None  # which opacity calc method is used
@@ -39,40 +40,40 @@ class OpaPremodit(OpaCalc):
         opainfo: information set used in PreMODIT
 
     """
-    def __init__(self,
-                 mdb,
-                 nu_grid,
-                 diffmode=0,
-                 broadening_resolution={
-                     "mode": "manual",
-                     "value": 0.2
-                 },
-                 auto_trange=None,
-                 manual_params=None,
-                 dit_grid_resolution=None,
-                 allow_32bit=False,
-                 wavelength_order="descending"):
+
+    def __init__(
+        self,
+        mdb,
+        nu_grid,
+        diffmode=0,
+        broadening_resolution={"mode": "manual", "value": 0.2},
+        auto_trange=None,
+        manual_params=None,
+        dit_grid_resolution=None,
+        allow_32bit=False,
+        wavelength_order="descending",
+    ):
         """initialization of OpaPremodit
 
         Note:
-            If auto_trange nor manual_params is not given in arguments, 
+            If auto_trange nor manual_params is not given in arguments,
             use manual_setting()
             or provide self.dE, self.Tref, self.Twt and apply self.apply_params()
-            
+
         Note:
             The option of "broadening_parameter_resolution" controls the resolution of broadening parameters.
             When you wanna use the manual resolution, set broadening_parameter_resolution = {mode: "manual", value: 0.2}.
             When you wanna use the min and max values of broadening parameters in database, set broadening_parameter_resolution = {mode: "minmax", value: None}.
             When you wanna give single broadening parameters: set broadening_parameter_resolution = {mode: "single", value: None} the median values of gamma_ref, n_Texp are used
-            or set broadening_parameter_resolution = {mode: "single", value: [gamma_ref, n_Texp]} values are at 296K, for the fixed parameter set.  
-            The use of device memory: "manual" >= "minmax" > "single". In general, small value (such as 0.2) requires large device memory. 
+            or set broadening_parameter_resolution = {mode: "single", value: [gamma_ref, n_Texp]} values are at 296K, for the fixed parameter set.
+            The use of device memory: "manual" >= "minmax" > "single". In general, small value (such as 0.2) requires large device memory.
             We recommend to check the difference of the final specrum between "manual", "minmax", and "single" when you had a device memory problem.
-            
+
         Args:
             mdb (mdb class): mdbExomol, mdbHitemp, mdbHitran
             nu_grid (): wavenumber grid (cm-1)
             diffmode (int, optional): _description_. Defaults to 0.
-            broadening_resolution (dict, optional): definition of the broadening parameter resolution. Default to {"mode": "manual", value: 0.2}. See Note. 
+            broadening_resolution (dict, optional): definition of the broadening parameter resolution. Default to {"mode": "manual", value: 0.2}. See Note.
             auto_trange (optional): temperature range [Tl, Tu], in which line strength is within 1 % prescision. Defaults to None.
             manual_params (optional): premodit parameter set [dE, Tref, Twt]. Defaults to None.
             dit_grid_resolution (float, optional): force to set broadening_parameter_resolution={mode:manual, value: dit_grid_resolution}), ignores broadening_parameter_resolution.
@@ -82,29 +83,33 @@ class OpaPremodit(OpaCalc):
         super().__init__()
         check_jax64bit(allow_32bit)
 
-        #default setting
+        # default setting
         self.method = "premodit"
         self.diffmode = diffmode
         self.warning = True
         self.nu_grid = nu_grid
         self.wavelength_order = wavelength_order
-        self.wav = nu2wav(self.nu_grid,
-                          wavelength_order=self.wavelength_order,
-                          unit="AA")
+        self.wav = nu2wav(
+            self.nu_grid, wavelength_order=self.wavelength_order, unit="AA"
+        )
         self.resolution = resolution_eslog(nu_grid)
         self.mdb = mdb
         self.ngrid_broadpar = None
 
-        #broadening parameter setting
-        self.determine_broadening_parameter_resolution(broadening_resolution,
-                                                       dit_grid_resolution)
+        # check if the mdb lines are in nu_grid
+        if is_outside_range(self.mdb.nu_lines, self.nu_grid[0], self.nu_grid[-1]):
+            raise ValueError("None of the lines in mdb are within nu_grid.")
+
+        # broadening parameter setting
+        self.determine_broadening_parameter_resolution(
+            broadening_resolution, dit_grid_resolution
+        )
         self.broadening_parameters_setting()
 
         if auto_trange is not None:
             self.auto_setting(auto_trange[0], auto_trange[1])
         elif manual_params is not None:
-            self.manual_setting(manual_params[0], manual_params[1],
-                                manual_params[2])
+            self.manual_setting(manual_params[0], manual_params[1], manual_params[2])
         else:
             print("OpaPremodit: initialization without parameters setting")
             print("Call self.apply_params() to complete the setting.")
@@ -145,26 +150,29 @@ class OpaPremodit(OpaCalc):
         if np.mod(Nx, 2) == 1:
             Nx = Nx + 1
         self.nu_grid, self.wav, self.resolution = wavenumber_grid(
-            x0, x1, Nx, unit=unit, xsmode="premodit")
+            x0, x1, Nx, unit=unit, xsmode="premodit"
+        )
 
     def set_Tref_broadening_to_midpoint(self):
-        """Set self.Tref_broadening using log midpoint of Tmax and Tmin
-        """
+        """Set self.Tref_broadening using log midpoint of Tmax and Tmin"""
         from exojax.spec.premodit import reference_temperature_broadening_at_midpoint
+
         self.Tref_broadening = reference_temperature_broadening_at_midpoint(
-            self.Tmin, self.Tmax)
-        print("OpaPremodit: Tref_broadening is set to ", self.Tref_broadening,
-              "K")
+            self.Tmin, self.Tmax
+        )
+        print("OpaPremodit: Tref_broadening is set to ", self.Tref_broadening, "K")
 
     def determine_broadening_parameter_resolution(
-            self, broadening_parameter_resolution, dit_grid_resolution):
+        self, broadening_parameter_resolution, dit_grid_resolution
+    ):
         if dit_grid_resolution is not None:
             warnings.warn(
                 "dit_grid_resolution is not None. Ignoring broadening_parameter_resolution.",
-                UserWarning)
+                UserWarning,
+            )
             self.broadening_parameter_resolution = {
                 "mode": "manual",
-                "value": dit_grid_resolution
+                "value": dit_grid_resolution,
             }
         else:
             self.broadening_parameter_resolution = broadening_parameter_resolution
@@ -195,8 +203,8 @@ class OpaPremodit(OpaCalc):
         """convert gamma_ref to the regular formalization and noramlize it for Tref_braodening
 
         Notes:
-            gamma (T) = (gamma at Tref_original) * (Tref_original/Tref_broadening)**n 
-            * (T/Tref_broadening)**-n * (P/1bar) 
+            gamma (T) = (gamma at Tref_original) * (Tref_original/Tref_broadening)**n
+            * (T/Tref_broadening)**-n * (P/1bar)
 
         Args:
             mdb (_type_): mdb instance
@@ -207,20 +215,18 @@ class OpaPremodit(OpaCalc):
                 "OpaPremodit: gamma_air and n_air are used. gamma_ref = gamma_air/Patm"
             )
             self.n_Texp = mdb.n_air
-            reference_factor = (Tref_original /
-                                self.Tref_broadening)**(self.n_Texp)
+            reference_factor = (Tref_original / self.Tref_broadening) ** (self.n_Texp)
             self.gamma_ref = mdb.gamma_air * reference_factor / Patm
         elif mdb.dbtype == "exomol":
             self.n_Texp = mdb.n_Texp
-            reference_factor = (Tref_original /
-                                self.Tref_broadening)**(self.n_Texp)
+            reference_factor = (Tref_original / self.Tref_broadening) ** (self.n_Texp)
             self.gamma_ref = mdb.alpha_ref * reference_factor
 
     def apply_params(self):
         self.mdb.change_reference_temperature(self.Tref)
         self.dbtype = self.mdb.dbtype
 
-        #broadening
+        # broadening
         if self.single_broadening:
             print("OpaPremodit: a single broadening parameter set is used.")
             self.Tref_broadening = Tref_original
@@ -246,11 +252,19 @@ class OpaPremodit(OpaCalc):
             diffmode=self.diffmode,
             single_broadening=self.single_broadening,
             single_broadening_parameters=self.single_broadening_parameters,
-            warning=self.warning)
+            warning=self.warning,
+        )
         self.ready = True
 
-        lbd_coeff, multi_index_uniqgrid, elower_grid, \
-            ngamma_ref_grid, n_Texp_grid, R, pmarray = self.opainfo
+        (
+            lbd_coeff,
+            multi_index_uniqgrid,
+            elower_grid,
+            ngamma_ref_grid,
+            n_Texp_grid,
+            R,
+            pmarray,
+        ) = self.opainfo
         self.ngrid_broadpar = len(multi_index_uniqgrid)
         self.ngrid_elower = len(elower_grid)
 
@@ -260,8 +274,15 @@ class OpaPremodit(OpaCalc):
         from exojax.spec.premodit import xsvector_second
         from exojax.spec import normalized_doppler_sigma
 
-        lbd_coeff, multi_index_uniqgrid, elower_grid, \
-            ngamma_ref_grid, n_Texp_grid, R, pmarray = self.opainfo
+        (
+            lbd_coeff,
+            multi_index_uniqgrid,
+            elower_grid,
+            ngamma_ref_grid,
+            n_Texp_grid,
+            R,
+            pmarray,
+        ) = self.opainfo
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
 
         if self.mdb.dbtype == "hitran":
@@ -270,28 +291,64 @@ class OpaPremodit(OpaCalc):
             qt = self.mdb.qr_interp(T)
 
         if self.diffmode == 0:
-            return xsvector_zeroth(T, P, nsigmaD, lbd_coeff, self.Tref, R,
-                                   pmarray, self.nu_grid, elower_grid,
-                                   multi_index_uniqgrid, ngamma_ref_grid,
-                                   n_Texp_grid, qt, self.Tref_broadening)
+            return xsvector_zeroth(
+                T,
+                P,
+                nsigmaD,
+                lbd_coeff,
+                self.Tref,
+                R,
+                pmarray,
+                self.nu_grid,
+                elower_grid,
+                multi_index_uniqgrid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                qt,
+                self.Tref_broadening,
+            )
         elif self.diffmode == 1:
-            return xsvector_first(T, P, nsigmaD, lbd_coeff, self.Tref,
-                                  self.Twt, R, pmarray, self.nu_grid,
-                                  elower_grid, multi_index_uniqgrid,
-                                  ngamma_ref_grid, n_Texp_grid, qt,
-                                  self.Tref_broadening)
+            return xsvector_first(
+                T,
+                P,
+                nsigmaD,
+                lbd_coeff,
+                self.Tref,
+                self.Twt,
+                R,
+                pmarray,
+                self.nu_grid,
+                elower_grid,
+                multi_index_uniqgrid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                qt,
+                self.Tref_broadening,
+            )
         elif self.diffmode == 2:
-            return xsvector_second(T, P, nsigmaD, lbd_coeff, self.Tref,
-                                   self.Twt, R, pmarray, self.nu_grid,
-                                   elower_grid, multi_index_uniqgrid,
-                                   ngamma_ref_grid, n_Texp_grid, qt,
-                                   self.Tref_broadening)
+            return xsvector_second(
+                T,
+                P,
+                nsigmaD,
+                lbd_coeff,
+                self.Tref,
+                self.Twt,
+                R,
+                pmarray,
+                self.nu_grid,
+                elower_grid,
+                multi_index_uniqgrid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                qt,
+                self.Tref_broadening,
+            )
 
     def xsmatrix(self, Tarr, Parr):
         """cross section matrix
 
         Args:
-            Tarr (): tempearture array in K 
+            Tarr (): tempearture array in K
             Parr (): pressure array in bar
 
         Raises:
@@ -304,8 +361,16 @@ class OpaPremodit(OpaCalc):
         from exojax.spec.premodit import xsmatrix_first
         from exojax.spec.premodit import xsmatrix_second
         from jax import vmap
-        lbd_coeff, multi_index_uniqgrid, elower_grid, \
-            ngamma_ref_grid, n_Texp_grid, R, pmarray = self.opainfo
+
+        (
+            lbd_coeff,
+            multi_index_uniqgrid,
+            elower_grid,
+            ngamma_ref_grid,
+            n_Texp_grid,
+            R,
+            pmarray,
+        ) = self.opainfo
 
         if self.mdb.dbtype == "hitran":
             qtarr = vmap(self.mdb.qr_interp, (None, 0))(self.mdb.isotope, Tarr)
@@ -313,32 +378,65 @@ class OpaPremodit(OpaCalc):
             qtarr = vmap(self.mdb.qr_interp)(Tarr)
 
         if self.diffmode == 0:
-            return xsmatrix_zeroth(Tarr, Parr, self.Tref, R, pmarray,
-                                   lbd_coeff, self.nu_grid, ngamma_ref_grid,
-                                   n_Texp_grid, multi_index_uniqgrid,
-                                   elower_grid, self.mdb.molmass, qtarr,
-                                   self.Tref_broadening)
+            return xsmatrix_zeroth(
+                Tarr,
+                Parr,
+                self.Tref,
+                R,
+                pmarray,
+                lbd_coeff,
+                self.nu_grid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                multi_index_uniqgrid,
+                elower_grid,
+                self.mdb.molmass,
+                qtarr,
+                self.Tref_broadening,
+            )
 
         elif self.diffmode == 1:
-            return xsmatrix_first(Tarr, Parr, self.Tref, self.Twt, R, pmarray,
-                                  lbd_coeff, self.nu_grid, ngamma_ref_grid,
-                                  n_Texp_grid, multi_index_uniqgrid,
-                                  elower_grid, self.mdb.molmass, qtarr,
-                                  self.Tref_broadening)
+            return xsmatrix_first(
+                Tarr,
+                Parr,
+                self.Tref,
+                self.Twt,
+                R,
+                pmarray,
+                lbd_coeff,
+                self.nu_grid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                multi_index_uniqgrid,
+                elower_grid,
+                self.mdb.molmass,
+                qtarr,
+                self.Tref_broadening,
+            )
 
         elif self.diffmode == 2:
-            return xsmatrix_second(Tarr, Parr, self.Tref, self.Twt, R, pmarray,
-                                   lbd_coeff, self.nu_grid, ngamma_ref_grid,
-                                   n_Texp_grid, multi_index_uniqgrid,
-                                   elower_grid, self.mdb.molmass, qtarr,
-                                   self.Tref_broadening)
+            return xsmatrix_second(
+                Tarr,
+                Parr,
+                self.Tref,
+                self.Twt,
+                R,
+                pmarray,
+                lbd_coeff,
+                self.nu_grid,
+                ngamma_ref_grid,
+                n_Texp_grid,
+                multi_index_uniqgrid,
+                elower_grid,
+                self.mdb.molmass,
+                qtarr,
+                self.Tref_broadening,
+            )
 
         else:
             raise ValueError("diffmode should be 0, 1, 2.")
 
-    def plot_broadening_parameters(self,
-                                   figname="broadpar_grid.png",
-                                   crit=300000):
+    def plot_broadening_parameters(self, figname="broadpar_grid.png", crit=300000):
         """plot broadening parameters and grids
 
         Args:
@@ -346,13 +444,20 @@ class OpaPremodit(OpaCalc):
             crit (int, optional): sampling criterion. Defaults to 300000. when the number of lines is huge and if it exceeded ~ crit, we sample the lines to reduce the computation.
         """
         from exojax.plot.opaplot import plot_broadening_parameters_grids
+
         _, _, _, ngamma_ref_grid, n_Texp_grid, _, _ = self.opainfo
         gamma_ref_in = self.gamma_ref
         n_Texp_in = self.n_Texp
-        plot_broadening_parameters_grids(ngamma_ref_grid, n_Texp_grid,
-                                         self.nu_grid, self.resolution,
-                                         gamma_ref_in, n_Texp_in, crit,
-                                         figname)
+        plot_broadening_parameters_grids(
+            ngamma_ref_grid,
+            n_Texp_grid,
+            self.nu_grid,
+            self.resolution,
+            gamma_ref_in,
+            n_Texp_in,
+            crit,
+            figname,
+        )
 
 
 class OpaModit(OpaCalc):
@@ -362,15 +467,18 @@ class OpaModit(OpaCalc):
         opainfo: information set used in MODIT: cont_nu, index_nu, R, pmarray
 
     """
-    def __init__(self,
-                 mdb,
-                 nu_grid,
-                 Tarr_list=None,
-                 Parr=None,
-                 Pself_ref=None,
-                 dit_grid_resolution=0.2,
-                 allow_32bit=False,
-                 wavelength_order="descending"):
+
+    def __init__(
+        self,
+        mdb,
+        nu_grid,
+        Tarr_list=None,
+        Parr=None,
+        Pself_ref=None,
+        dit_grid_resolution=0.2,
+        allow_32bit=False,
+        wavelength_order="descending",
+    ):
         """initialization of OpaModit
 
         Note:
@@ -385,21 +493,21 @@ class OpaModit(OpaCalc):
             dit_grid_resolution (float, optional): dit grid resolution. Defaxults to 0.2.
             allow_32bit (bool, optional): If True, allow 32bit mode of JAX. Defaults to False.
             wavlength order: wavelength order: "ascending" or "descending"
-            
+
         Raises:
             ValueError: _description_
         """
         super().__init__()
         check_jax64bit(allow_32bit)
 
-        #default setting
+        # default setting
         self.method = "modit"
         self.warning = True
         self.nu_grid = nu_grid
         self.wavelength_order = wavelength_order
-        self.wav = nu2wav(self.nu_grid,
-                          wavelength_order=self.wavelength_order,
-                          unit="AA")
+        self.wav = nu2wav(
+            self.nu_grid, wavelength_order=self.wavelength_order, unit="AA"
+        )
         self.resolution = resolution_eslog(nu_grid)
         self.mdb = mdb
         self.dit_grid_resolution = dit_grid_resolution
@@ -409,8 +517,7 @@ class OpaModit(OpaCalc):
         if Tarr_list is not None and Parr is not None:
             self.setdgm(Tarr_list, Parr, Pself_ref=Pself_ref)
         else:
-            warnings.warn("Tarr_list/Parr are needed for xsmatrix.",
-                          UserWarning)
+            warnings.warn("Tarr_list/Parr are needed for xsmatrix.", UserWarning)
 
     def apply_params(self):
         self.dbtype = self.mdb.dbtype
@@ -426,7 +533,7 @@ class OpaModit(OpaCalc):
             Pself (float, optional): self pressure for HITEMP/HITRAN. Defaults to 0.0.
 
         Returns:
-            1D array: cross section in cm2 
+            1D array: cross section in cm2
         """
         from exojax.spec import normalized_doppler_sigma, gamma_natural
         from exojax.spec.hitran import line_strength
@@ -441,24 +548,35 @@ class OpaModit(OpaCalc):
         if self.mdb.dbtype == "hitran":
             qt = self.mdb.qr_interp(self.mdb.isotope, T)
             gammaL = gamma_hitran(
-                P, T, Pself, self.mdb.n_air, self.mdb.gamma_air,
-                self.mdb.gamma_self) + gamma_natural(self.mdb.A)
+                P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
+            ) + gamma_natural(self.mdb.A)
         elif self.mdb.dbtype == "exomol":
             qt = self.mdb.qr_interp(T)
-            gammaL = gamma_exomol(P, T, self.mdb.n_Texp,
-                                  self.mdb.alpha_ref) + gamma_natural(
-                                      self.mdb.A)
+            gammaL = gamma_exomol(
+                P, T, self.mdb.n_Texp, self.mdb.alpha_ref
+            ) + gamma_natural(self.mdb.A)
         dv_lines = self.mdb.nu_lines / R
         ngammaL = gammaL / dv_lines
 
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
-        Sij = line_strength(T, self.mdb.logsij0, self.mdb.nu_lines,
-                            self.mdb.elower, qt, self.mdb.Tref)
+        Sij = line_strength(
+            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, self.mdb.Tref
+        )
 
         ngammaL_grid = ditgrid_log_interval(
-            ngammaL, dit_grid_resolution=self.dit_grid_resolution)
-        return xsvector_scanfft(cont_nu, index_nu, R, pmarray, nsigmaD,
-                                ngammaL, Sij, self.nu_grid, ngammaL_grid)
+            ngammaL, dit_grid_resolution=self.dit_grid_resolution
+        )
+        return xsvector_scanfft(
+            cont_nu,
+            index_nu,
+            R,
+            pmarray,
+            nsigmaD,
+            ngammaL,
+            Sij,
+            self.nu_grid,
+            ngammaL_grid,
+        )
 
     def setdgm(self, Tarr_list, Parr, Pself_ref=None):
         """_summary_
@@ -485,16 +603,19 @@ class OpaModit(OpaCalc):
         set_dgm_minmax = []
         for Tarr in Tarr_list:
             if self.mdb.dbtype == "exomol":
-                SijM, ngammaLM, nsigmaDl = exomol(self.mdb, Tarr, Parr, R,
-                                                  self.mdb.molmass)
+                SijM, ngammaLM, nsigmaDl = exomol(
+                    self.mdb, Tarr, Parr, R, self.mdb.molmass
+                )
             elif self.mdb.dbtype == "hitran":
-                SijM, ngammaLM, nsigmaDl = hitran(self.mdb, Tarr, Parr,
-                                                  Pself_ref, R,
-                                                  self.mdb.molmass)
+                SijM, ngammaLM, nsigmaDl = hitran(
+                    self.mdb, Tarr, Parr, Pself_ref, R, self.mdb.molmass
+                )
             set_dgm_minmax.append(
-                minmax_ditgrid_matrix(ngammaLM, self.dit_grid_resolution))
+                minmax_ditgrid_matrix(ngammaLM, self.dit_grid_resolution)
+            )
         dgm_ngammaL = precompute_modit_ditgrid_matrix(
-            set_dgm_minmax, dit_grid_resolution=self.dit_grid_resolution)
+            set_dgm_minmax, dit_grid_resolution=self.dit_grid_resolution
+        )
         self.dgm_ngammaL = jnp.array(dgm_ngammaL)
 
     def xsmatrix(self, Tarr, Parr):
@@ -504,7 +625,7 @@ class OpaModit(OpaCalc):
             Currently Pself is regarded to be zero for HITEMP/HITRAN
 
         Args:
-            Tarr (): tempearture array in K 
+            Tarr (): tempearture array in K
             Parr (): pressure array in bar
 
         Raises:
@@ -516,27 +637,36 @@ class OpaModit(OpaCalc):
         from exojax.spec.modit_scanfft import xsmatrix_scanfft
         from exojax.spec.modit import exomol
         from exojax.spec.modit import hitran
+
         cont_nu, index_nu, R, pmarray = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            #qtarr = vmap(self.mdb.qr_interp, (None, 0))(self.mdb.isotope, Tarr)
-            SijM, ngammaLM, nsigmaDl = hitran(self.mdb, Tarr, Parr,
-                                              np.zeros_like(Parr), R,
-                                              self.mdb.molmass)
+            # qtarr = vmap(self.mdb.qr_interp, (None, 0))(self.mdb.isotope, Tarr)
+            SijM, ngammaLM, nsigmaDl = hitran(
+                self.mdb, Tarr, Parr, np.zeros_like(Parr), R, self.mdb.molmass
+            )
         elif self.mdb.dbtype == "exomol":
-            #qtarr = vmap(self.mdb.qr_interp)(Tarr)
-            SijM, ngammaLM, nsigmaDl = exomol(self.mdb, Tarr, Parr, R,
-                                              self.mdb.molmass)
+            # qtarr = vmap(self.mdb.qr_interp)(Tarr)
+            SijM, ngammaLM, nsigmaDl = exomol(self.mdb, Tarr, Parr, R, self.mdb.molmass)
 
-        return xsmatrix_scanfft(cont_nu, index_nu, R, pmarray, nsigmaDl,
-                                ngammaLM, SijM, self.nu_grid, self.dgm_ngammaL)
+        return xsmatrix_scanfft(
+            cont_nu,
+            index_nu,
+            R,
+            pmarray,
+            nsigmaDl,
+            ngammaLM,
+            SijM,
+            self.nu_grid,
+            self.dgm_ngammaL,
+        )
 
 
 class OpaDirect(OpaCalc):
     def __init__(self, mdb, nu_grid, wavelength_order="descending"):
         """initialization of OpaDirect (LPF)
 
-            
+
 
         Args:
             mdb (mdb class): mdbExomol, mdbHitemp, mdbHitran
@@ -544,14 +674,14 @@ class OpaDirect(OpaCalc):
         """
         super().__init__()
 
-        #default setting
+        # default setting
         self.method = "lpf"
         self.warning = True
         self.nu_grid = nu_grid
         self.wavelength_order = wavelength_order
-        self.wav = nu2wav(self.nu_grid,
-                          wavelength_order=self.wavelength_order,
-                          unit="AA")
+        self.wav = nu2wav(
+            self.nu_grid, wavelength_order=self.wavelength_order, unit="AA"
+        )
         self.mdb = mdb
         self.apply_params()
 
@@ -569,7 +699,7 @@ class OpaDirect(OpaCalc):
             Pself (float, optional): self pressure for HITEMP/HITRAN. Defaults to 0.0.
 
         Returns:
-            1D array: cross section in cm2 
+            1D array: cross section in cm2
         """
         from exojax.spec import gamma_natural
         from exojax.spec import doppler_sigma
@@ -583,16 +713,17 @@ class OpaDirect(OpaCalc):
         if self.mdb.dbtype == "hitran":
             qt = self.mdb.qr_interp(self.mdb.isotope, T)
             gammaL = gamma_hitran(
-                P, T, Pself, self.mdb.n_air, self.mdb.gamma_air,
-                self.mdb.gamma_self) + gamma_natural(self.mdb.A)
+                P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
+            ) + gamma_natural(self.mdb.A)
         elif self.mdb.dbtype == "exomol":
             qt = self.mdb.qr_interp(T)
-            gammaL = gamma_exomol(P, T, self.mdb.n_Texp,
-                                  self.mdb.alpha_ref) + gamma_natural(
-                                      self.mdb.A)
+            gammaL = gamma_exomol(
+                P, T, self.mdb.n_Texp, self.mdb.alpha_ref
+            ) + gamma_natural(self.mdb.A)
         sigmaD = doppler_sigma(self.mdb.nu_lines, T, self.mdb.molmass)
-        Sij = line_strength(T, self.mdb.logsij0, self.mdb.nu_lines,
-                            self.mdb.elower, qt, self.mdb.Tref)
+        Sij = line_strength(
+            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, self.mdb.Tref
+        )
         return xsvector_lpf(numatrix, sigmaD, gammaL, Sij)
 
     def xsmatrix(self, Tarr, Parr):
@@ -602,7 +733,7 @@ class OpaDirect(OpaCalc):
             Currently Pself is regarded to be zero for HITEMP/HITRAN
 
         Args:
-            Tarr (): tempearture array in K 
+            Tarr (): tempearture array in K
             Parr (): pressure array in bar
 
         Raises:
@@ -625,43 +756,103 @@ class OpaDirect(OpaCalc):
             vmapqt = vmap(self.mdb.qr_interp, (None, 0))
             qt = vmapqt(self.mdb.isotope, Tarr)
             vmaphitran = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))
-            gammaLM = vmaphitran(Parr, Tarr, np.zeros_like(Parr),
-                                 self.mdb.n_air, self.mdb.gamma_air,
-                                 self.mdb.gamma_self) + gamma_natural(
-                                     self.mdb.A)
-            SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines,
-                                   self.mdb.elower, qt, self.mdb.Tref)
-            sigmaDM = jit(vmap(doppler_sigma,
-                            (None, 0, None)))(self.mdb.nu_lines, Tarr,
-                                                self.mdb.molmass)
+            gammaLM = vmaphitran(
+                Parr,
+                Tarr,
+                np.zeros_like(Parr),
+                self.mdb.n_air,
+                self.mdb.gamma_air,
+                self.mdb.gamma_self,
+            ) + gamma_natural(self.mdb.A)
+            SijM = vmaplinestrengh(
+                Tarr,
+                self.mdb.logsij0,
+                self.mdb.nu_lines,
+                self.mdb.elower,
+                qt,
+                self.mdb.Tref,
+            )
+            sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
+                self.mdb.nu_lines, Tarr, self.mdb.molmass
+            )
         elif self.mdb.dbtype == "exomol":
             vmapqt = vmap(self.mdb.qr_interp)
             qt = vmapqt(Tarr)
             vmapexomol = jit(vmap(gamma_exomol, (0, 0, None, None)))
-            gammaLMP = vmapexomol(Parr, Tarr, self.mdb.n_Texp,
-                                  self.mdb.alpha_ref)
+            gammaLMP = vmapexomol(Parr, Tarr, self.mdb.n_Texp, self.mdb.alpha_ref)
             gammaLMN = gamma_natural(self.mdb.A)
             gammaLM = gammaLMP + gammaLMN[None, :]
-            SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines,
-                                   self.mdb.elower, qt, self.mdb.Tref)
-            sigmaDM = jit(vmap(doppler_sigma,
-                            (None, 0, None)))(self.mdb.nu_lines, Tarr,
-                                                self.mdb.molmass)
+            SijM = vmaplinestrengh(
+                Tarr,
+                self.mdb.logsij0,
+                self.mdb.nu_lines,
+                self.mdb.elower,
+                qt,
+                self.mdb.Tref,
+            )
+            sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
+                self.mdb.nu_lines, Tarr, self.mdb.molmass
+            )
         elif (self.mdb.dbtype == "kurucz") or (self.mdb.dbtype == "vald"):
-            qt_284=vmap(self.mdb.QT_interp_284)(Tarr)
+            qt_284 = vmap(self.mdb.QT_interp_284)(Tarr)
             qt_K = jnp.zeros([len(self.mdb.QTmask), len(Tarr)])
             for i, mask in enumerate(self.mdb.QTmask):
-                qt_K = qt_K.at[i].set(qt_284[:,mask]) #e.g., qt_284[:,76] #Fe I
-            qt_K = jnp.array(qt_K)     
-            vmapvald3 = jit(vmap(gamma_vald3,(0,0,0,0,None,None,None,None,None,None,None,None,None,None,None)))
-            PH,PHe,PHH = Parr*self.mdb.vmrH, Parr*self.mdb.vmrHe, Parr*self.mdb.vmrHH 
-            gammaLM = vmapvald3(Tarr, PH, PHH, PHe, self.mdb.ielem, self.mdb.iion, \
-                                self.mdb.dev_nu_lines, self.mdb.elower, self.mdb.eupper, \
-                                self.mdb.atomicmass, self.mdb.ionE, \
-                                self.mdb.gamRad, self.mdb.gamSta, self.mdb.vdWdamp, 1.0)
-            SijM = vmaplinestrengh(Tarr, self.mdb.logsij0, self.mdb.nu_lines, \
-                                    self.mdb.elower, qt_K.T, self.mdb.Tref)
-            sigmaDM = jit(vmap(doppler_sigma,(None,0,None)))\
-                (self.mdb.nu_lines, Tarr, self.mdb.atomicmass)
+                qt_K = qt_K.at[i].set(qt_284[:, mask])  # e.g., qt_284[:,76] #Fe I
+            qt_K = jnp.array(qt_K)
+            vmapvald3 = jit(
+                vmap(
+                    gamma_vald3,
+                    (
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    ),
+                )
+            )
+            PH, PHe, PHH = (
+                Parr * self.mdb.vmrH,
+                Parr * self.mdb.vmrHe,
+                Parr * self.mdb.vmrHH,
+            )
+            gammaLM = vmapvald3(
+                Tarr,
+                PH,
+                PHH,
+                PHe,
+                self.mdb.ielem,
+                self.mdb.iion,
+                self.mdb.dev_nu_lines,
+                self.mdb.elower,
+                self.mdb.eupper,
+                self.mdb.atomicmass,
+                self.mdb.ionE,
+                self.mdb.gamRad,
+                self.mdb.gamSta,
+                self.mdb.vdWdamp,
+                1.0,
+            )
+            SijM = vmaplinestrengh(
+                Tarr,
+                self.mdb.logsij0,
+                self.mdb.nu_lines,
+                self.mdb.elower,
+                qt_K.T,
+                self.mdb.Tref,
+            )
+            sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
+                self.mdb.nu_lines, Tarr, self.mdb.atomicmass
+            )
 
         return xsmatrix_lpf(numatrix, sigmaDM, gammaLM, SijM)

--- a/src/exojax/utils/checkarray.py
+++ b/src/exojax/utils/checkarray.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def is_sorted(x):
     """Check if a list is sorted in ascending or descending order.
 
@@ -14,8 +17,31 @@ def is_sorted(x):
     if isinstance(x, (int, float, str, bool)):
         return "single"
     elif all(a <= b for a, b in zip(x, x[1:])):
-        return 'ascending'
+        return "ascending"
     elif all(a >= b for a, b in zip(x, x[1:])):
-        return 'descending'
+        return "descending"
     else:
-        return 'unordered'
+        return "unordered"
+
+
+def is_outside_range(xarr, xs, xe):
+    """
+    Check if all elements in the array are outside the specified range.
+
+    Args:
+        xarr (numpy.ndarray): An array of numerical values.
+        xs (float): The start of the range (exclusive).
+        xe (float): The end of the range (exclusive).
+
+    Returns:
+        bool: True if all elements in xarr are outside the range (xs, xe), False otherwise.
+
+    Examples:
+        >>> xarr = np.array([1.2, 1.4, 1.7, 1.3, 1.0])
+        >>> xs = 0.7
+        >>> xe = 0.8
+        >>> result = is_outside_range(xarr, xs, xe) #-> True
+
+        
+    """
+    return not np.any((xarr > xs) & (xarr < xe))

--- a/tests/integration/api/inconsistent_nu_error_test.py
+++ b/tests/integration/api/inconsistent_nu_error_test.py
@@ -1,0 +1,42 @@
+from exojax.spec.api import MdbHitran
+from exojax.spec.opacalc import OpaPremodit
+from exojax.utils.grids import wavenumber_grid
+from exojax.utils.checkarray import is_outside_range
+import numpy as np
+import pytest
+
+def test_raise_error_in_premodit_when_no_mdblines_in_nu_grid():
+    wavelength_start = 7100.0 #AA
+    wavelength_end = 7450.0 #AA
+
+    wavenumber_start = 7100.0 #cm-1
+    wavenumber_end = 7450.0 #cm-1
+
+    N=40000
+    mdb_water = MdbHitran("H2O", nurange=[1.e8/wavelength_end, 1.e8/wavelength_start], isotope=0)
+    nus, wav, res = wavenumber_grid(wavenumber_start, wavenumber_end, N, xsmode="premodit")
+
+    print("opa nu range", nus[0],nus[-1])
+    print("mdb nu range", np.min(mdb_water.nu_lines), np.max(mdb_water.nu_lines))
+    print(is_outside_range(mdb_water.nu_lines,nus[0],nus[-1]))
+
+    with pytest.raises(ValueError):
+        opa = OpaPremodit(mdb_water, nu_grid=nus, allow_32bit=True, auto_trange=[150.0,250.0])
+
+
+def test_no_error_in_premodit_when_mdblines_in_nu_grid():
+    wavelength_start = 7100.0 #AA
+    wavelength_end = 7450.0 #AA
+
+    wavenumber_start = 1.e8/wavelength_end
+    wavenumber_end = 1.e8/wavelength_start 
+
+    N=40000
+    mdb_water = MdbHitran("H2O", nurange=[1.e8/wavelength_end, 1.e8/wavelength_start], isotope=0)
+    nus, wav, res = wavenumber_grid(wavenumber_start, wavenumber_end, N, xsmode="premodit")
+
+    print("opa nu range", nus[0],nus[-1])
+    print("mdb nu range", np.min(mdb_water.nu_lines), np.max(mdb_water.nu_lines))
+    print(is_outside_range(mdb_water.nu_lines,nus[0],nus[-1]))
+
+    opa = OpaPremodit(mdb_water, nu_grid=nus, allow_32bit=True, auto_trange=[150.0,250.0])

--- a/tests/unittests/utils/grids_test.py
+++ b/tests/unittests/utils/grids_test.py
@@ -6,26 +6,23 @@ from exojax.utils.grids import delta_velocity_from_resolution
 from exojax.utils.grids import check_eslog_wavenumber_grid
 from exojax.utils.grids import check_scale_xsmode
 from exojax.utils.checkarray import is_sorted
+from exojax.utils.checkarray import is_outside_range
+
 
 @pytest.mark.parametrize("order", ["ascending", "descending"])
 def test_wavenumber_grid_order(order):
     Nx = 4000
-    nus, wav_revert, res = wavenumber_grid(29200.0,
-                                           29300.,
-                                           Nx,
-                                           unit='AA',
-                                           xsmode="lpf",
-                                           wavelength_order=order)
+    nus, wav_revert, res = wavenumber_grid(
+        29200.0, 29300.0, Nx, unit="AA", xsmode="lpf", wavelength_order=order
+    )
     assert is_sorted(wav_revert) == order
+
 
 def test_wavenumber_grid():
     Nx = 4000
-    nus, wav_revert, res = wavenumber_grid(29200.0,
-                                           29300.,
-                                           Nx,
-                                           unit='AA',
-                                           xsmode="lpf",
-                                           wavelength_order="ascending")
+    nus, wav_revert, res = wavenumber_grid(
+        29200.0, 29300.0, Nx, unit="AA", xsmode="lpf", wavelength_order="ascending"
+    )
     dif = np.log(nus[1:]) - np.log(nus[:-1])
     refval = 8.54915417e-07
     assert np.all(dif == pytest.approx(refval * np.ones_like(dif)))
@@ -33,17 +30,18 @@ def test_wavenumber_grid():
 
 def test_delta_velocity_from_resolution():
     from exojax.utils.constants import c
+
     N = 60
     Rarray = np.logspace(2, 7, N)
     dv_np = c * np.log1p(1.0 / Rarray)
     dv = delta_velocity_from_resolution(Rarray)
     resmax = np.max(np.abs(dv / dv_np) - 1)
-    assert resmax < 3. * 1.e-7
+    assert resmax < 3.0 * 1.0e-7
 
 
 def test_velocity_grid():
     resolution = 10**5
-    vmax = 150.0  #km/s
+    vmax = 150.0  # km/s
     x = velocity_grid(resolution, vmax)
     x = x / vmax
     assert x[0] <= -1.0 and x[-1] >= 1.0
@@ -51,32 +49,23 @@ def test_velocity_grid():
 
 
 def test_check_eslog_wavenumber_grid():
-    nus, wav, res = wavenumber_grid(22999,
-                                    23000,
-                                    1000,
-                                    unit='AA',
-                                    xsmode="modit",
-                                    wavelength_order="descending")
+    nus, wav, res = wavenumber_grid(
+        22999, 23000, 1000, unit="AA", xsmode="modit", wavelength_order="descending"
+    )
     assert check_eslog_wavenumber_grid(nus)
-    nus, wav, res = wavenumber_grid(22999,
-                                    23000,
-                                    10000,
-                                    unit='AA',
-                                    xsmode="modit",
-                                    wavelength_order="descending")
+    nus, wav, res = wavenumber_grid(
+        22999, 23000, 10000, unit="AA", xsmode="modit", wavelength_order="descending"
+    )
     assert check_eslog_wavenumber_grid(nus)
-    nus, wav, res = wavenumber_grid(22999,
-                                    23000,
-                                    100000,
-                                    unit='AA',
-                                    xsmode="modit",
-                                    wavelength_order="descending")
+    nus, wav, res = wavenumber_grid(
+        22999, 23000, 100000, unit="AA", xsmode="modit", wavelength_order="descending"
+    )
     assert check_eslog_wavenumber_grid(nus)
-    nus = np.linspace(1.e8 / 23000., 1.e8 / 22999., 1000)
+    nus = np.linspace(1.0e8 / 23000.0, 1.0e8 / 22999.0, 1000)
     assert not check_eslog_wavenumber_grid(nus)
-    nus = np.linspace(1.e8 / 23000., 1.e8 / 22999., 10000)
+    nus = np.linspace(1.0e8 / 23000.0, 1.0e8 / 22999.0, 10000)
     assert not check_eslog_wavenumber_grid(nus)
-    nus = np.linspace(1.e8 / 23000., 1.e8 / 22999., 100000)
+    nus = np.linspace(1.0e8 / 23000.0, 1.0e8 / 22999.0, 100000)
     assert not check_eslog_wavenumber_grid(nus)
 
 
@@ -95,11 +84,31 @@ def test_check_scale_xsmode():
 
 def test_is_sorted():
     import numpy as np
+
     a = np.array([1, 2, 3])
+    b = np.array([1, 3, 2])
+
     assert is_sorted(a) == "ascending"
     assert is_sorted(a[::-1]) == "descending"
-    a = np.array([1, 3, 2])
-    assert is_sorted(a) == "unordered"
+    assert is_sorted(b) == "unordered"
+    assert is_sorted(2.0) == "single"
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "xarr, xs, xe, expected",
+    [
+        (np.array([1.2, 1.4, 1.7, 1.3, 1.0]), 0.7, 0.8, True),  # No element in range
+        (np.array([0.75, 1.0, 1.5]), 0.7, 0.8, False),  # One element in range
+        (np.array([0.6, 0.9, 1.2]), 0.7, 0.8, True),  # No element in range
+        (np.array([]), 0.5, 1.0, True),  # Empty array
+        (np.array([0.5, 1.0]), 0.5, 1.0, True),  # Boundary values
+    ],
+)
+def test_is_outside_range(xarr, xs, xe, expected):
+    assert is_outside_range(xarr, xs, xe) == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses #449. Just added `ValueError` when none of the lines in `opa.mdb` are within `opa.nu_grid` for opa=OpaPremodit.

tests: tests/integration/api/inconsistent_nu_error_test.py