### PR TITLE
database: hide exomol version branching behind adapter capabilities

### DIFF
--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -3,6 +3,8 @@
 This module centralizes RADIS imports so exojax modules do not import RADIS
 directly. The goal is dependency isolation only; behavior is unchanged.
 """
+import warnings
+from packaging import version
 
 
 def get_radis_version():
@@ -10,6 +12,36 @@ def get_radis_version():
     from radis import __version__ as radis_version
 
     return radis_version
+
+
+def supports_exomol_broadf_download():
+    """Return whether backend supports ExoMol ``broadf_download``."""
+    return version.parse(get_radis_version()) >= version.parse("0.16")
+
+
+def exomol_init_needs_bkgdatm():
+    """Return whether ExoMol manager init expects ``bkgdatm`` argument."""
+    return not supports_exomol_broadf_download()
+
+
+def warn_if_exomol_broadf_download_unsupported():
+    """Emit the legacy warning message for backends without broadf_download."""
+    if supports_exomol_broadf_download():
+        return
+    radis_version = get_radis_version()
+    print("radis==", radis_version)
+    msg = "The current version of radis does not support broadf_download (requires >=0.16)."
+    warnings.warn(msg, UserWarning)
+
+
+def exomol_broadening_mode():
+    """Return ExoMol broadening mode key used by ExoJAX call sites."""
+    radis_version = get_radis_version()
+    if version.parse(radis_version) <= version.parse("0.14"):
+        return "compute_broadening"
+    if version.parse(radis_version) <= version.parse("0.15.2"):
+        return "set_broadening_coef_legacy"
+    return "set_broadening_coef_species"
 
 
 def get_auto_memory_mapping_engine():

--- a/src/exojax/database/exomol/api.py
+++ b/src/exojax/database/exomol/api.py
@@ -15,13 +15,15 @@ import warnings
 
 import jax.numpy as jnp
 import numpy as np
-from packaging import version
 from exojax.database.core.broadening import gamma_natural as gn
 from exojax.database.core.line_strength import line_strength_numpy
 from exojax.database.molinfo import isotope_molmass
 from exojax.database._common.radis_adapter import (
+    exomol_broadening_mode,
+    exomol_init_needs_bkgdatm,
     get_exomol_mdb_class,
-    get_radis_version,
+    supports_exomol_broadf_download,
+    warn_if_exomol_broadf_download_unsupported,
 )
 from exojax.utils.constants import Tref_original
 from exojax.utils.molname import e2s
@@ -30,7 +32,6 @@ from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
 __all__ = ["MdbExomol"]
 CapiMdbExomol = get_exomol_mdb_class()
-radis_version = get_radis_version()
 
 
 class MdbExomol(CapiMdbExomol):
@@ -102,12 +103,10 @@ class MdbExomol(CapiMdbExomol):
         self.gpu_transfer = gpu_transfer
         self.Ttyp = Ttyp
         self.broadf = broadf
-        if radis_version >= "0.16":
+        if supports_exomol_broadf_download():
             self.broadf_download = broadf_download
         else:
-            print("radis==", radis_version)
-            msg = "The current version of radis does not support broadf_download (requires >=0.16)."
-            warnings.warn(msg, UserWarning)
+            warn_if_exomol_broadf_download_unsupported()
         self.simple_molecule_name = e2s(self.exact_molecule_name)
         self.molmass = isotope_molmass(self.exact_molecule_name)
         self.skip_optional_data = not optional_quantum_states
@@ -115,7 +114,7 @@ class MdbExomol(CapiMdbExomol):
         wavenum_min, wavenum_max = self.set_wavenum(nurange)
         self.engine = _set_engine(engine)
 
-        if radis_version >= "0.16":
+        if not exomol_init_needs_bkgdatm():
             super().__init__(
                 str(self.path),
                 local_databases=local_databases,
@@ -269,9 +268,10 @@ class MdbExomol(CapiMdbExomol):
 
         self.attributes_from_dataframes(df[mask])
 
-        if version.parse(radis_version) <= version.parse("0.14"):
+        broadening_mode = exomol_broadening_mode()
+        if broadening_mode == "compute_broadening":
             self.compute_broadening(self.jlower.astype(int), self.jupper.astype(int))
-        elif version.parse(radis_version) <= version.parse("0.15.2"):
+        elif broadening_mode == "set_broadening_coef_legacy":
             print("Broadener: ", self.bkgdatm)
             self.set_broadening_coef(df[mask], add_columns=False)
         else:


### PR DESCRIPTION
## Summary

  Implements Issue 2 from RADIS_ADAPTER_API_REVIEW.md: move RADIS release checks out of ExoJAX call sites and behind
  adapter capability/query APIs.

  ## What changed

  ### 1) Adapter now exposes capability-style helpers

  Updated radis_adapter.py with ExoMol capability/query functions:

  - supports_exomol_broadf_download()
  - exomol_init_needs_bkgdatm()
  - warn_if_exomol_broadf_download_unsupported()
  - exomol_broadening_mode()

  These helpers encapsulate RADIS version branching internally.

  ### 2) ExoMol call site no longer branches on RADIS version directly

  Updated api.py:

  - Removed direct get_radis_version() usage in this module.
  - Replaced direct version comparisons with adapter capability checks for:
      - enabling/disabling broadf_download
      - selecting constructor path (bkgdatm legacy init vs newer init)
      - selecting broadening behavior in activate().

  ## Behavior / scope

  - No packaging changes.
  - No native backend added.
  - No public ExoJAX API renames.
  - No numerical behavior changes intended.
  - Scope kept local to adapter + ExoMol call site.

  ## Notes on boundary quality

  - get_radis_version() still exists in adapter as an internal primitive.
  - In the touched area, version-specific branching now lives in adapter functions, not ExoJAX DB call-site logic.

  ## Validation

  Targeted tests passed:

  - tests/unittests/database/api/api_test.py
  - tests/unittests/database/api/api_line_strength_test.py
  - tests/unittests/database/api/api_eq_method_test.py

  Result: 13 passed.
