### PR TITLE
bug when the elower_max option is given in MdbHitemp 

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -510,7 +510,7 @@ class MdbCommonHitempHitran:
         mask = (df.wav > self.load_wavenum_min) * (df.wav < self.load_wavenum_max)
         mask *= line_strength_numpy(self.Ttyp, df.int, df.wav, df.El, qrtyp) > self.crit
         if self.elower_max is not None:
-            mask *= df.elower < self.elower_max
+            mask *= df.El < self.elower_max
         return mask
 
     def apply_mask_mdb(self, mask):

--- a/tests/integration/api/hitemp_elowermax_test.py
+++ b/tests/integration/api/hitemp_elowermax_test.py
@@ -1,0 +1,15 @@
+from jax.config import config
+
+config.update("jax_enable_x64", True)
+
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
+def test_hitemp_elower_max():
+    import numpy as np
+    from exojax.spec.api import MdbHitemp
+    nu_start = 11353.636363636364
+    nu_end = 11774.70588235294
+    mdb = MdbHitemp("CH4", nurange=[nu_start,nu_end], elower_max=4000.0)
+    print(np.max(mdb.elower))
+    assert np.max(mdb.elower) < 4000.0


### PR DESCRIPTION
In `MdbHitemp`, `elower_max` option did not work. I fixed it.

`test/integration/api/hitemp_elowermax_test.py`