### PR TITLE
database: use query-style adapter APIs for molparams and partition

### DIFF
--- a/src/exojax/database/_common/commonapi.py
+++ b/src/exojax/database/_common/commonapi.py
@@ -7,7 +7,7 @@ from exojax.database._common.hitranapi import molecid_hitran
 from exojax.database._common.hitranapi import make_partition_function_grid_hitran
 from exojax.database._common.radis_adapter import (
     get_molecule,
-    get_partfunc_tips_class,
+    get_partition_function_value,
 )
 from exojax.utils.constants import Tref_original
 from exojax.utils.isotopes import molmass_hitran
@@ -65,10 +65,8 @@ class MdbCommonHitempHitran:
             isotope_for_Qt = 1  # we use isotope=1 for QT
         else:
             isotope_for_Qt = int(self.isotope)
-        PartFuncTIPS = get_partfunc_tips_class()
-        Q = PartFuncTIPS(self.molecid, isotope_for_Qt)
-        QTref = Q.at(T=Tref_original)
-        QTtyp = Q.at(T=Ttyp)
+        QTref = get_partition_function_value(self.molecid, isotope_for_Qt, Tref_original)
+        QTtyp = get_partition_function_value(self.molecid, isotope_for_Qt, Ttyp)
         return QTref, QTtyp
 
     def set_wavenum(self, nurange):

--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -68,18 +68,20 @@ def get_molecule_identifier(simple_molecule_name):
     return _get_molecule_identifier(simple_molecule_name)
 
 
-def get_partfunc_tips_class():
-    """Return ``radis.levels.partfunc.PartFuncTIPS`` class."""
+def get_partition_function_value(molecule_identifier, isotope, temperature):
+    """Return partition function value for molecule/isotope at temperature."""
     from radis.levels.partfunc import PartFuncTIPS
 
-    return PartFuncTIPS
+    partfunc = PartFuncTIPS(molecule_identifier, isotope)
+    return partfunc.at(T=temperature)
 
 
-def get_molparams_class():
-    """Return ``radis.db.molparam.MolParams`` class lazily."""
+def get_isotope_name(simple_molecule_name, isotope):
+    """Return exact isotope name for molecule/isotope pair."""
     from radis.db.molparam import MolParams
 
-    return MolParams
+    molparams = MolParams()
+    return molparams.get(simple_molecule_name, isotope, "isotope_name")
 
 
 def get_isotope_name_dict():

--- a/src/exojax/utils/molname.py
+++ b/src/exojax/utils/molname.py
@@ -13,8 +13,8 @@ import re
 import warnings
 from exojax.database._common.radis_adapter import (
     get_isotope_name_dict,
+    get_isotope_name,
     get_molecule,
-    get_molparams_class,
 )
 
 
@@ -29,9 +29,7 @@ def exact_molecule_name_from_isotope(simple_molecule_name, isotope, dbtype="hitr
     Returns:
         str: HITRAN exact isotope name such as (12C)(16O) for dbtype="hitran", 12C-16O for "exomol"
     """
-    MolParams = get_molparams_class()
-    mp = MolParams()
-    exact_molname = mp.get(simple_molecule_name, isotope, "isotope_name")
+    exact_molname = get_isotope_name(simple_molecule_name, isotope)
     if dbtype == "hitran":
         return exact_molname
     elif dbtype == "exomol":


### PR DESCRIPTION
### What changed

  - radis_adapter.py
      - Added query/data-oriented helpers:
          - get_partition_function_value(molecule_identifier, isotope, temperature)
          - get_isotope_name(simple_molecule_name, isotope)
      - Removed class-returning helpers that were used only as thin pass-throughs:
          - get_partfunc_tips_class()
          - get_molparams_class()
  - commonapi.py
      - QT_for_select_line() now uses get_partition_function_value(...) instead of requesting a RADIS class and calling
        methods on it.
  - molname.py
      - exact_molecule_name_from_isotope() now uses get_isotope_name(...) instead of requesting a RADIS MolParams class.

  ### Why

  This keeps the adapter boundary more ExoJAX-oriented by returning directly-needed values rather than backend classes,
  while preserving behavior and keeping scope minimal.

  ### Behavior impact

  - No numerical logic changes.
  - No packaging changes.
  - No public ExoJAX API renames.
  - Lazy import behavior preserved (RADIS imports remain inside adapter functions).

  ### Remaining class-returning adapter APIs

  - get_exomol_mdb_class()
  - get_hitran_database_manager_class()
  - get_hitemp_database_manager_class()

  These remain because current DB implementations still inherit backend manager classes; removing these would require
  broader architectural changes outside Issue 1 scope.

  ### Validation

  Targeted tests passed:

  - tests/unittests/database/api/api_test.py
  - tests/unittests/database/api/api_line_strength_test.py
  - tests/unittests/database/api/api_eq_method_test.py
  - tests/unittests/utils/misc/molname_test.py
  - tests/unittests/utils/misc/mollabel_test.py
