### PR TITLE
Bug fix introduced by #515 (qr was not normalized by Tref, but Tref_original)

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -360,18 +360,18 @@ class MdbExomol(CapiMdbExomol):
         """
         return self.QT_interp(T) / self.QT_interp(Tref)
 
-    def line_strength(self, Tref):
-        """line strength at Tref
+    def line_strength(self, T):
+        """line strength at T
 
         Args:
-            Tref (_type_): reference temperature
+            T (float): temperature
 
         Returns:
-            _type_: line strength at Tref
+            float: line strength at T
         """
-        qr = self.qr_interp(Tref, Tref_original)
+        qr = self.qr_interp(T, Tref_original)
         return line_strength_numpy(
-            Tref,
+            T,
             self.line_strength_ref_original,
             self.nu_lines,
             self.elower,
@@ -590,14 +590,14 @@ class MdbCommonHitempHitran:
 
         return exact_molecule_name_from_isotope(self.simple_molecule_name, isotope)
 
-    def line_strength(self, Tref):
-        """line strength at Tref
+    def line_strength(self, T):
+        """line strength at T
         
         Args:
-            Tref (_type_): reference temperature
+            T (float): temperature
 
         Returns:
-            _type_: line strength at Tref
+            float: line strength at T
         """
         if self.isotope is None or self.isotope == 0:
             msg1 = "Currently all isotope mode is not fully compatible to MdbCommonHitempHitran."
@@ -605,12 +605,12 @@ class MdbCommonHitempHitran:
                 "QT assumed isotope=1 instead."
             )
             warnings.warn(msg1 + msg2, UserWarning)
-            qr = self.qr_interp(1, Tref, Tref_original)
+            qr = self.qr_interp(1, T, Tref_original)
         else:
-            qr = self.qr_interp(self.isotope, Tref, Tref_original)
+            qr = self.qr_interp(self.isotope, T, Tref_original)
 
         return line_strength_numpy(
-            Tref, self.line_strength_ref_original, self.nu_lines, self.elower, qr, Tref_original
+            T, self.line_strength_ref_original, self.nu_lines, self.elower, qr, Tref_original
         )
         
     def check_line_existence_in_nurange(self, df_load_mask):

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -335,10 +335,8 @@ class OpaPremodit(OpaCalc):
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
 
         if self.mdb.dbtype == "hitran":
-            # qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
             qt = self.mdb.qr_interp(self.mdb.isotope, T, self.Tref)
         elif self.mdb.dbtype == "exomol":
-            # qt = self.mdb.qr_interp(T, Tref_original)
             qt = self.mdb.qr_interp(T, self.Tref)
 
         if self.diffmode == 0:
@@ -424,16 +422,12 @@ class OpaPremodit(OpaCalc):
         ) = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            # qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(self.mdb.isotope, Tarr, Tref_original)
             qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(
                 self.mdb.isotope, Tarr, self.Tref
             )
         elif self.mdb.dbtype == "exomol":
-            # qtarr = vmap(self.mdb.qr_interp, (0, None))(Tarr, Tref_original)
-            qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(
-                self.mdb.isotope, Tarr, self.Tref
-            )
-
+            qtarr = vmap(self.mdb.qr_interp, (0, None))(Tarr, self.Tref)
+            
         if self.diffmode == 0:
             return xsmatrix_zeroth(
                 Tarr,

--- a/src/exojax/spec/opacalc.py
+++ b/src/exojax/spec/opacalc.py
@@ -145,19 +145,18 @@ class OpaPremodit(OpaCalc):
 
         return eq_attributes
 
-
     def _if_exist_check_eq(self, other, attribute, eq_attributes):
         if hasattr(self, attribute) and hasattr(other, attribute):
-            return eq_attributes and getattr(self,attribute) == getattr(other,attribute)
+            return eq_attributes and getattr(self, attribute) == getattr(
+                other, attribute
+            )
         elif not hasattr(self, attribute) and not hasattr(other, attribute):
             return eq_attributes
         else:
             return False
 
-
     def __ne__(self, other):
         return not self.__eq__(other)
-
 
     def auto_setting(self, Tl, Tu):
         print("OpaPremodit: params automatically set.")
@@ -270,7 +269,7 @@ class OpaPremodit(OpaCalc):
             self.gamma_ref = mdb.alpha_ref * reference_factor
 
     def apply_params(self):
-        #self.mdb.change_reference_temperature(self.Tref)
+        # self.mdb.change_reference_temperature(self.Tref)
         self.dbtype = self.mdb.dbtype
 
         # broadening
@@ -288,7 +287,9 @@ class OpaPremodit(OpaCalc):
             self.mdb.elower,
             self.gamma_ref,
             self.n_Texp,
-            self.mdb.line_strength(self.Tref), # line strength at Tref (is not necessary for Tref_original)
+            self.mdb.line_strength(
+                self.Tref
+            ),  # line strength at Tref (is not necessary for Tref_original)
             self.Twt,
             Tref=self.Tref,
             Tref_broadening=self.Tref_broadening,
@@ -333,9 +334,11 @@ class OpaPremodit(OpaCalc):
         nsigmaD = normalized_doppler_sigma(T, self.mdb.molmass, R)
 
         if self.mdb.dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
+            # qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
+            qt = self.mdb.qr_interp(self.mdb.isotope, T, self.Tref)
         elif self.mdb.dbtype == "exomol":
-            qt = self.mdb.qr_interp(T, Tref_original)
+            # qt = self.mdb.qr_interp(T, Tref_original)
+            qt = self.mdb.qr_interp(T, self.Tref)
 
         if self.diffmode == 0:
             return xsvector_zeroth(
@@ -420,9 +423,15 @@ class OpaPremodit(OpaCalc):
         ) = self.opainfo
 
         if self.mdb.dbtype == "hitran":
-            qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(self.mdb.isotope, Tarr, Tref_original)
+            # qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(self.mdb.isotope, Tarr, Tref_original)
+            qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(
+                self.mdb.isotope, Tarr, self.Tref
+            )
         elif self.mdb.dbtype == "exomol":
-            qtarr = vmap(self.mdb.qr_interp, (0, None))(Tarr, Tref_original)
+            # qtarr = vmap(self.mdb.qr_interp, (0, None))(Tarr, Tref_original)
+            qtarr = vmap(self.mdb.qr_interp, (None, 0, None))(
+                self.mdb.isotope, Tarr, self.Tref
+            )
 
         if self.diffmode == 0:
             return xsmatrix_zeroth(
@@ -583,12 +592,11 @@ class OpaModit(OpaCalc):
             and (self.wavelength_order == other.wavelength_order)
             and all(self.nu_grid == other.nu_grid)
         )
-    
+
         return eq_attributes
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
 
     def apply_params(self):
         self.dbtype = self.mdb.dbtype
@@ -773,7 +781,7 @@ class OpaDirect(OpaCalc):
             and (self.wavelength_order == other.wavelength_order)
             and all(self.nu_grid == other.nu_grid)
         )
-    
+
         return eq_attributes
 
     def __ne__(self, other):
@@ -870,7 +878,7 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines, Tarr, self.mdb.molmass
             )
         elif self.mdb.dbtype == "exomol":
-            vmapqt = vmap(self.mdb.qr_interp,(0, None))
+            vmapqt = vmap(self.mdb.qr_interp, (0, None))
             qt = vmapqt(Tarr, Tref_original)
             vmapexomol = jit(vmap(gamma_exomol, (0, 0, None, None)))
             gammaLMP = vmapexomol(Parr, Tarr, self.mdb.n_Texp, self.mdb.alpha_ref)

--- a/tests/integration/premodit/line_strength_comparison_exomol.py
+++ b/tests/integration/premodit/line_strength_comparison_exomol.py
@@ -35,7 +35,7 @@ nus, wav, res = wavenumber_grid(22900.0,
                                 unit='AA',
                                 xsmode="premodit")
 
-diffmode = 2
+diffmode = 0
 
 Ttest = 1200.0
 P = 1.0
@@ -52,7 +52,7 @@ lbd_coeff, multi_index_uniqgrid, elower_grid, \
 xsv = opa.xsvector(Ttest,P)
 
 #tries manual computation of xsvector below
-qt = mdb.qr_interp(Ttest)
+qt = mdb.qr_interp(Ttest, opa.Tref)
 dE = opa.dE
 NE = len(elower_grid)
 
@@ -80,8 +80,8 @@ xsv_manual = calc_xsection_from_lsd_scanfft(Slsd_premodit, R, pmarray,
 from exojax.spec.modit import xsvector
 from exojax.spec.initspec import init_modit
 
-mdb.change_reference_temperature(Tref_original)
-qt = mdb.qr_interp(Ttest)
+#mdb.change_reference_temperature(Tref_original)
+qt = mdb.qr_interp(Ttest, Tref_original)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
 Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
 gammaL = gamma_exomol(P, Ttest, mdb.n_Texp, mdb.alpha_ref)

--- a/tests/integration/premodit/line_strength_comparison_exomol_water.py
+++ b/tests/integration/premodit/line_strength_comparison_exomol_water.py
@@ -49,7 +49,7 @@ opa = OpaPremodit(mdb=mdb, nu_grid=nus, auto_trange=[1000.0,1200.0],diffmode=dif
 lbd_coeff, multi_index_uniqgrid, elower_grid, \
         ngamma_ref_grid, n_Texp_grid, R, pmarray = opa.opainfo
     
-qt = mdb.qr_interp(T)
+qt = mdb.qr_interp(T, opa.Tref)
 dE = opa.dE
 NE = len(elower_grid)
 
@@ -67,10 +67,9 @@ Spremodit = (np.sum(Slsd_premodit, axis=1))
 # We need to revert the reference temperature to 296K to reuse mdb for MODIT
 #===========================================================================
 
-mdb.change_reference_temperature(Tref_original)
-qt = mdb.qr_interp(T)
+qt = mdb.qr_interp(T, Tref_original)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
-Sij = line_strength(T, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
+Sij = line_strength(T, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, Tref_original)
 gammaL = gamma_exomol(P, T, mdb.n_Texp, mdb.alpha_ref)
 dv_lines = mdb.nu_lines / R
 ngammaL = gammaL / dv_lines

--- a/tests/integration/premodit/line_strength_comparison_hitemp.py
+++ b/tests/integration/premodit/line_strength_comparison_hitemp.py
@@ -54,7 +54,7 @@ lbd_coeff, multi_index_uniqgrid, elower_grid, \
 xsv = opa.xsvector(Ttest,P)
 
 #tries manual computation of xsvector below
-qt = mdb.qr_interp(mdb.isotope, Ttest)
+qt = mdb.qr_interp(mdb.isotope, Ttest, opa.Tref)
 dE = opa.dE
 NE = len(elower_grid)
 
@@ -82,10 +82,9 @@ xsv_manual = calc_xsection_from_lsd_scanfft(Slsd_premodit, R, pmarray,
 from exojax.spec.modit import xsvector
 from exojax.spec.initspec import init_modit
 
-mdb.change_reference_temperature(Tref_original)
-qt = mdb.qr_interp(mdb.isotope, Ttest)
+qt = mdb.qr_interp(mdb.isotope, Ttest, Tref_original)
 cont, index, R, pmarray = initspec.init_modit(mdb.nu_lines, nus)
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, Tref_original)
 gammaL = gamma_hitran(P, Ttest, 0.0, mdb.n_air, mdb.gamma_air,
                       mdb.gamma_self) + gamma_natural(mdb.A)
 
@@ -99,7 +98,7 @@ Slsd_modit = inc2D_givenx(lsd_array, Sij, cont, index, jnp.log(ngammaL),
 Smodit = (np.sum(Slsd_modit, axis=1))
 
 ## also, xs
-Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, mdb.Tref)
+Sij = line_strength(Ttest, mdb.logsij0, mdb.nu_lines, mdb.elower, qt, Tref_original)
 cont_nu, index_nu, R, pmarray = init_modit(mdb.nu_lines, nus)
 ngammaL_grid = ditgrid_log_interval(ngammaL, dit_grid_resolution=0.1)
 xsv_modit = xsvector(cont_nu, index_nu, R, pmarray, nsigmaD, ngammaL, Sij, nus,

--- a/tests/integration/premodit_lpf/CH4_Gascellmodel_2408rev_test.py
+++ b/tests/integration/premodit_lpf/CH4_Gascellmodel_2408rev_test.py
@@ -1,0 +1,262 @@
+# multi wavelength range
+# Create the model data of absorption separating each lines
+# 2024/08/29 created based on "CH4Gascellmodel_repeat_2407rev.py"
+##opapremodit, gridboost
+
+from exojax.utils.grids import wavenumber_grid
+from exojax.spec.api import MdbHitemp
+from exojax.spec.hitran import line_strength
+from exojax.spec.specop import SopInstProfile
+from Trans_model_1Voigt_HITEMP_nu_2408rev_test import (
+    Trans_model_MultiVoigt_test,
+    create_mdbs_multi,
+    calc_dnumber_isobaric,
+)
+import jax.numpy as jnp
+import numpy as np
+from exojax.utils.constants import Tref_original
+import matplotlib.collections as mc
+from jax import config
+
+config.update("jax_enable_x64", True)
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+
+
+# Calculate the Line strength S(T)
+def S_Tcalc(nu, S_0, T):
+    logeS_0 = jnp.log(S_0)
+    qr = mdb.qr_interp_lines(T, Tref_original)
+    return line_strength(T, logeS_0, nu, mdb.elower, qr, Tref_original)
+
+
+wmin = 1621.78
+wspan = 0.15
+adjustrange = 0.2
+Resolution = 0.0025
+nu_offset = 0.00
+Twt = 1000
+gridboost = 10
+
+# model spectra setting
+VMR = 1  # volume mixing ratio
+kB = 1.380649e-16
+L = 50 * 1  # cm
+P0 = 0.423  # @296K
+# Tarr = jnp.array([1000, 1000, 1000])
+Tarr = jnp.array([720.5, 720.0, 727.2, 734.3, 733.8, 731.4, 729.7, 725.2]) + 273.15
+# Tarr =jnp.array([320,383,414,427,427,414,385,324]) +273#CH3-9 of  162178-93 at 2023/07/24/15:21:02
+# Tarr =jnp.array([581, 664, 702, 721, 720, 705, 668, 590]) +273#CH3-9 of  162141-51 at 2023/07/25/17:02:00
+
+roundorder = 5  # digit to round up
+Nx = round(((wspan + 2 * adjustrange) / Resolution + 1))  # it should be even number
+start_idx = round(adjustrange / Resolution)  # start index in wav array for triminng
+slicesize = round((wspan / Resolution + 1))
+
+Nx_boost = Nx * gridboost
+ngas, P_total = calc_dnumber_isobaric(Tarr, P0, Tref_original)
+P_self = P_total * VMR
+nMolecule = ngas * VMR
+
+wmax = round(wmin + wspan, 5)
+wav_n = round(wspan / Resolution + 1)  # equal to the specified amount of data point
+wav_adjust = jnp.linspace(wmin - adjustrange, wmax + adjustrange, Nx)
+nu_adjust = 1e7 / wav_adjust[::-1]
+
+nu_min = 1e7 / wmax
+nu_max = 1e7 / wmin
+
+# generate the wavenumber&wavelength grid for cross-section
+nu_grid, wav, res = wavenumber_grid(
+    nu_min - adjustrange,
+    nu_max + adjustrange,
+    # jnp.max(wavd),
+    Nx_boost,
+    unit="cm-1",
+    xsmode="premodit",
+    wavelength_order="ascending",
+)
+
+sop_inst = SopInstProfile(nu_grid)
+
+# Read the line database
+mdb = MdbHitemp(
+    ".database/CH4/",
+    nurange=nu_grid,
+    gpu_transfer=False,  # Trueだと計算速度低下
+)  # for obtaining the error of each line
+
+# line amount for Voigt fitting
+linenum = 1
+# Calculate the line index in the order of the line strength at T=twt
+S_T = S_Tcalc(jnp.exp(mdb.nu_lines), mdb.line_strength_ref_original, Twt)
+
+strline_ind_array = jnp.argsort(S_T)[::-1][:linenum]
+strline_ind_array_nu = jnp.sort(strline_ind_array)
+
+mdb_weak, nu_center_voigt, mdb_voigt = create_mdbs_multi(mdb, strline_ind_array_nu)
+# opa = create_opapremodit(mdb_weak, nu_grid, Tarr)
+from exojax.spec.opacalc import OpaPremodit
+
+opa = OpaPremodit(
+    mdb=mdb_voigt,
+    nu_grid=nu_grid,
+    diffmode=0,  # i-th Taylor expansion is used for the weight, default is 0.
+    auto_trange=(np.min(Tarr), np.max(Tarr)),
+    # manual_params=(160, Tref_original, np.max(Tarr)),
+)  # opacity calculation
+print(opa.Tref, opa.Tref_broadening)
+#import sys
+#sys.exit()
+#opa.Tref = Tref_original
+#opa.Tref_broadening = Tref_original
+
+
+# Fixed values definition
+nspec = 1  # Number of spectra is 1, so loops over nspec can be removed
+valrange = 1.0  # Value range, adjust as needed
+nu_span = 0.5  # Span of nu, adjust as needed
+
+# Parameter definitions with fixed values
+offrange = 0.1
+
+alphas = jnp.ones((linenum))  # Fixed value as an array of ones
+gamma_selfs = mdb_voigt.gamma_self
+ns = mdb_voigt.n_air
+# Polynomial coefficients for nspec = 1
+coeffs = [
+    {
+        "a": 0.0,  # Fixed value
+        "b": 0.0,  # Fixed value
+        "c": 0.0,  # Fixed value
+        "d": 1.0,  # Fixed value
+    }
+]
+
+wavmodel = wav_adjust[start_idx : start_idx + slicesize]
+nu_model = 1e7 / wavmodel
+
+
+xsmatrix_opa, xsmatirx_lpf = Trans_model_MultiVoigt_test(
+    nu_offset,
+    alphas,
+    mdb_voigt.gamma_air,
+    gamma_selfs,
+    ns,
+    Tarr,
+    P_total,
+    P_self,
+    L,
+    nMolecule,
+    nu_grid,
+    nu_model,
+    mdb_voigt,
+    opa,
+    sop_inst,
+)
+
+fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(16, 9))
+# plot the measured spectra
+
+ax.plot(
+    wavmodel,
+    xsmatrix_opa[::-1],
+    "-",
+    alpha=1.0,
+    linewidth=2,
+    color="C0",
+    label="opapremodit cross-section",
+)
+
+
+ax.plot(
+    wavmodel,
+    xsmatirx_lpf[::-1],
+    "-",
+    alpha=1.0,
+    linewidth=2,
+    ls="dashed",
+    color="C1",
+    label="lpf cross-section",
+)
+
+
+# Plot range
+ymin = 0.0
+ymax = 1.01
+yspan = ymax - ymin
+# plt.ylim(ymin, ymax)
+plt.xlim(wmin, wmax)
+# plt.xlim(wmin - adjustrange, wmax + adjustrange)
+
+
+# plot the line centers
+wavlinecenter1 = 1 / mdb.nu_lines * 1.0e7  # convert to wavelength (descending)
+wavlines1 = [
+    [(wavlinecenter1[i], ymax - yspan * 0.05), (wavlinecenter1[i], ymax)]
+    for i in range(linenum)
+]
+lc1 = mc.LineCollection(
+    wavlines1, colors="gray", linewidths=1, linestyle="-", label="line centers"
+)
+ax.add_collection(lc1)
+
+# plot setting
+plt.grid(which="major", axis="both", alpha=0.7, linestyle="--", linewidth=1)
+ax.grid(which="minor", axis="both", alpha=0.3, linestyle="--", linewidth=1)
+ax.minorticks_on()
+plt.xlabel("wavelength (nm)", fontsize=16)
+plt.ylabel("Transmittance", fontsize=16)
+ax.legend(loc="lower right", bbox_to_anchor=(1, 0), fontsize=8, ncol=4)
+ax.get_xaxis().get_major_formatter().set_useOffset(
+    False
+)  # To avoid exponential labeling
+plt.tick_params(labelsize=16)
+plt.text(
+    0.99,
+    1.01,
+    "Line N=" + str(len(mdb.nu_lines)),
+    fontsize=10,
+    va="bottom",
+    ha="right",
+    transform=ax.transAxes,
+)
+
+# Read the Wavelength range as str
+wavmin_str = str(wmin).replace(".", "")
+wavmax_str = str(wmax).replace(".", "")
+
+direc = "Results/TransSpectra/"
+Fname = (
+    "TEST_"
+    + "CH4-VMR1_L="
+    + str(L)
+    + "cm_T1000K_P1430_"
+    + wavmin_str
+    + "-"
+    + wavmax_str
+    + "_00025_hitemp_gamma-air_linenum"
+    + str(linenum)
+    + "_VSmeasure_adjustrange_opa-Tbroad-Tref-Treforig"
+)
+
+# save the Graph
+plt.savefig(
+    direc + Fname + "_eachline_wong2019_2408rev_VScrosssection.jpg", bbox_inches="tight"
+)
+print("Saved .jpg as ", Fname, "_eachline.jpg")
+
+# plt.show()
+plt.clf()  # clear the plot
+plt.close()  # close the plot window
+
+"""
+#Save the plot data as txt file
+Modeldirectry = "Results/TransSpectra/"
+f = open(Modeldirectry + Fname + ".txt",'w')
+for i in range(wavmodel.size): 
+    f.write(str(wavmodel[i]) + "," +str(transmodel_all[i]) +  "\n")
+    #f.write(str(wavmodel[i]) + "," +str(noisemodel[i]) +  "\n")
+f.close()
+print("Saved .txt as ", Fname)
+"""

--- a/tests/integration/premodit_lpf/README.md
+++ b/tests/integration/premodit_lpf/README.md
@@ -1,0 +1,2 @@
+# OpaPremodit vs LPF using methane
+This test compares OpaPremodit and LPF, made by KoHosokawa. See #520 and #521 (2024. September 2nd)

--- a/tests/integration/premodit_lpf/Trans_model_1Voigt_HITEMP_nu_2408rev_test.py
+++ b/tests/integration/premodit_lpf/Trans_model_1Voigt_HITEMP_nu_2408rev_test.py
@@ -1,0 +1,178 @@
+# calculate the Transmission model with Voigt×1 + cross-section
+# updated 2024/08/06
+
+
+# Import the modules
+from exojax.utils.constants import Patm, Tref_original  # [bar/atm]
+from exojax.spec.hitran import line_strength, doppler_sigma, gamma_hitran
+from exojax.spec import initspec, voigt
+from exojax.spec.lpf import xsmatrix as lpf_xsmatrix
+from jax import jit, vmap
+import numpy as np
+from jax import config
+import copy
+
+config.update("jax_enable_x64", True)
+# from HMC_defs_8data_nsep import gamma_hitran_nsep
+
+
+# multiply the alpha at Sij
+def Trans_model_MultiVoigt_test(
+    nu_offset,
+    alphas,
+    gamma_refs,
+    gamma_selfs,
+    ns,
+    Tarr,
+    P_total,
+    P_self,
+    L,
+    nMolecule,
+    nu_grid,
+    nu_data,
+    mdb_voigt,  # masked mdb for Voigt fitting
+    opa,
+    sop_inst,
+):
+
+    Lbin = L / len(Tarr)  # spliting the bins
+    # include the offset to wavenumber grid(it is shifted to the oppsite direction of actual offset)
+    nu_data_offset_grid = nu_data
+
+    # create the pressure array
+    P_total_array = np.full(len(Tarr), P_total)
+    P_self_array = np.full(len(Tarr), P_self)
+
+    # cross-section matrix of weak lines at each Temperature channel
+    xsmatrix_opa = opa.xsmatrix(Tarr, P_total_array)
+
+    # Calculation for Voigt fitting
+    # doppler width
+    doppler_array = jit(vmap(doppler_sigma, (None, 0, None)))(
+        mdb_voigt.nu_lines, Tarr, mdb_voigt.molmass
+    )
+    # partition function
+    Tref_array = np.full(len(Tarr), Tref_original)
+    qt = vmap(mdb_voigt.qr_interp_lines)(Tarr, Tref_array)
+
+    # line strength
+    SijM = jit(vmap(line_strength, (0, None, None, None, 0, None)))(
+        Tarr,
+        mdb_voigt.logsij0,
+        mdb_voigt.nu_lines,
+        mdb_voigt.elower,
+        qt,
+        Tref_original,
+    )
+
+    # test by HK
+    P_self_array = np.zeros_like(P_self_array)
+    gamma_selfs = np.zeros_like(gamma_selfs)
+
+    # Lorentz width
+    gamma_L_voigt = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))(
+        P_total_array,
+        Tarr,
+        P_self_array,
+        ns,
+        gamma_refs,
+        gamma_selfs,
+    )
+
+    # create wavenumber matrix
+    nu_matrix = initspec.init_lpf(mdb_voigt.nu_lines + nu_offset, nu_grid)
+
+    # cross section
+    xsmatrix_lpf = lpf_xsmatrix(nu_matrix, doppler_array, gamma_L_voigt, SijM * alphas)
+
+    # summing up all layers
+    xsmatrix_opa_alllayer = xsmatrix_opa.sum(axis=0)
+    xsmatrix_lpf_alllayer = xsmatrix_lpf.sum(axis=0)
+
+    # downsampling along to the instrumental resolution, include the effect of offset, trim the adjust range region
+    xsmatrix_opa_specgrid = sop_inst.sampling(
+        xsmatrix_opa_alllayer, 0, nu_data_offset_grid
+    )
+    xsmatrix_lpf_specgrid = sop_inst.sampling(
+        xsmatrix_lpf_alllayer, 0, nu_data_offset_grid
+    )
+
+    return xsmatrix_opa_specgrid, xsmatrix_lpf_specgrid
+
+
+def create_mdbs_multi(mdb, strline_ind_array_nu):
+    # Create the mdb copy and remove the strongest line
+    mdb_weak = copy.deepcopy(mdb)
+
+    # Ensure strline_ind is a 1D array
+    strline_inds = np.array(strline_ind_array_nu).flatten()
+    nu_centers = mdb_weak.nu_lines[strline_inds]
+
+    # nu_centers = [mdb_weak.nu_lines[i] for i in strline_inds]
+
+    # Create a mask: Set True for indices not included in strline_ind_array
+    mask = np.ones_like(mdb_weak.nu_lines, dtype=bool)
+    mask[strline_inds] = False  # Set positions corresponding to strline_ind to False
+
+    # Apply the mask
+    mdb_weak.apply_mask_mdb(mask)
+
+    # Check if the mdb_weak has one less data point
+    if len(mdb_weak.nu_lines) != len(mdb.nu_lines) - strline_inds.size:
+        raise ValueError(
+            "mdb_weak does not have the correct number of data points after removing the strongest line."
+        )
+
+    # Create the mdb class only including the line for Voigt fitting
+    mdb_voigt = copy.deepcopy(mdb)
+    mdb_voigt.apply_mask_mdb(~mask)
+    strline_inds = np.atleast_1d(strline_inds)
+    mdb_voigt.logsij0 = mdb_voigt.logsij0[strline_inds]
+
+    # Check if the mdb_voigt contains only the strongest line
+    if len(mdb_voigt.nu_lines) != strline_inds.size:
+        raise ValueError("mdb_voigt does not contain only the strong lines.")
+    if not np.all(np.isin(mdb_voigt.nu_lines, nu_centers)):
+        raise ValueError("The strong line in mdb_voigt does not match nu_center_array.")
+    return mdb_weak, nu_centers, mdb_voigt
+
+
+def calc_dnumber_isobaric(T_array, P0, T0):
+    """
+    #Calculate the number density at each region
+    Assumption(if there is "i" Temperature regions with same volume)
+       V1 = V2 =...= Vi = V_total / i
+       P1 = P2 =...= Pi = P_total
+       ∴ n1 * T1 = n2 * T2 = .... ni * Ti,
+         ni = T1 * n1 / Ti
+
+    Also, the Total amount of molecule is equal to the sum of each amount of molecule
+        n_total * V_total = n1 * V1 +...+ ni * Vi
+        n_total * i * V1 = (n1 + T1 / T2 * n1 + T1 / T3 * n1 +...+ T1 / Ti * n1) * V1
+        n_total * i = n1 * T1 * (1 / T1 + 1 / T2 +...+1 / Ti)
+        ∴ n1 = n_total * i / (T1 * Tinv_sum), (Tinv_sum = 1 / T1 + 1 / T2 +...+1 / Ti)
+
+        P_total = P1 = n1 * k_b * T1
+                     = n_total * i /(T1 * Tinv_sum) * k_b * T1
+                     = n_total * i * k_B /Tinv_sum
+
+    """
+
+    from exojax.atm.idealgas import number_density
+    from exojax.utils.constants import kB
+
+    # Calculate the total number density and volume at the initial condition by PV=n*k_b*T
+    n_total = number_density(P0, T0)  # P[bar]. n=P/k_b*T
+    # V_total = (n_total * kB * T0) / P0
+    nlayer = len(T_array)  # number of Temperature layer
+
+    Tinv_sum = 0
+    for i in range(nlayer):
+        Tinv_sum += 1 / T_array[i]
+    n_array = n_total * nlayer / (T_array * Tinv_sum)
+
+    # Calculate the pressure at given Temperatures(1e-6:conversion factor of the Pa to bar)
+    P_total = nlayer * kB * 1.0e-6 * n_total / (Tinv_sum)
+
+    # print(nlayer/Tinv_sum)
+    return n_array, P_total


### PR DESCRIPTION
addresses #520 

The bugs were [here](https://github.com/HajimeKawahara/exojax/pull/515/files#r1740101433) and other similar points. 

### What was wrong?

In `OpaPremodit`, `qr` should be normalized by `opa.Tref`. Before #515, this was done in `mdb`. But, this implementation can induce side effects because `opa` changes the internal state (i.e. `mdb.Tref`). In #515 I changed the code to be more stateless (but not complete yet though, anyway at least `opa` does not change `mdb`). Then I should have normalize `qr` in `opa` using `opa.Tref` but I forgot it. 

### LPF vs OpaPremodit
The test made by @KoHosokawa was included in `tests/integration/premodit_lpf/`.
It uses CH4 Hitemp, so, will take a bit long time for the first time.

The output should be like the following:

![TEST_CH4-VMR1_L=50cm_T1000K_P1430_162178-162193_00025_hitemp_gamma-air_linenum1_VSmeasure_adjustrange_opa-Tbroad-Tref-Treforig_eachline_wong2019_2408rev_VScrosssection](https://github.com/user-attachments/assets/1a51005d-13e2-4fa9-a2c2-4a3ace74c845)

 