### PR TITLE
No change mdb (Exomol, HITRAN, Hitemp) from opa 

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -120,7 +120,6 @@ class MdbExomol(CapiMdbExomol):
         self.database = str(self.path.stem)
         self.bkgdatm = bkgdatm
         # molecbroad = self.exact_molecule_name + '__' + self.bkgdatm
-        # self.Tref = Tref_original
         self.gpu_transfer = gpu_transfer
         self.Ttyp = Ttyp
         self.broadf = broadf
@@ -416,7 +415,6 @@ class MdbCommonHitempHitran:
         self.simple_molecule_name = get_molecule(self.molecid)
         self.crit = crit
         self.elower_max = elower_max
-        #self.Tref = Tref_original
         self.Ttyp = Ttyp
         self.nurange = [np.min(nurange), np.max(nurange)]
         self.isotope = isotope
@@ -561,12 +559,13 @@ class MdbCommonHitempHitran:
         isotope_index = _isotope_index_from_isotope_number(isotope, self.uniqiso)
         return _qr_interp(isotope_index, T, self.T_gQT, self.gQT, Tref)
 
-    def qr_interp_lines(self, T):
+    def qr_interp_lines(self, T, Tref):
         """Partition Function ratio using HAPI partition data.
         (This function works for JAX environment.)
 
         Args:
             T: temperature (K)
+            Tref: reference temperature (K)
 
         Returns:
             Qr_line, partition function ratio array for lines [Nlines]
@@ -575,7 +574,7 @@ class MdbCommonHitempHitran:
             Nlines=len(self.nu_lines)
         """
         return _qr_interp_lines(
-            T, self.isoid, self.uniqiso, self.T_gQT, self.gQT, self.Tref
+            T, self.isoid, self.uniqiso, self.T_gQT, self.gQT, Tref
         )
 
     def exact_isotope_name(self, isotope):
@@ -809,7 +808,6 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
             and all(self.uniqiso == other.uniqiso)
             and self.isotope == other.isotope
             and self.simple_molecule_name == other.simple_molecule_name
-            and self.Tref == other.Tref
             and self.gpu_transfer == other.gpu_transfer
             and self.Ttyp == other.Ttyp
             and self.elower_max == other.elower_max
@@ -1052,7 +1050,6 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
             and all(self.uniqiso == other.uniqiso)
             and self.isotope == other.isotope
             and self.simple_molecule_name == other.simple_molecule_name
-            and self.Tref == other.Tref
             and self.gpu_transfer == other.gpu_transfer
             and self.Ttyp == other.Ttyp
             and self.elower_max == other.elower_max

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -59,7 +59,7 @@ class OpaPremodit(OpaCalc):
         Note:
             If auto_trange nor manual_params is not given in arguments,
             use manual_setting()
-            or provide self.dE, self.Tref, self.Twt and apply self.apply_params()
+            or provide self.dE, self.Twt and apply self.apply_params()
 
         Note:
             The option of "broadening_parameter_resolution" controls the resolution of broadening parameters.
@@ -270,7 +270,7 @@ class OpaPremodit(OpaCalc):
             self.gamma_ref = mdb.alpha_ref * reference_factor
 
     def apply_params(self):
-        self.mdb.change_reference_temperature(self.Tref)
+        #self.mdb.change_reference_temperature(self.Tref)
         self.dbtype = self.mdb.dbtype
 
         # broadening
@@ -288,7 +288,7 @@ class OpaPremodit(OpaCalc):
             self.mdb.elower,
             self.gamma_ref,
             self.n_Texp,
-            self.mdb.line_strength_ref,
+            self.mdb.line_strength(self.Tref), # line strength at Tref (is not necessary for Tref_original)
             self.Twt,
             Tref=self.Tref,
             Tref_broadening=self.Tref_broadening,

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -631,7 +631,7 @@ class OpaModit(OpaCalc):
 
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
         Sij = line_strength(
-            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, self.mdb.Tref
+            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, Tref_original
         )
 
         ngammaL_grid = ditgrid_log_interval(
@@ -816,7 +816,7 @@ class OpaDirect(OpaCalc):
             ) + gamma_natural(self.mdb.A)
         sigmaD = doppler_sigma(self.mdb.nu_lines, T, self.mdb.molmass)
         Sij = line_strength(
-            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, self.mdb.Tref
+            T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, Tref_original
         )
         return xsvector_lpf(numatrix, sigmaD, gammaL, Sij)
 
