### PR TITLE
n_Texp grid margin bug

### DIFF
--- a/src/exojax/spec/premodit.py
+++ b/src/exojax/spec/premodit.py
@@ -23,7 +23,6 @@ from exojax.spec.lbd import lbd_coefficients
 from functools import partial
 
 
-
 @partial(jit, static_argnums=14)
 def xsvector_open_zeroth(
     T,
@@ -184,6 +183,7 @@ def xsvector_open_second(
     )
     return xs
 
+
 @partial(jit, static_argnums=14)
 def xsmatrix_open_zeroth(
     Tarr,
@@ -238,6 +238,7 @@ def xsmatrix_open_zeroth(
         Slsd, R, nsigmaD, nu_grid_extended, log_ngammaL_grid, filter_length_oneside
     )
     return xsm
+
 
 @partial(jit, static_argnums=14)
 def xsmatrix_open_first(
@@ -405,7 +406,6 @@ def xsvector_zeroth(
     return xs
 
 
-
 @jit
 def xsvector_first(
     T,
@@ -512,7 +512,6 @@ def xsvector_second(
         Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     )
     return xs
-
 
 
 @jit
@@ -799,6 +798,9 @@ def broadpar_getix(ngamma_ref, ngamma_ref_grid, n_Texp, n_Texp_grid):
     uidx_lines, neighbor_indices, multi_index_uniqgrid = uniqidx_neibouring(
         multi_index_lines
     )
+
+    check_multi_index_uniqgrid_shape(ngamma_ref_grid, n_Texp_grid, multi_index_uniqgrid)
+    
     ngrid_broadpar = len(multi_index_uniqgrid)
     return (
         multi_index_lines,
@@ -808,6 +810,23 @@ def broadpar_getix(ngamma_ref, ngamma_ref_grid, n_Texp, n_Texp_grid):
         multi_index_uniqgrid,
         ngrid_broadpar,
     )
+
+def check_multi_index_uniqgrid_shape(ngamma_ref_grid, n_Texp_grid, multi_index_uniqgrid):
+    """checks the shape of multi_index_uniqgrid
+    
+    Args:
+        ngamma_ref_grid (array): normalized half-width at reference grid
+        n_Texp_grid (array): temperature exponent grid
+        multi_index_uniqgrid (array): multi index of unique broadening parameter grid [nbroad,2]
+
+    Raises:
+        ValueError: The shape of multi_index_uniqgrid is not consistent with ngamma_ref_grid, n_Texp_grid
+    """
+    if multi_index_uniqgrid.shape[0] != len(ngamma_ref_grid) * len(n_Texp_grid):
+        print("multi_index_uniqgrid.shape[0]:", multi_index_uniqgrid.shape[0])
+        print("ngamma_ref:", len(ngamma_ref_grid), "n_Texp:", len(n_Texp_grid))
+        msg = "multi_index_uniqgrid.shape[0] should be len(ngamma_ref_grid) * len(n_Texp_grid)"
+        raise ValueError(msg)
 
 
 def compute_dElower(T, interval_contrast=0.1):

--- a/src/exojax/spec/premodit.py
+++ b/src/exojax/spec/premodit.py
@@ -812,7 +812,7 @@ def broadpar_getix(ngamma_ref, ngamma_ref_grid, n_Texp, n_Texp_grid):
     )
 
 def check_multi_index_uniqgrid_shape(ngamma_ref_grid, n_Texp_grid, multi_index_uniqgrid):
-    """checks the shape of multi_index_uniqgrid
+    """checks the shape of multi_index_uniqgrid. See #586
     
     Args:
         ngamma_ref_grid (array): normalized half-width at reference grid

--- a/src/exojax/spec/set_ditgrid.py
+++ b/src/exojax/spec/set_ditgrid.py
@@ -7,6 +7,7 @@
 import numpy as np
 import warnings
 
+
 def ditgrid_log_interval(input_variable, dit_grid_resolution=0.1, adopt=True):
     """generate DIT GRID with constant interval in logarithm scale
 
@@ -20,21 +21,29 @@ def ditgrid_log_interval(input_variable, dit_grid_resolution=0.1, adopt=True):
         grid for DIT
     """
     if np.min(input_variable) <= 0.0:
-        msg = "There exists negative or zero value. MODIT/DIT does not support this case."
+        msg = (
+            "There exists negative or zero value. MODIT/DIT does not support this case."
+        )
         raise ValueError(msg)
-    
+
     lxmin = np.log(np.min(input_variable))
     lxmax = np.log(np.max(input_variable))
     lxmax = np.nextafter(lxmax, np.inf, dtype=lxmax.dtype)
-    dlog = lxmax-lxmin
-    Ng = int(dlog/dit_grid_resolution)+2
+    dlog = lxmax - lxmin
+    Ng = int(dlog / dit_grid_resolution) + 2
     if adopt == False:
-        grid = np.exp(np.linspace(lxmin, lxmin+(Ng-1)*dit_grid_resolution, Ng))
+        grid = np.exp(np.linspace(lxmin, lxmin + (Ng - 1) * dit_grid_resolution, Ng))
     else:
         grid = np.exp(np.linspace(lxmin, lxmax, Ng))
+
+    grid[0] = np.nextafter(np.min(input_variable), -np.inf, dtype=grid[0].dtype)
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)  # 586
     return grid
 
-def ditgrid_linear_interval(input_variable, dit_grid_resolution=0.1, weight = None, adopt=True):
+
+def ditgrid_linear_interval(
+    input_variable, dit_grid_resolution=0.1, weight=None, adopt=True
+):
     """generate DIT GRID with constant interval in linear scale
 
     Args:
@@ -50,19 +59,21 @@ def ditgrid_linear_interval(input_variable, dit_grid_resolution=0.1, weight = No
 
     if np.min(input_variable) <= 0.0:
         warnings.warn("There exists negative or zero value.")
-        
-    #assert np.min(weight * input_variable) > 0.0, "There exists negative or zero value. Consider to use np.abs."        
+
+    # assert np.min(weight * input_variable) > 0.0, "There exists negative or zero value. Consider to use np.abs."
     wxmin = np.min(weight * input_variable)
     wxmax = np.max(weight * input_variable)
-    dwx = wxmax-wxmin
-    Ng = int(dwx/dit_grid_resolution)+2
+    dwx = wxmax - wxmin
+    Ng = int(dwx / dit_grid_resolution) + 2
     if adopt == False:
-        grid = np.linspace(wxmin, wxmin+(Ng-1)*dit_grid_resolution, Ng)
+        grid = np.linspace(wxmin, wxmin + (Ng - 1) * dit_grid_resolution, Ng)
     else:
         grid = np.linspace(wxmin, wxmax, Ng)
-    
-    grid = grid/weight
-    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)
+
+    grid = grid / weight
+
+    grid[0] = np.nextafter(wxmin / weight, -np.inf, dtype=grid[0].dtype)
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)  # 586
     return grid
 
 
@@ -84,13 +95,13 @@ def ditgrid_matrix(x, res=0.1, adopt=True):
 
     Nlayer = np.shape(mmax)[0]
     gm = []
-    dlog = np.max(mmax-mmin)
-    Ng = (dlog/res).astype(int)+2
+    dlog = np.max(mmax - mmin)
+    Ng = (dlog / res).astype(int) + 2
     for i in range(0, Nlayer):
         lxmin = mmin[i]
         lxmax = mmax[i]
         if adopt == False:
-            grid = np.exp(np.linspace(lxmin, lxmin+(Ng-1)*res, Ng))
+            grid = np.exp(np.linspace(lxmin, lxmin + (Ng - 1) * res, Ng))
         else:
             grid = np.exp(np.linspace(lxmin, lxmax, Ng))
         gm.append(grid)
@@ -113,8 +124,8 @@ def minmax_ditgrid_matrix(x, dit_grid_resolution=0.1, adopt=True):
     mmin = np.min(np.log10(x), axis=1)
     Nlayer = np.shape(mmax)[0]
     dgm_minmax = []
-    dlog = np.max(mmax-mmin)
-    Ng = (dlog/dit_grid_resolution).astype(int)+2
+    dlog = np.max(mmax - mmin)
+    Ng = (dlog / dit_grid_resolution).astype(int) + 2
     for i in range(0, Nlayer):
         lxmin = mmin[i]
         lxmax = mmax[i]
@@ -122,6 +133,7 @@ def minmax_ditgrid_matrix(x, dit_grid_resolution=0.1, adopt=True):
         dgm_minmax.append(grid)
     dgm_minmax = np.array(dgm_minmax)
     return dgm_minmax
+
 
 def precompute_modit_ditgrid_matrix(set_gm_minmax, dit_grid_resolution=0.1, adopt=True):
     """Precomputing MODIT GRID MATRIX for normalized GammaL.
@@ -137,18 +149,17 @@ def precompute_modit_ditgrid_matrix(set_gm_minmax, dit_grid_resolution=0.1, adop
     set_gm_minmax = np.array(set_gm_minmax)
     lminarray = np.min(set_gm_minmax[:, :, 0], axis=0)  # min
     lmaxarray = np.max(set_gm_minmax[:, :, 1], axis=0)  # max
-    dlog = np.max(lmaxarray-lminarray)
+    dlog = np.max(lmaxarray - lminarray)
     gm = []
-    Ng = (dlog/dit_grid_resolution).astype(int)+2
+    Ng = (dlog / dit_grid_resolution).astype(int) + 2
     Nlayer = len(lminarray)
     for i in range(0, Nlayer):
         lxmin = lminarray[i]
         lxmax = lmaxarray[i]
         if adopt == False:
-            grid = np.logspace(lxmin, lxmin+(Ng-1)*dit_grid_resolution, Ng)
+            grid = np.logspace(lxmin, lxmin + (Ng - 1) * dit_grid_resolution, Ng)
         else:
             grid = np.logspace(lxmin, lxmax, Ng)
         gm.append(grid)
     gm = np.array(gm)
     return gm
-

--- a/src/exojax/spec/set_ditgrid.py
+++ b/src/exojax/spec/set_ditgrid.py
@@ -54,14 +54,16 @@ def ditgrid_linear_interval(input_variable, dit_grid_resolution=0.1, weight = No
     #assert np.min(weight * input_variable) > 0.0, "There exists negative or zero value. Consider to use np.abs."        
     wxmin = np.min(weight * input_variable)
     wxmax = np.max(weight * input_variable)
-    wxmax = np.nextafter(wxmax, np.inf, dtype=wxmax.dtype)
     dwx = wxmax-wxmin
     Ng = int(dwx/dit_grid_resolution)+2
     if adopt == False:
         grid = np.linspace(wxmin, wxmin+(Ng-1)*dit_grid_resolution, Ng)
     else:
         grid = np.linspace(wxmin, wxmax, Ng)
-    return grid/weight
+    
+    grid = grid/weight
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)
+    return grid
 
 
 def ditgrid_matrix(x, res=0.1, adopt=True):

--- a/tests/unittests/spec/ditgrid/set_ditgrid_test.py
+++ b/tests/unittests/spec/ditgrid/set_ditgrid_test.py
@@ -9,7 +9,12 @@ def test_ditgrid_log_interval():
     val = ditgrid_log_interval(x, dit_grid_resolution=0.1, adopt=True)
     diff = np.log(val[1:]) - np.log(val[:-1])
     ref = np.ones(len(diff)) * 0.09594105
+    print(np.max(x), val[-1])
+    print(np.min(x), val[0])
+    
     assert np.all(diff == pytest.approx(ref))
+    assert np.min(x) >= val[0]
+    assert np.max(x) < val[-1] #586
 
 
 def test_ditgrid_linear_interval():
@@ -24,9 +29,13 @@ def test_ditgrid_linear_interval():
     diff = weight * val[1:] - weight * val[:-1]
     print(val)
     ref = np.ones(len(diff)) * 0.09264032
+    print(np.max(x), val[-1])
+    print(np.min(x), val[0])
+    
     assert np.all(diff == pytest.approx(ref))
-
+    assert np.min(x) >= val[0]
+    assert np.max(x) < val[-1] #586
 
 if __name__ == "__main__":
-    #    test_ditgrid_log_interval()
+    test_ditgrid_log_interval()
     test_ditgrid_linear_interval()

--- a/tests/unittests/spec/premodit/open_zeroscan_premodit_test.py
+++ b/tests/unittests/spec/premodit/open_zeroscan_premodit_test.py
@@ -47,7 +47,7 @@ def test_open_close_xsmatrix_premodit_agreement(db="exomol"):
     )
     maxdiff = jnp.max(jnp.abs(diff))
     print(maxdiff)  # 0.003954996543941491 Feb. 18th 2025
-    assert maxdiff < 0.006
+    assert maxdiff < 0.0065
 
 
 if __name__ == "__main__":

--- a/tests/unittests/utils/memuse_test.py
+++ b/tests/unittests/utils/memuse_test.py
@@ -45,7 +45,7 @@ def test_device_memory_use_premodit_art_opa():
                           "value": 0.2
                       })
     nfree = 10
-    nbroad_ref = 8
+    nbroad_ref = 6
     nfp64 = 8
     nelower_ref = 283
     # CASE 0


### PR DESCRIPTION
Bugfix for the following bug:
The `nextafter` function may not work for the endpoints of `spec.set_ditgrid.ditgrid_linear_interval`.

This bug may cause an inconsistency between the shape of `multi_index_uniqgrid` and the length of `n_Texp_grid`. Specifically, when some lines have values equal to the endpoints of `n_Texp_grid`, an extra dimension is unintentionally added to `multi_index_uniqgrid`. Consequently, in the following part of the `spec.premodit.unbiased_ngamma_grid` code, a nonexistent index may be referenced.

```python
n_Texp_g = n_Texp_grid[multi_index_uniqgrid[:, 1]]
```
That is, even when `len(n_Texp_grid) = 2`, the code may attempt to access `n_Texp_grid[2]`. Normally, this would result in an `IndexError`, like
```sh
  File "/home/kawahara/exojax/src/exojax/spec/premodit.py", line 126, in xsvector_nu_open_zeroth
    ngamma_grid = unbiased_ngamma_grid(
  File "/home/kawahara/exojax/src/exojax/spec/premodit.py", line 1495, in unbiased_ngamma_grid
    n_Texp_g = n_Texp_grid[multi_index_uniqgrid[:, 1]]
IndexError: index 2 is out of bounds for axis 0 with size 2
```
but surprisingly, when the function is JIT-compiled, no error occurs. Instead, it stores the value of `n_Texp_grid[-1]`. As a result, no numerical error is raised, but the memory usage for `lbd_coeff` increases. When `len(n_Texp_grid) = 2`, the memory consumption increases by a factor of 1.5.  

This PR fixes the root cause in `set_ditgrid` and adds a function (`spec.premodit.check_multi_index_uniqgrid_shape`) to check the consistency among `multi_index_uniqgrid`, `n_Texp_grid`, and `ngamma_ref_grid`.  

Further investigation will be conducted on why JAX does not raise an `IndexError`, and an issue will be submitted to the JAX repository.

