### PR TITLE
deprecated option broderner_sepcies was removed (use bkgdatm)

### DIFF
--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -142,7 +142,7 @@ class MdbExomol(CapiMdbExomol):
             nurange=[wavenum_min, wavenum_max],
             engine=self.engine,
             crit=crit,
-            bkgdatm=self.bkgdatm,
+            bkgdatm=self.bkgdatm, #uses radis <= 0.15.2
             broadf=self.broadf,
             cache=True,
             skip_optional_data=self.skip_optional_data,
@@ -275,17 +275,16 @@ class MdbExomol(CapiMdbExomol):
         
         if version.parse(radis_version) <= version.parse("0.14"):
             self.compute_broadening(self.jlower.astype(int), self.jupper.astype(int))
+        elif version.parse(radis_version) <= version.parse("0.15.2"):
+            print("Broadener: ", self.bkgdatm)
+            self.set_broadening_coef(df[mask], add_columns=False)
         else:
-            try:
-                # new broadener see radis#716, radis#742
-                print("Broadener: ", self.bkgdatm)
-                self.set_broadening_coef(
-                    df[mask], add_columns=False, species=self.bkgdatm
-                )
-            except:
-                print("broadener_species option is not available. Broadener: H2")
-                self.set_broadening_coef(df[mask], add_columns=False)
-
+            # new broadener see radis#716, radis#742
+            print("Broadener: ", self.bkgdatm)
+            self.set_broadening_coef(
+                df[mask], add_columns=False, species=self.bkgdatm
+            )
+        
         self.gamma_natural = gn(self.A)
         if self.gpu_transfer:
             self.generate_jnp_arrays()

--- a/src/exojax/spec/api.py
+++ b/src/exojax/spec/api.py
@@ -99,7 +99,6 @@ class MdbExomol(CapiMdbExomol):
         activation=True,
         local_databases="./",
         engine=None,
-        broadener_species="H2",
     ):
         """Molecular database for Exomol form.
 
@@ -115,8 +114,7 @@ class MdbExomol(CapiMdbExomol):
             optional_quantum_states: if True, all of the fields available in self.df will be loaded. if False, the mandatory fields (i,E,g,J) will be loaded.
             activation: if True, the activation of mdb will be done when initialization, if False, the activation won't be done and it makes self.df attribute available.
             engine: engine for radis api ("pytables" or "vaex" or None). if None, radis automatically determines. default to None
-            broadener_species: broadener species for broadening. default to "H2", corresponding "species" in radis.api.exomolapi.MdbExomol.set_broadening_coef, available >= radis-0.16
-
+        
         Note:
             The trans/states files can be very large. For the first time to read it, we convert it to HDF/vaex. After the second-time, we use the HDF5 format with vaex instead.
         """
@@ -135,8 +133,7 @@ class MdbExomol(CapiMdbExomol):
         self.activation = activation
         wavenum_min, wavenum_max = self.set_wavenum(nurange)
         self.engine = _set_engine(engine)
-        self.broadener_species = broadener_species
-
+        
         super().__init__(
             str(self.path),
             local_databases=local_databases,
@@ -281,9 +278,9 @@ class MdbExomol(CapiMdbExomol):
         else:
             try:
                 # new broadener see radis#716, radis#742
-                print("Broadener: ", self.broadener_species)
+                print("Broadener: ", self.bkgdatm)
                 self.set_broadening_coef(
-                    df[mask], add_columns=False, species=self.broadener_species
+                    df[mask], add_columns=False, species=self.bkgdatm
                 )
             except:
                 print("broadener_species option is not available. Broadener: H2")

--- a/src/exojax/test/emulate_mdb.py
+++ b/src/exojax/test/emulate_mdb.py
@@ -59,7 +59,8 @@ def mock_mdbExomol(crit=0.):
                         nus,
                         crit=crit,
                         inherit_dataframe=True,
-                        gpu_transfer=True)
+                        gpu_transfer=True,
+                        )
     return mdb
 
 


### PR DESCRIPTION
I noticed #580 defined `broadener_species` option despite the presence of `bkgdatm` in `api.MdbExomol`
so removed the former. 
In addition, the new version was set in radis (0.16) so, I modified to use `radis.__version__` to switch the functions.  