@@ -864,7 +864,7 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines,
                 self.mdb.elower,
                 qt,
-                self.mdb.Tref,
+                Tref_original,
             )
             sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
                 self.mdb.nu_lines, Tarr, self.mdb.molmass
@@ -882,7 +882,7 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines,
                 self.mdb.elower,
                 qt,
-                self.mdb.Tref,
+                Tref_original,
             )
             sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
                 self.mdb.nu_lines, Tarr, self.mdb.molmass
@@ -943,7 +943,7 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines,
                 self.mdb.elower,
                 qr_K.T,
-                self.mdb.Tref,
+                Tref_original,
             )
             sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
                 self.mdb.nu_lines, Tarr, self.mdb.atomicmass

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -333,9 +333,9 @@ class OpaPremodit(OpaCalc):
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
 
         if self.mdb.dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T)
+            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
         elif self.mdb.dbtype == "exomol":
-            qt = self.mdb.qr_interp(T)
+            qt = self.mdb.qr_interp(T, Tref_original)
 
         if self.diffmode == 0:
             return xsvector_zeroth(
@@ -420,9 +420,9 @@ class OpaPremodit(OpaCalc):
         ) = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            qtarr = vmap(self.mdb.qr_interp, (None, 0))(self.mdb.isotope, Tarr)
+            qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(self.mdb.isotope, Tarr, Tref_original)
         elif self.mdb.dbtype == "exomol":
-            qtarr = vmap(self.mdb.qr_interp)(Tarr)
+            qtarr = vmap(self.mdb.qr_interp, (0, None))(Tarr, Tref_original)
 
         if self.diffmode == 0:
             return xsmatrix_zeroth(
@@ -617,12 +617,12 @@ class OpaModit(OpaCalc):
         cont_nu, index_nu, R, pmarray = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T)
+            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
             gammaL = gamma_hitran(
                 P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
             ) + gamma_natural(self.mdb.A)
         elif self.mdb.dbtype == "exomol":
-            qt = self.mdb.qr_interp(T)
+            qt = self.mdb.qr_interp(T, Tref_original)
             gammaL = gamma_exomol(
                 P, T, self.mdb.n_Texp, self.mdb.alpha_ref
             ) + gamma_natural(self.mdb.A)
@@ -805,12 +805,12 @@ class OpaDirect(OpaCalc):
         numatrix = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T)
+            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
             gammaL = gamma_hitran(
                 P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
             ) + gamma_natural(self.mdb.A)
         elif self.mdb.dbtype == "exomol":
-            qt = self.mdb.qr_interp(T)
+            qt = self.mdb.qr_interp(T, Tref_original)
             gammaL = gamma_exomol(
                 P, T, self.mdb.n_Texp, self.mdb.alpha_ref
             ) + gamma_natural(self.mdb.A)
@@ -847,8 +847,8 @@ class OpaDirect(OpaCalc):
         numatrix = self.opainfo
         vmaplinestrengh = jit(vmap(line_strength, (0, None, None, None, 0, None)))
         if self.mdb.dbtype == "hitran":
-            vmapqt = vmap(self.mdb.qr_interp, (None, 0))
-            qt = vmapqt(self.mdb.isotope, Tarr)
+            vmapqt = vmap(self.mdb.qr_interp, (None, 0, None))
+            qt = vmapqt(self.mdb.isotope, Tarr, Tref_original)
             vmaphitran = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))
             gammaLM = vmaphitran(
                 Parr,
@@ -870,8 +870,8 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines, Tarr, self.mdb.molmass
             )
         elif self.mdb.dbtype == "exomol":
-            vmapqt = vmap(self.mdb.qr_interp)
-            qt = vmapqt(Tarr)
+            vmapqt = vmap(self.mdb.qr_interp,(0, None))
+            qt = vmapqt(Tarr, Tref_original)
             vmapexomol = jit(vmap(gamma_exomol, (0, 0, None, None)))
             gammaLMP = vmapexomol(Parr, Tarr, self.mdb.n_Texp, self.mdb.alpha_ref)
             gammaLMN = gamma_natural(self.mdb.A)

--- a/src/exojax/test/generate_xs.py
+++ b/src/exojax/test/generate_xs.py
@@ -22,6 +22,8 @@ import matplotlib.pyplot as plt
 
 from jax import config
 
