### PR TITLE
added nstream=2 just in case in the test scripts for the comparison with petitRADTRANS

### DIFF
--- a/tests/integration/comparison/twostream/comparison_petitRADTRANS_CIA.py
+++ b/tests/integration/comparison/twostream/comparison_petitRADTRANS_CIA.py
@@ -95,6 +95,7 @@ def run_exojax(path_data, ld_min, ld_max, mols, db, T0, alpha, logg, logvmr):
             F0_ibased = art.run(dtau, Tarr)
 
             art.rtsolver = "fbased2st"
+            art.nstream = 2
             F0_fbased = art.run(dtau, Tarr)
 
             mu_ibased.append(F0_ibased)

--- a/tests/integration/comparison/twostream/comparison_petitRADTRANS_narrow_R70000.py
+++ b/tests/integration/comparison/twostream/comparison_petitRADTRANS_narrow_R70000.py
@@ -95,6 +95,7 @@ def run_exojax(path_data, ld_min, ld_max, mols, db, T0, alpha, logg, logvmr):
             F0_ibased = art.run(dtau, Tarr)
 
             art.rtsolver = "fbased2st"
+            art.nstream = 2
             F0_fbased = art.run(dtau, Tarr)
 
             mu_ibased.append(F0_ibased)

--- a/tests/integration/comparison/twostream/comparison_petitRADTRANS_wide_R7000.py
+++ b/tests/integration/comparison/twostream/comparison_petitRADTRANS_wide_R7000.py
@@ -95,6 +95,7 @@ def run_exojax(path_data, ld_min, ld_max, mols, db, T0, alpha, logg, logvmr):
             F0_ibased = art.run(dtau, Tarr)
 
             art.rtsolver = "fbased2st"
+            art.nstream = 2
             F0_fbased = art.run(dtau, Tarr)
 
             mu_ibased.append(F0_ibased)


### PR DESCRIPTION
I have just added ``art.nstream = 2`` in the test scripts for the comparison with petitRADTRANS when changing from ``art.rtsolver = ibased`` to ``art.rtsolver = fbased2st``. This is just to avoid possible confusion, and I have confirmed that there would not be any change for the results since the nstream parameter is not used for ``art.rtsolver = fbased2st``. Thank you.