### PR TITLE
added warning and exit statement in MultiMol

### DIFF
--- a/src/exojax/spec/multimol.py
+++ b/src/exojax/spec/multimol.py
@@ -1,6 +1,7 @@
 import numpy as np
 from exojax.spec import api
 import os
+import traceback
 
 
 class MultiMol():
@@ -119,8 +120,13 @@ class MultiMol():
                                           Ttyp=Ttyp,
                                           gpu_transfer=False,
                                           isotope=1))
-                except:
-                    mask[i] = False
+                except Exception as e:
+                    if 'No line found in ' in e.args:
+                        print(self.molmulti[k][i], self.dbmulti[k][i], "in the range of", e.args[1], e.args[2], "will be ignored due to no available lines found")
+                        mask[i] = False
+                    else:
+                        print(traceback.format_exc())
+                        exit()
 
             self.masked_molmulti[k] = np.array(self.molmulti[k])[mask].tolist()
             _multimdb.append(mdb_k)


### PR DESCRIPTION
I have modified multimol.py so that the code stops when an error is raised while it continues running when just no lines exist in the specified wavenumber range.

```
from exojax.utils.grids import wavenumber_grid
from exojax.spec.multimol import MultiMol

nus, wav, res = wavenumber_grid(7000, 7050, 10000, unit='cm-1', xsmode='premodit')
mul = MultiMol(molmulti=[['CO']], dbmulti=[['HITEMP']], database_root_path='/home/kawashima/database')
multimdb = mul.multimdb([nus], crit=1.e-30, Ttyp=1000.)

mul = MultiMol(molmulti=[['CO']], dbmulti=[['ExoMol']], database_root_path='/home/kawashima/database')
multimdb = mul.multimdb([nus], crit=1.e-30, Ttyp=1000.)

mul = MultiMol(molmulti=[['H2O']], dbmulti=[['ExoMol']], database_root_path='/home/kawashima/database')
multimdb = mul.multimdb([nus], crit=1.e-30, Ttyp=1000.)
```