### PR TITLE
bug fix of the overflow of the line strength when 32 bit mode

### DIFF
--- a/src/exojax/database/api.py
+++ b/src/exojax/database/api.py
@@ -56,6 +56,9 @@ def _set_engine(engine):
     print("radis engine = ", engine_selected)
     return engine_selected
 
+def _checkf64(instance, name):
+    if instance.dtype != np.float64:
+        raise TypeError(name+" must be np.float64, but got {}".format(instance).dtype)
 
 class MdbExomol(CapiMdbExomol):
     """molecular database of ExoMol form.
@@ -310,8 +313,8 @@ class MdbExomol(CapiMdbExomol):
     def compute_load_mask(self, df):
         # wavelength
         mask = (df.nu_lines > self.nurange[0]) & (df.nu_lines < self.nurange[1])
-        QTtyp = np.array(self.QT_interp(self.Ttyp))
-        QTref_original = np.array(self.QT_interp(Tref_original))
+        QTtyp = np.array(self.QT_interp_numpy(self.Ttyp))
+        QTref_original = np.array(self.QT_interp_numpy(Tref_original))
         mask = mask & (
             line_strength_numpy(
                 self.Ttyp, df.Sij0, df.nu_lines, df.elower, QTtyp / QTref_original
@@ -357,15 +360,7 @@ class MdbExomol(CapiMdbExomol):
         # jnp arrays
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        self.gamma_natural = jnp.array(self.gamma_natural)
-        self.A = jnp.array(self.A)
-        self.elower = jnp.array(self.elower)
-        self.gpp = jnp.array(self.gpp)
-        self.jlower = jnp.array(self.jlower, dtype=int)
-        self.jupper = jnp.array(self.jupper, dtype=int)
-        self.alpha_ref = jnp.array(self.alpha_ref)
-        self.n_Texp = jnp.array(self.n_Texp)
-
+        
     def QT_interp(self, T):
         """interpolated partition function.
 
@@ -376,6 +371,18 @@ class MdbExomol(CapiMdbExomol):
             Q(T) interpolated in jnp.array
         """
         return jnp.interp(T, self.T_gQT, self.gQT)
+
+    def QT_interp_numpy(self, T):
+        """interpolated partition function using numpy.
+
+        Args:
+            T: temperature
+
+        Returns:
+            Q(T) interpolated in np.array
+        """
+        return np.interp(T, self.T_gQT, self.gQT)
+
 
     def qr_interp(self, T, Tref):
         """interpolated partition function ratio.
@@ -389,6 +396,19 @@ class MdbExomol(CapiMdbExomol):
         """
         return self.QT_interp(T) / self.QT_interp(Tref)
 
+    def qr_interp_numpy(self, T, Tref):
+        """interpolated partition function ratio numpy version.
+
+        Args:
+            T: temperature
+            Tref: reference temperature
+
+        Returns:
+            qr(T)=Q(T)/Q(Tref) interpolated
+        """
+        return self.QT_interp_numpy(T) / self.QT_interp_numpy(Tref)
+
+
     def line_strength(self, T):
         """line strength at T
 
@@ -398,7 +418,9 @@ class MdbExomol(CapiMdbExomol):
         Returns:
             float: line strength at T
         """
-        qr = self.qr_interp(T, Tref_original)
+        
+        qr = self.qr_interp_numpy(T, Tref_original)
+        
         return line_strength_numpy(
             T,
             self.line_strength_ref_original,
@@ -407,6 +429,7 @@ class MdbExomol(CapiMdbExomol):
             qr,
             Tref_original,
         )
+
 
 
 class MdbCommonHitempHitran:
@@ -895,17 +918,7 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        self.line_strength_ref_original = jnp.array(self.line_strength_ref_original)
-        self.delta_air = jnp.array(self.delta_air)
-        self.A = jnp.array(self.A)
-        self.n_air = jnp.array(self.n_air)
-        self.gamma_air = jnp.array(self.gamma_air)
-        self.gamma_self = jnp.array(self.gamma_self)
-        self.elower = jnp.array(self.elower)
-        self.gpp = jnp.array(self.gpp)
-        if self.with_error:
-            self.ierr = jnp.array(self.ierr)
-
+        
 
 class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
     """molecular database of HITRAN
