### PR TITLE
Reflect updates to astropy (unit "Angstrom")

### DIFF
--- a/src/exojax/utils/photometry.py
+++ b/src/exojax/utils/photometry.py
@@ -68,6 +68,8 @@ def download_filter_from_svo(filter_id):
     print("You can check the available filters at", url_svo_filter())
     data = SvoFps.get_transmission_data(filter_id)
     unit = str(data["Wavelength"].unit)
+    if unit == "Angstrom": # for astropy >= 7.1.0
+        unit = "AA"
     wl_ref = np.array(data["Wavelength"])
     nu_ref, transmission_ref = wav2nu(
         wl_ref, unit=unit, values=np.array(data["Transmission"])


### PR DESCRIPTION
This PR resolves the unit conflict described in issue #613.
With astropy=7.1.0, the unit "Angstrom" is returned. I modified the `download_filter_from_svo()` function to convert this to "AA", since the conversion factors in `wav2nu` only accept "AA". 

As far as I can confirm, this issue seems to affect only this specific part. (I searched the codebase for both "astropy" and "astroquery", but this was the only place where the problem appeared.)