+from exojax.utils.constants import Tref_original
+
 config.update("jax_enable_x64", True)
 
 testdata = {}
@@ -58,7 +60,7 @@ def gendata_xs_modit_exomol():
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
     Sij = line_strength(
-        Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref
+        Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, Tref_original
     )
 
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
@@ -111,7 +113,7 @@ def gendata_xs_modit_hitemp(airmode=False):
     ngammaL = gammaL / dv_lines
     nsigmaD = normalized_doppler_sigma(Tfix, Mmol, R)
     Sij = line_strength(
-        Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, mdbCO.Tref
+        Tfix, mdbCO.logsij0, mdbCO.nu_lines, mdbCO.elower, qt, Tref_original
     )
     cont_nu, index_nu, R, pmarray = init_modit(mdbCO.nu_lines, nu_grid)
     ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)

--- a/tests/integration/api/api_premodit_to_direct.py
+++ b/tests/integration/api/api_premodit_to_direct.py
@@ -105,7 +105,7 @@ vmr = 1.
 Ppart = P * vmr
 Mmol = molinfo.molmass("CO")
 
-logsij0 = np.log(mdb.line_strength_ref)
+logsij0 = np.log(mdb.line_strength)
 sigmaD = doppler_sigma(mdb.nu_lines,T,Mmol)
 qt = mdb.qr_interp(mdb.isotope, T)
 gammaL = gamma_hitran(P,T, Ppart, mdb.n_air, mdb.gamma_air, mdb.gamma_self) + gamma_natural(mdb.A)
@@ -123,7 +123,7 @@ opa = OpaPremodit(mdb=mdb,
 opad = OpaDirect(mdb=mdb,
                  nu_grid=np.array(nus))
 
-logsij0 = np.log(mdb.line_strength_ref)
+logsij0 = np.log(mdb.line_strength)
 qt = mdb.qr_interp(mdb.isotope, T)
 Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt, mdb.Tref)
 #Sij = line_strength(T,logsij0,mdb.nu_lines,mdb.elower,qt)                                                                                                          

--- a/tests/integration/moldb/quantum_states_filter_exomol.py
+++ b/tests/integration/moldb/quantum_states_filter_exomol.py
@@ -49,7 +49,7 @@ load_mask = (mdb.df["v_u"] - mdb.df["v_l"] == 3)
 
 mdb.activate(mdb.df, load_mask)
 plt.plot(1.e4 / mdb.nu_lines,
-         mdb.line_strength_ref,
+         mdb.line_strength,
          "+",
          color="black",
          label="activated lines")

--- a/tests/integration/moldb/quantum_states_filter_hitemp.py
+++ b/tests/integration/moldb/quantum_states_filter_hitemp.py
@@ -24,7 +24,7 @@ for dv in range(0, 6):
 load_mask = (mdb.df["vu"] - mdb.df["vl"] == 3)
 mdb.activate(mdb.df, load_mask)
 plt.plot(1.e4 / mdb.nu_lines,
-         mdb.line_strength_ref,
+         mdb.line_strength,
          "+",
          color="black",
          label="activated lines")

--- a/tests/integration/moldb/quantum_states_filter_hitran_co.py
+++ b/tests/integration/moldb/quantum_states_filter_hitran_co.py
@@ -30,7 +30,7 @@ for dv in range(0, 6):
 load_mask = (mdb.df["vu"] - mdb.df["vl"] == 2)
 mdb.activate(mdb.df, load_mask)
 plt.plot(1.e4 / mdb.nu_lines,
-         mdb.line_strength_ref,
+         mdb.line_strength,
          "+",
          color="black",
          label="activated lines")

--- a/tests/integration/premodit/checkindex.py
+++ b/tests/integration/premodit/checkindex.py
@@ -29,7 +29,7 @@ ngamma_ref_grid_H2O, n_Texp_grid_H2O, R_H2O, pmarray_H2O = initspec.init_premodi
     mdbH2O_orig.elower,
     mdbH2O_orig.alpha_ref,
     mdbH2O_orig.n_Texp,
-    mdbH2O_orig.line_strength_ref,
+    mdbH2O_orig.line_strength,
     Twt=Tgue,
     Tref=1000.0,
     Tref_broadening=1000.0,

