### PR TITLE
Set custom JVP for sqrt in opachord to enable forward mode differentiation of transmission

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4
 hjson          # Json with comments (for default_radis.json)
 tqdm
 PyMieScatt
-radis == 0.15.2
+radis == 0.15.2 # temporary downgrade to avoid issues with the latest version (#822)
 numba
 tables
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4
 hjson          # Json with comments (for default_radis.json)
 tqdm
 PyMieScatt
-radis >= 0.15.2
+radis == 0.15.2
 numba
 tables
 pandas


### PR DESCRIPTION
Fixed NaN issue in forward mode differentiation of the transmission spectrum by adding a custom JVP for sqrt in opachord.py.

Changes:
Implemented custom JVP for sqrt to handle division by zero.

Note:
Without [at]jit for chord_geometric_matrix_lower and chord_geometric_matrix, both branches of where may be evaluated, causing division by zero when x = 0. 