@@ -1151,33 +1164,7 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        self.line_strength_ref_original = jnp.array(self.line_strength_ref_original)
-        self.delta_air = jnp.array(self.delta_air)
-        self.A = jnp.array(self.A)
-        self.n_air = jnp.array(self.n_air)
-        self.gamma_air = jnp.array(self.gamma_air)
-        self.gamma_self = jnp.array(self.gamma_self)
-        self.elower = jnp.array(self.elower)
-        self.gpp = jnp.array(self.gpp)
-        if self.with_error:
-            self.ierr = jnp.array(self.ierr)
-
-        if hasattr(self.df_load_mask, "n_h2") and self.nonair_broadening:
-            self.n_h2 = jnp.array(self.n_h2)
-            self.gamma_h2 = jnp.array(self.gamma_h2)
-
-        if hasattr(self.df_load_mask, "n_he") and self.nonair_broadening:
-            self.n_he = jnp.array(self.n_he)
-            self.gamma_he = jnp.array(self.gamma_he)
-
-        if hasattr(self.df_load_mask, "n_co2") and self.nonair_broadening:
-            self.n_co2 = jnp.array(self.n_co2)
-            self.gamma_co2 = jnp.array(self.gamma_co2)
-
-        if hasattr(self.df_load_mask, "n_h2o") and self.nonair_broadening:
-            self.n_h2o = jnp.array(self.n_h2o)
-            self.gamma_h2o = jnp.array(self.gamma_h2o)
-
+        
 
 def _convert_proper_isotope(isotope):
     """covert isotope (int) to proper type for df

--- a/src/exojax/database/api.py
+++ b/src/exojax/database/api.py
@@ -6,7 +6,7 @@
 * MdbCommonHitempHitran is the common MDB for HITEMP and HITRAN
 
 Notes:
-    If you use vaex as radis engine, hdf5 files are saved while pytables uses .h5 files. 
+    If you use vaex as radis engine, hdf5 files are saved while pytables uses .h5 files.
 
 """
 
@@ -28,10 +28,10 @@ from radis.db.classes import get_molecule
 from radis.levels.partfunc import PartFuncTIPS
 
 from exojax.database import hitranapi
-from exojax.database.hitran  import gamma_natural as gn
-from exojax.database.hitran  import line_strength_numpy
+from exojax.database.hitran import gamma_natural as gn
+from exojax.database.hitran import line_strength_numpy
 from exojax.database.hitranapi import molecid_hitran
-from exojax.database.molinfo  import isotope_molmass
+from exojax.database.molinfo import isotope_molmass
 from exojax.utils.constants import Tref_original
 from exojax.utils.isotopes import molmass_hitran
 from exojax.utils.molname import e2s
@@ -292,7 +292,7 @@ class MdbExomol(CapiMdbExomol):
             mask = self.df_load_mask
 
         self.attributes_from_dataframes(df[mask])
-        
+
         if version.parse(radis_version) <= version.parse("0.14"):
             self.compute_broadening(self.jlower.astype(int), self.jupper.astype(int))
         elif version.parse(radis_version) <= version.parse("0.15.2"):
@@ -357,7 +357,7 @@ class MdbExomol(CapiMdbExomol):
         # jnp arrays
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        
+
     def QT_interp(self, T):
         """interpolated partition function.
 
@@ -379,7 +379,6 @@ class MdbExomol(CapiMdbExomol):
             Q(T) interpolated in np.array
         """
         return np.interp(T, self.T_gQT, self.gQT)
-
 
     def qr_interp(self, T, Tref):
         """interpolated partition function ratio.
@@ -405,7 +404,6 @@ class MdbExomol(CapiMdbExomol):
         """
         return self.QT_interp_numpy(T) / self.QT_interp_numpy(Tref)
 
-
     def line_strength(self, T):
         """line strength at T
 
@@ -415,9 +413,7 @@ class MdbExomol(CapiMdbExomol):
         Returns:
             float: line strength at T
         """
-        
         qr = self.qr_interp_numpy(T, Tref_original)
-        
         return line_strength_numpy(
             T,
             self.line_strength_ref_original,
@@ -426,7 +422,6 @@ class MdbExomol(CapiMdbExomol):
             qr,
             Tref_original,
         )
