### PR TITLE
added allow_32bit option for MultiMol.multiopa_premodit

### DIFF
--- a/src/exojax/spec/multimol.py
+++ b/src/exojax/spec/multimol.py
@@ -163,7 +163,8 @@ class MultiMol():
                           nu_grid_list,
                           auto_trange,
                           diffmode=2,
-                          dit_grid_resolution=0.2):
+                          dit_grid_resolution=0.2,
+                          allow_32bit=False):
         """multiple opa for PreMODIT
 
         Args:
@@ -185,7 +186,8 @@ class MultiMol():
                                     nu_grid=nu_grid_list[k],
                                     diffmode=diffmode,
                                     auto_trange=auto_trange,
-                                    dit_grid_resolution=dit_grid_resolution)
+                                    dit_grid_resolution=dit_grid_resolution,
+                                    allow_32bit=allow_32bit)
                 opa_k.append(opa_i)
             multiopa.append(opa_k)
 


### PR DESCRIPTION
This pull request just adds the allow_32bit option in MultiMoll.multiopa_premodit. You can check with the following script. Thank you.

```
from exojax.utils.grids import wavenumber_grid
from exojax.spec.multimol import MultiMol

nus, wav, res = wavenumber_grid(7000, 7050, 10000, unit='cm-1', xsmode='premodit')
mul = MultiMol(molmulti=[['H2O']], dbmulti=[['ExoMol']], database_root_path='/home/kawashima/database')
multimdb = mul.multimdb([nus], crit=1.e-30, Ttyp=1000.)
multiopa = mul.multiopa_premodit(multimdb, [nus], auto_trange=[500.,1500.], dit_grid_resolution=1.0, allow_32bit=True)
```