### PR TITLE
use searchsorted to determine cloud base pressure

### DIFF
--- a/src/exojax/atm/amclouds.py
+++ b/src/exojax/atm/amclouds.py
@@ -75,10 +75,7 @@ def compute_cloud_base_pressure_index(pressure, saturation_pressure, vmr_vapor):
     Returns:
         int: cloud base pressure index
     """
-    # ibase=jnp.searchsorted((Psat/VMR)-Parr,0.0) # 231 +- 9.2 us
-    ibase = jnp.argmin(
-        jnp.abs(jnp.log(pressure) - jnp.log(saturation_pressure) + jnp.log(vmr_vapor))
-    )  # 73.8 +- 2.9 us
+    ibase=jnp.searchsorted((saturation_pressure/vmr_vapor)-pressure,0.0) # 231 +- 9.2 us, find index from ascending array 
     return ibase
 
 


### PR DESCRIPTION
This PR fixes a bug related to cloud calculations.

The previous code used `argmin` to determine the intersection between the T-P profile and a condensation curve. However, this sometimes picks up the minimum value even if it is not at the intersection, as shown in the orange line in the figure.
<img width="904" alt="スクリーンショット 2024-04-23 13 50 39" src="https://github.com/HajimeKawahara/exojax/assets/66584422/caeaf9c6-1369-4e52-b552-ed6c4b5bb6a7">

Therefore, I changed it to `searchsorted`, which solved the problem. I confirmed that this function is differentiable.
By default, the intersection was found only when the ascending array was input, which is probably physically correct.
<img width="492" alt="スクリーンショット 2024-04-23 13 51 45" src="https://github.com/HajimeKawahara/exojax/assets/66584422/150d03cd-b491-4df0-8161-8cd1c8b44b94">