-
 
 
 class MdbCommonHitempHitran:
@@ -915,7 +910,7 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        
+
 
 class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
     """molecular database of HITRAN
@@ -1161,7 +1156,7 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         # jnp.array copy from the copy sources
         self.dev_nu_lines = jnp.array(self.nu_lines)
         self.logsij0 = jnp.array(np.log(self.line_strength_ref_original))
-        
+
 
 def _convert_proper_isotope(isotope):
     """covert isotope (int) to proper type for df

--- a/src/exojax/database/api.py
+++ b/src/exojax/database/api.py
@@ -56,9 +56,6 @@ def _set_engine(engine):
     print("radis engine = ", engine_selected)
     return engine_selected
 
-def _checkf64(instance, name):
-    if instance.dtype != np.float64:
-        raise TypeError(name+" must be np.float64, but got {}".format(instance).dtype)
 
 class MdbExomol(CapiMdbExomol):
     """molecular database of ExoMol form.

--- a/src/exojax/database/hitran.py
+++ b/src/exojax/database/hitran.py
@@ -46,13 +46,14 @@ def line_strength_numpy(T, Sij0, nu_lines, elower, qr, Tref=Tref_original):
     Returns:
         line strength at Ttyp
     """
-    return (
+    _line_strength = (
         Sij0
         * np.exp(-hcperk * elower * (1.0 / T - 1.0 / Tref))
         * np.expm1(-hcperk * nu_lines / T)
         / np.expm1(-hcperk * nu_lines / Tref)
         / qr  # Apply qr (jnp array) last to minimize rounding errors in 32bit mode.
     )
+    return _line_strength
 
 
 @jit

--- a/src/exojax/opacity/_common/profconv.py
+++ b/src/exojax/opacity/_common/profconv.py
@@ -107,11 +107,9 @@ def calc_xsection_from_lsd_zeroscan(
         log_ngammaL_grid,
         Ng_nu,
         pmarray,
-    )
-    
+    )    
     init = jnp.zeros(vk.shape[0], dtype=_check_complex(vk[0, 0]))
     fftvalvk, _ = scan(f, init, [Slsd.T, vk.T])
-    
     return jnp.fft.irfft(fftvalvk)[:Ng_nu] * R / nu_grid
 
 

