### PR TITLE
uncomment install_radis_develop() in setup.py?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def reinstall(package):
     subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", package])
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
-install_radis_develop()
+#install_radis_develop()
 uninstall('vaex-core')
 uninstall('vaex-astro')
 uninstall('vaex-jupyter')


### PR DESCRIPTION
I just thought it might be good to uncomment ``install_radis_develop()`` in setup.py for the time being as the current develop branch keeps installing radis==0.15, causing the issue reported in #458 (radis==0.14 does not cause this error).

But this is just my opinion, and this pull request is just in case you found it useful, too. Please don't hesitate to ignore it otherwise.