--- a/tests/unittests/spec/api/api_eq_method_test.py
+++ b/tests/unittests/spec/api/api_eq_method_test.py
@@ -11,21 +11,9 @@ def test_eq_Exomol():
     mdb = mock_mdbExomol()
     assert mdb_orig == mdb
 
-def test_neq_Hitemp():
-    mdb_orig = mock_mdbHitemp(multi_isotope=True)
-    mdb  = copy.deepcopy(mdb_orig)
-    mdb.change_reference_temperature(1320.0)
-    assert mdb_orig != mdb
-
-def test_neq_Exomol():
-    mdb_orig = mock_mdbExomol()
-    mdb  = copy.deepcopy(mdb_orig)
-    mdb.change_reference_temperature(1320.0)
-    assert mdb_orig != mdb
 
 
 if __name__ == "__main__":
-    #test_eq_Hitemp()
-    #test_eq_Exomol()
-    #test_neq_Hitemp()
-    test_neq_Exomol()
+    test_eq_Hitemp()
+    test_eq_Exomol()
+    

--- a/tests/unittests/spec/api/api_line_strength_test.py
+++ b/tests/unittests/spec/api/api_line_strength_test.py
@@ -5,30 +5,34 @@ import pytest
 
 def test_line_strength_exomol():
     mdb = mock_mdbExomol()
-    assert pytest.approx(np.sum(mdb.line_strength_ref)) == 3.260386610389642e-22
+    assert pytest.approx(np.sum(mdb.line_strength_ref_original)) == 3.260386610389642e-22
 
 
 def test_line_strength_exomol_t():
     mdb = mock_mdbExomol()
-    mdb.change_reference_temperature(1200.0)
-    mask = np.isfinite(mdb.line_strength_ref)
-    val = np.sum(mdb.line_strength_ref[mask])
+    Tref = 1200.0
+    #mdb.change_reference_temperature(Tref) #old
+    mask = np.isfinite(mdb.line_strength(Tref))
+    val = np.sum(mdb.line_strength(Tref)[mask])
     assert pytest.approx(val) == 1.2823972e-20
 
 
 def test_line_strength_hitemp():
     mdb = mock_mdbHitemp()
-    assert pytest.approx(np.sum(mdb.line_strength_ref)) == 3.2168443e-22
+    assert pytest.approx(np.sum(mdb.line_strength_ref_original)) == 3.2168443e-22
 
 
 def test_line_strength_hitemp_t():
     mdb = mock_mdbHitemp()
-    mdb.change_reference_temperature(1200.0)
-    mask = np.isfinite(mdb.line_strength_ref)
-    val = np.sum(mdb.line_strength_ref[mask])
+    Tref = 1200.0
+    #mdb.change_reference_temperature(Tref)
+    mask = np.isfinite(mdb.line_strength(Tref))
+    val = np.sum(mdb.line_strength(Tref)[mask])
     assert pytest.approx(val) == 1.2651083e-20
 
 
 if __name__ == "__main__":
-    test_line_strength_exomol_t()
+    #test_line_strength_exomol()
+    #test_line_strength_exomol_t()
+    #test_line_strength_hitemp()
     test_line_strength_hitemp_t()

--- a/tests/unittests/spec/modit/modit_test.py
+++ b/tests/unittests/spec/modit/modit_test.py
@@ -14,6 +14,8 @@ from exojax.test.emulate_mdb import mock_wavenumber_grid
 
 from jax import config
 
+from exojax.utils.constants import Tref_original
+
 config.update("jax_enable_x64", True)
 
 
@@ -25,7 +27,7 @@ def test_xs_exomol():
     Mmol = mdbCO.molmass
     
     cont_nu, index_nu, R, pmarray = init_modit(mdbCO.nu_lines, nus)
-    qt = mdbCO.qr_interp(Tfix)
+    qt = mdbCO.qr_interp(Tfix, Tref_original)
     gammaL = gamma_exomol(Pfix, Tfix, mdbCO.n_Texp,
                           mdbCO.alpha_ref) + gamma_natural(mdbCO.A)
     dv_lines = mdbCO.nu_lines / R
@@ -92,5 +94,5 @@ def test_rt_exomol():
 
 
 if __name__ == "__main__":
-#    test_xs_exomol()
+    test_xs_exomol()
     test_rt_exomol()