--- a/src/exojax/opacity/_common/profconv.py
+++ b/src/exojax/opacity/_common/profconv.py
@@ -5,7 +5,6 @@
     - calc_xsection_from_lsd_scanfft: compute cross section from LSD in MODIT algorithm using scan+fft to avoid 4GB memory limit in fft (see #277), deprecated
 
 """
-
 import jax.numpy as jnp
 from jax import vmap
 from jax.lax import scan
@@ -109,9 +108,10 @@ def calc_xsection_from_lsd_zeroscan(
         Ng_nu,
         pmarray,
     )
-
+    
     init = jnp.zeros(vk.shape[0], dtype=_check_complex(vk[0, 0]))
     fftvalvk, _ = scan(f, init, [Slsd.T, vk.T])
+    
     return jnp.fft.irfft(fftvalvk)[:Ng_nu] * R / nu_grid
 
 

--- a/src/exojax/opacity/initspec.py
+++ b/src/exojax/opacity/initspec.py
@@ -280,9 +280,8 @@ def init_premodit(
         len(ngamma_ref_grid),
         len(n_Texp_grid),
     )
-
     wavmask = (nu_lines >= nu_grid[0]) * (nu_lines <= nu_grid[-1])  # Issue 341
-
+    
     lbd_coeff, multi_index_uniqgrid = generate_lbd(
         line_strength_ref[wavmask],
         nu_lines[wavmask],

--- a/src/exojax/opacity/premodit/api.py
+++ b/src/exojax/opacity/premodit/api.py
@@ -265,7 +265,8 @@ class OpaPremodit(OpaCalc):
         )
 
         # comment-1: gamma_ref at Tref_broadening (is not necessary for Tref_original)
-        # comment-2: line strength at Tref (is not necessary for Tref_original)
+        # comment-2: line strength at Tref (is not necessary for Tref_original), should be np.float64
+        
         (
             self.lbd_coeff,
             multi_index_uniqgrid,

--- a/src/exojax/opacity/premodit/premodit.py
+++ b/src/exojax/opacity/premodit/premodit.py
@@ -20,7 +20,10 @@ from exojax.opacity._common.profconv import (
     calc_open_nu_xsection_from_lsd_zeroscan,
     calc_xsection_from_lsd_zeroscan,
 )
-from exojax.opacity._common.set_ditgrid import ditgrid_linear_interval, ditgrid_log_interval
+from exojax.opacity._common.set_ditgrid import (
+    ditgrid_linear_interval,
+    ditgrid_log_interval,
+)
 from exojax.utils.constants import Tref_original, hcperk
 from exojax.utils.indexing import npgetix, uniqidx_neibouring
 
@@ -721,7 +724,7 @@ def xsmatrix_nu_open_second(
     return xsm
 
 
-@jit 
+@jit
 def xsvector_zeroth(
     T,
     P,
@@ -1156,7 +1159,7 @@ def broadpar_getix(ngamma_ref, ngamma_ref_grid, n_Texp, n_Texp_grid):
         >>> print(multi_index_lines[iline_interest]) # multi index from a line
         >>> print(multi_cont_lines[iline_interest]) # multi contribution from a line
         >>> print(uidx_lines[iline_interest]) # uniq index of a line
-        >>> print(multi_index_uniqgrid[uniq_index]) # multi index from uniq_index
+        >>> print(multi_index_uniqgrid[uniq_qr_interp_numpyindex]) # multi index from uniq_index
         >>> ui,uj,uk=neighbor_uidx[uniq_index, :] # neighbour uniq index
     """
     cont_ngamma_ref, index_ngamma_ref = npgetix(ngamma_ref, ngamma_ref_grid)
@@ -1175,7 +1178,6 @@ def broadpar_getix(ngamma_ref, ngamma_ref_grid, n_Texp, n_Texp_grid):
         error_diagnositcs(status, multi_index_uniqgrid, ngamma_ref, ngamma_ref_grid)
     elif status == 2:
         error_diagnositcs(status, multi_index_uniqgrid, n_Texp, n_Texp_grid)
-
 
     ngrid_broadpar = len(multi_index_uniqgrid)
 
@@ -1212,7 +1214,6 @@ def check_multi_index_uniqgrid_shape(
     return 0
 
 
-
 def error_diagnositcs(status, multi_index_uniqgrid, val, val_grid):
     print("****** ERROR Diagnostics ******")
     valname = ["ngamma_ref_grid", "n_Texp_grid"]
@@ -1222,11 +1223,13 @@ def error_diagnositcs(status, multi_index_uniqgrid, val, val_grid):
         + str(index)
         + "]) = "
         + str(np.max(multi_index_uniqgrid[:, index]))
-        + " should be smaller than len("+valname[index]+") = "
+        + " should be smaller than len("
+        + valname[index]
+        + ") = "
         + str(len(val_grid))
     )
     print(msg)
-    
+
     msgtell = "If you see this error, please contact @HajimeKawahara via github ExoJAX page! (#586)"
     raise ValueError(msgtell)
 
@@ -1309,7 +1312,6 @@ def generate_lbd(
     """
     _print_grids(0, ngamma_ref, ngamma_ref_grid)
     _print_grids(1, n_Texp, n_Texp_grid)
-    
 
     cont_nu, index_nu = npgetix(nu_lines, nu_grid)
     single_broadening = _check_single_broadening(ngamma_ref_grid, n_Texp_grid)
@@ -1368,7 +1370,6 @@ def generate_lbd(
                 neighbor_uidx,
                 sumz=1.0,
             )
-            
         if idiff == 0:
             lbd_diff = convert_to_jnplog(lbd_diff)
         else:
@@ -1377,14 +1378,15 @@ def generate_lbd(
         lbd_coeff.append(lbd_diff[:-1, :, :])
         # [:-1,:,:] is to remove the mostright bin of nu direction (check Ng_nu_plus_one)
 
-    lbd_coeff = np.array(lbd_coeff) 
-    
+    lbd_coeff = np.array(lbd_coeff)
+
     return lbd_coeff, multi_index_uniqgrid
+
 
 def _print_grids(index, val, val_grid):
     valname = ["ngamma_ref_grid", "n_Texp_grid"]
-    print("max value of ",valname[index], ":", np.max(val))
-    print("min value of ",valname[index], ":", np.min(val))
+    print("max value of ", valname[index], ":", np.max(val))
+    print("min value of ", valname[index], ":", np.min(val))
     print(valname[index], "grid :", val_grid)
 
 

--- a/src/exojax/opacity/premodit/premodit.py
+++ b/src/exojax/opacity/premodit/premodit.py
@@ -721,7 +721,7 @@ def xsmatrix_nu_open_second(
     return xsm
 
 
-@jit
+@jit 
 def xsvector_zeroth(
     T,
     P,
@@ -1368,6 +1368,7 @@ def generate_lbd(
                 neighbor_uidx,
                 sumz=1.0,
             )
+            
         if idiff == 0:
             lbd_diff = convert_to_jnplog(lbd_diff)
         else:
@@ -1376,9 +1377,8 @@ def generate_lbd(
         lbd_coeff.append(lbd_diff[:-1, :, :])
         # [:-1,:,:] is to remove the mostright bin of nu direction (check Ng_nu_plus_one)
 
-    # lbd_coeff = np.array(lbd_coeff) #almost same
-    lbd_coeff = jnp.array(lbd_coeff)
-
+    lbd_coeff = np.array(lbd_coeff) 
+    
     return lbd_coeff, multi_index_uniqgrid
 
 def _print_grids(index, val, val_grid):

--- a/tests/endtoend/f32/f32xs.py
+++ b/tests/endtoend/f32/f32xs.py
@@ -1,12 +1,9 @@
 """test for Issue 619, 32-bit mode test for premodit
 """
-
 from jax import config
-config.update("jax_enable_x64", False) #this does not
-#config.update("jax_enable_x64", True) #this works
+config.update("jax_enable_x64", False)
 
 from exojax.utils.grids import wavenumber_grid
-
 nu_grid, wav, resolution = wavenumber_grid(
     22920.0, 23000.0, 3500, unit="AA", xsmode="premodit"
 )

--- a/tests/endtoend/f32/f32xs.py
+++ b/tests/endtoend/f32/f32xs.py
@@ -1,0 +1,35 @@
+"""test for Issue 619, 32-bit mode test for premodit
+"""
+
+from jax import config
+config.update("jax_enable_x64", False) #this does not
+#config.update("jax_enable_x64", True) #this works
+
+from exojax.utils.grids import wavenumber_grid
+
+nu_grid, wav, resolution = wavenumber_grid(
+    22920.0, 23000.0, 3500, unit="AA", xsmode="premodit"
+)
+print("Resolution=", resolution)
+
+from exojax.database.api  import MdbExomol
+mdb = MdbExomol(".database/CO/12C-16O/Li2015", nurange=nu_grid)
+from exojax.opacity import OpaPremodit
+opa = OpaPremodit(mdb, nu_grid, auto_trange=[500.0, 1500.0], dit_grid_resolution=1.0, allow_32bit=True)
+
+P = 1.0  # bar
+T_1 = 500.0  # K
+xsv_1 = opa.xsvector(T_1, P)  # cm2
+
+T_2 = 1500.0  # K
+xsv_2 = opa.xsvector(T_2, P)  # cm2
+
+import matplotlib.pyplot as plt
+
+plt.plot(nu_grid, xsv_1, label=str(T_1) + "K")  # cm2
+plt.plot(nu_grid, xsv_2, alpha=0.5, label=str(T_2) + "K")  # cm2
+plt.yscale("log")
+plt.legend()
+plt.xlabel("wavenumber (cm-1)")
+plt.ylabel("cross section (cm2)")
+plt.show()


### PR DESCRIPTION
This PR addresses #619

The reason of `nan` in cross section using the 32-bit mode was
- `elower` was converted to `jnp.array` (float32, when 32-bit mode) when `gpu_transfer=True` (default) in `mdb`. 
- Also, `qr_interp` was float32.
This makes the overflow of `line_strength` and `Slsd`.

## Solutions
- removes `jnp.array`-nization in `generate_jnp.arrays` in `mdb`'s. 
- makes the numpy version of  `QT_interp` and `qr_interp` 

## refactoring in near future
we need further refactoring of `databases/api.py`
