### PR TITLE
Change the order of calculations for 32-bit mode

### DIFF
--- a/src/exojax/atm/atmprof.py
+++ b/src/exojax/atm/atmprof.py
@@ -153,7 +153,9 @@ def gh_product(temperature, mean_molecular_weight):
     Returns:
         gravity x pressure scale height cm2/s2
     """
-    return kB * temperature / (m_u * mean_molecular_weight)
+    return (
+        kB * temperature / m_u / mean_molecular_weight
+    )  # Apply mmw (jnp array) last to minimize rounding errors in 32bit mode.
 
 
 def pressure_scale_height(gravity, T, mean_molecular_weight):

--- a/src/exojax/spec/atmrt.py
+++ b/src/exojax/spec/atmrt.py
@@ -87,7 +87,6 @@ class ArtCommon:
 
 
         """
-        print("pressure decrease rate k=", self.pressure_decrease_rate)
         normalized_height, normalized_radius_lower = normalized_layer_height(
             temperature,
             self.pressure_decrease_rate,
@@ -160,7 +159,7 @@ class ArtCommon:
         Returns:
             dtau: opacity profile, whose element is optical depth in each layer.
         """
-        
+
         return layer_optical_depth_clouds_lognormal(
             self.dParr,
             extinction_coefficient,

--- a/src/exojax/spec/hitran.py
+++ b/src/exojax/spec/hitran.py
@@ -48,10 +48,10 @@ def line_strength_numpy(T, Sij0, nu_lines, elower, qr, Tref=Tref_original):
     """
     return (
         Sij0
-        / qr
         * np.exp(-hcperk * elower * (1.0 / T - 1.0 / Tref))
         * np.expm1(-hcperk * nu_lines / T)
         / np.expm1(-hcperk * nu_lines / Tref)
+        / qr  # Apply qr (jnp array) last to minimize rounding errors in 32bit mode.
     )
 
 
@@ -63,7 +63,7 @@ def gamma_hitran(P, T, Pself, n_air, gamma_air_ref, gamma_self_ref):
         P: pressure (bar)
         T: temperature (K)
         Pself: partial pressure (bar)
-        n_air: coefficient of the  temperature  dependence  of  the  air-broadened halfwidth
+        n_air: coefficient of the temperature dependence of the air-broadened halfwidth
         gamma_air_ref: gamma air
         gamma_self_ref: gamma self
 


### PR DESCRIPTION
I found that we can prevent NaNs in gradients that occur only in 32-bit mode by modifying the order of calculations. 
This may be because it is better to perform computation with 64-bit variables before applying 32-bit variables to minimize rounding errors.

Fixes #473