--- a/tests/unittests/spec/opa/opamodit_call_test.py
+++ b/tests/unittests/spec/opa/opamodit_call_test.py
@@ -5,14 +5,14 @@ from exojax.spec.opacalc import OpaModit
 def test_opamodit_hitemp_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")
     mdb = mock_mdbHitemp(multi_isotope=True)
-    opa = OpaModit(mdb, nu_grid=nus)
+    opa = OpaModit(mdb, nu_grid=nus, allow_32bit=True)
 
     assert isinstance(opa, OpaModit)
 
 def test_opamodit_exomol_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")
     mdb = mock_mdbExomol()
-    opa = OpaModit(mdb, nu_grid=nus)
+    opa = OpaModit(mdb, nu_grid=nus, allow_32bit=True)
     
     assert isinstance(opa, OpaModit)
 

--- a/tests/unittests/spec/opa/sideeffect_test.py
+++ b/tests/unittests/spec/opa/sideeffect_test.py
@@ -1,0 +1,26 @@
+"""
+See Issue #510, #515
+"""
+
+import copy
+from exojax.test.emulate_mdb import mock_mdbHitemp, mock_mdbExomol
+from exojax.utils.grids import wavenumber_grid
+from exojax.spec.opacalc import OpaPremodit
+import copy
+
+
+def test_sideeffect_call():
+    nus, wav, res = wavenumber_grid(
+        22920.0, 23100.0, 20000, unit="AA", xsmode="premodit"
+    )
+    mdb = mock_mdbHitemp(multi_isotope=True)
+    opa1 = OpaPremodit(mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1000])
+    opa1_orig = copy.deepcopy(opa1)
+    opa2 = OpaPremodit(
+        mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1200]
+    )  # used the same mdb used in opa1
+    print(opa1 == opa1_orig)
+    assert opa1 == opa1_orig
+
+if __name__ == "__main__":
+    test_sideeffect_call()

--- a/tests/unittests/spec/opa/sideeffect_test.py
+++ b/tests/unittests/spec/opa/sideeffect_test.py
@@ -22,5 +22,20 @@ def test_sideeffect_call():
     print(opa1 == opa1_orig)
     assert opa1 == opa1_orig
 
+def test_sideeffect_call_exomol():
+    nus, wav, res = wavenumber_grid(
+        22920.0, 23100.0, 20000, unit="AA", xsmode="premodit"
+    )
+    mdb = mock_mdbExomol()
+    opa1 = OpaPremodit(mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1000])
+    opa1_orig = copy.deepcopy(opa1)
+    opa2 = OpaPremodit(
+        mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1200]
+    )  # used the same mdb used in opa1
+    print(opa1 == opa1_orig)
+    assert opa1 == opa1_orig
+
+
 if __name__ == "__main__":
     test_sideeffect_call()
+    test_sideeffect_call_exomol()


### PR DESCRIPTION
address the side effect raised in #510 

The following is a simple test of the side effect:

`tests/unittest/opa/sideeffect_test.py`
```python
def test_sideeffect_call():
    nus, wav, res = wavenumber_grid(
        22920.0, 23100.0, 20000, unit="AA", xsmode="premodit"
    )
    mdb = mock_mdbHitemp(multi_isotope=True)
    opa1 = OpaPremodit(mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1000])
    opa1_orig = copy.deepcopy(opa1)
    opa2 = OpaPremodit(
        mdb, nu_grid=nus, allow_32bit=True, auto_trange=[500.0, 1200]
    )  # used the same mdb used in opa1
    print(opa1 == opa1_orig) -> True 
``` 
Before this PR (i.e. recent `develop` branch), `opa1 == opa1_orig` gives `False`. This means the second call of `OpaPremodit` using the same `mdb` changes `opa1.mdb`. In this PR, based on the strategy described in #510, we avoid the side effect, i.e. `opa` does not change the internal state of `mdb`. 

but, we need some modifications:
- removed the internal state `mdb.Tref`
- `line_strength_ref_original` was introduced for line strength at `T=Tref_original`
- `self.line_strength_ref` (which depends on `self.Tref`) -> `self.line_strength(Tref)` 
- `qr_interp(T)` -> `qr_interp(T,Tref)` in `MdbExomol`
- `qr_interp(iso,T)` -> `qr_interp(iso,T,Tref)` in `MdbHitemp/Hitran`
- `qr_interp_line(T)` -> `qr_interp_line(T,Tref)` in `MdbHitemp/Hitran`

- The deprecated attribute `Sij0` was removed.