### PR TITLE
Drop python 3.9 support and added 3.12 and 3.13 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       # Test the versions we advertise in classifiers
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        
     steps:
       # Checkout repository
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       # Test the versions we advertise in classifiers
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       # Checkout repository
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
 ]
 
@@ -47,6 +46,7 @@ dependencies = [
   "tqdm",
   "PyMieScatt",
   "radis>=0.15.2",
+  "numba",
   "tables",
   "pandas",
   "termcolor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
   "tqdm",
   "PyMieScatt",
   "radis>=0.15.2",
-  "numba",
   "tables",
   "pandas",
   "termcolor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,11 @@ requires-python = ">=3.9"
 # Classifiers ported from setup.py. Add more if applicable.
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
 ]
 


### PR DESCRIPTION
Following [radis](https://github.com/radis/radis/pull/875), we would drop Python 3.9 support and added 3.12-3.14 tests in CI.