### PR TITLE
nextafter type changed to np.float32

### DIFF
--- a/src/exojax/spec/set_ditgrid.py
+++ b/src/exojax/spec/set_ditgrid.py
@@ -36,8 +36,8 @@ def ditgrid_log_interval(input_variable, dit_grid_resolution=0.1, adopt=True):
     else:
         grid = np.exp(np.linspace(lxmin, lxmax, Ng))
 
-    grid[0] = np.nextafter(np.min(input_variable), -np.inf, dtype=grid[0].dtype)
-    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)  # 586
+    grid[0] = np.nextafter(np.min(input_variable), -np.inf, dtype=np.float32)
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586
     return grid
 
 
@@ -72,8 +72,8 @@ def ditgrid_linear_interval(
 
     grid = grid / weight
 
-    grid[0] = np.nextafter(wxmin / weight, -np.inf, dtype=grid[0].dtype)
-    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=grid[-1].dtype)  # 586
+    grid[0] = np.nextafter(wxmin / weight, -np.inf, dtype=np.float32)
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586
     return grid
 
 

--- a/src/exojax/spec/set_ditgrid.py
+++ b/src/exojax/spec/set_ditgrid.py
@@ -1,4 +1,4 @@
-"""set DIT 
+"""set DIT
 
 * This module provides functions to generate the grid used in DIT/MODIT/PreMODIT.
 
@@ -37,7 +37,7 @@ def ditgrid_log_interval(input_variable, dit_grid_resolution=0.1, adopt=True):
         grid = np.exp(np.linspace(lxmin, lxmax, Ng))
 
     grid[0] = np.nextafter(np.min(input_variable), -np.inf, dtype=np.float32)
-    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586 # 590
     return grid
 
 
@@ -73,7 +73,7 @@ def ditgrid_linear_interval(
     grid = grid / weight
 
     grid[0] = np.nextafter(wxmin / weight, -np.inf, dtype=np.float32)
-    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586
+    grid[-1] = np.nextafter(grid[-1], np.inf, dtype=np.float32)  # 586 # 590
     return grid
 
 

--- a/tests/unittests/spec/ditgrid/set_ditgrid_test.py
+++ b/tests/unittests/spec/ditgrid/set_ditgrid_test.py
@@ -9,10 +9,8 @@ def test_ditgrid_log_interval():
     val = ditgrid_log_interval(x, dit_grid_resolution=0.1, adopt=True)
     diff = np.log(val[1:]) - np.log(val[:-1])
     ref = np.ones(len(diff)) * 0.09594105
-    print(np.max(x), val[-1])
-    print(np.min(x), val[0])
     
-    assert np.all(diff == pytest.approx(ref))
+    assert np.all(diff[:-1] == pytest.approx(ref[:-1])) #the last component differs slightly see #586 #590
     assert np.min(x) >= val[0]
     assert np.max(x) < val[-1] #586
 
@@ -27,12 +25,11 @@ def test_ditgrid_linear_interval():
                                   weight=weight,
                                   adopt=True)
     diff = weight * val[1:] - weight * val[:-1]
-    print(val)
     ref = np.ones(len(diff)) * 0.09264032
     print(np.max(x), val[-1])
     print(np.min(x), val[0])
     
-    assert np.all(diff == pytest.approx(ref))
+    assert np.all(diff[:-1] == pytest.approx(ref[:-1])) #the last component differs slightly see #586 #590
     assert np.min(x) >= val[0]
     assert np.max(x) < val[-1] #586
 


### PR DESCRIPTION
I found dtype for `np.nextafter` in `set_ditgrid` in #586 should be float32