### PR TITLE
Unittest for PreModit and bugfix in optgrid.py

### DIFF
--- a/src/exojax/spec/optgrid.py
+++ b/src/exojax/spec/optgrid.py
@@ -52,9 +52,9 @@ def optelower(
     ) = opa.opainfo
     nsigmaD = normalized_doppler_sigma(Tmax, mdb.molmass, R)
     if mdb.dbtype == "exomol":
-        qt = mdb.qr_interp(Tmax)
+        qt = mdb.qr_interp(Tmax, opa.Tref)
     elif mdb.dbtype == "hitran":
-        qt = mdb.qr_interp(isotope, Tmax)
+        qt = mdb.qr_interp(isotope, Tmax, opa.Tref)
 
     Tref_broadening = Tref_original
     xsv_master = xsvector_zeroth(

--- a/tests/integration/unittests_long/premodit/optgrid_test.py
+++ b/tests/integration/unittests_long/premodit/optgrid_test.py
@@ -4,6 +4,20 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 
+def test_optelower_exomol_fast():
+    from exojax.test.emulate_mdb import mock_mdbExomol
+    from exojax.test.emulate_mdb import mock_wavenumber_grid
+    
+    nu_grid, wav, reso = mock_wavenumber_grid()
+    Tmax = 1020.0  #K
+    Pmin = 0.1  #bar
+    mdb = mock_mdbExomol(crit=1.e-37)
+    Eopt = optelower(mdb, nu_grid, Tmax, Pmin, accuracy=0.0)
+    print("optimal elower_max=",Eopt,"cm-1")
+    assert Eopt == pytest.approx(11615.5075)
+
+
+
 def test_optelower_exomol():
     from exojax.test.emulate_mdb import mock_mdbExomol
     from exojax.test.emulate_mdb import mock_wavenumber_grid
@@ -29,6 +43,7 @@ def test_optelower_hitemp():
     print("optimal elower_max=",Eopt,"cm-1")
     assert Eopt == pytest.approx(11659.3718)
 
+
 if __name__ == "__main__":
-    #test_optelower_exomol()
+    test_optelower_exomol()
     test_optelower_hitemp()

--- a/tests/integration/unittests_long/premodit/optgrid_test.py
+++ b/tests/integration/unittests_long/premodit/optgrid_test.py
@@ -4,20 +4,6 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 
-def test_optelower_exomol_fast():
-    from exojax.test.emulate_mdb import mock_mdbExomol
-    from exojax.test.emulate_mdb import mock_wavenumber_grid
-    
-    nu_grid, wav, reso = mock_wavenumber_grid()
-    Tmax = 1020.0  #K
-    Pmin = 0.1  #bar
-    mdb = mock_mdbExomol(crit=1.e-37)
-    Eopt = optelower(mdb, nu_grid, Tmax, Pmin, accuracy=0.0)
-    print("optimal elower_max=",Eopt,"cm-1")
-    assert Eopt == pytest.approx(11615.5075)
-
-
-
 def test_optelower_exomol():
     from exojax.test.emulate_mdb import mock_mdbExomol
     from exojax.test.emulate_mdb import mock_wavenumber_grid

--- a/tests/unittests/spec/premodit/lbderror_test.py
+++ b/tests/unittests/spec/premodit/lbderror_test.py
@@ -127,15 +127,16 @@ def test_optimal_params():
     Tl_in = 500.0  #K
     Tu_in = 1200.0  #K
     diffmode = 2
-    dE, Tl, Tu = optimal_params(Tl_in, Tu_in, diffmode)
-    assert dE == pytest.approx((diffmode+1)*750.0)
-    assert Tl == pytest.approx(1153.6267095763965)
-    assert Tu == pytest.approx(554.1714566743503)
-  
+    dE, Tl, Tu = optimal_params(Tl_in, Tu_in, diffmode)    
+    assert dE == pytest.approx(2475.0)
+    assert Tl == pytest.approx(1108.1485374361412) 
+    assert Tu == pytest.approx(570.9650338563875)
+
 
 
 if __name__ == "__main__":
     #test_weight_points_dE()
     #test_single_tilde_line_strength()
     #test_single_tilde_line_strength_first()
-    test_worst_tilde_line_strength_first()
+    #test_worst_tilde_line_strength_first()
+    test_optimal_params()

--- a/tests/unittests/spec/premodit/optgrid_fast_test.py
+++ b/tests/unittests/spec/premodit/optgrid_fast_test.py
@@ -1,0 +1,25 @@
+""" unittest for exojax.spec.premodit.optgrid
+
+Note: 
+    for the complete test, use integration/unittests_long/premodit/optgrid_test.py
+
+"""
+
+
+from exojax.spec.optgrid import optelower
+import pytest
+from jax import config
+config.update("jax_enable_x64", True)
+
+
+def test_optelower_exomol_fast():
+    from exojax.test.emulate_mdb import mock_mdbExomol
+    from exojax.test.emulate_mdb import mock_wavenumber_grid
+    
+    nu_grid, wav, reso = mock_wavenumber_grid()
+    Tmax = 1020.0  #K
+    Pmin = 0.1  #bar
+    mdb = mock_mdbExomol(crit=1.e-37)
+    Eopt = optelower(mdb, nu_grid, Tmax, Pmin, accuracy=0.0)
+    print("optimal elower_max=",Eopt,"cm-1")
+    assert Eopt == pytest.approx(11615.5075)


### PR DESCRIPTION
addresses parts of #522 and found a small bug in optgrid.py (forgot to add `opa.Tref` in the argument of `qr_interp`)