### PR TITLE
database: localize manager init behind adapter factories

### DIFF
--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -4,6 +4,7 @@ This module centralizes RADIS imports so exojax modules do not import RADIS
 directly. The goal is dependency isolation only; behavior is unchanged.
 """
 import warnings
+from pathlib import Path
 from packaging import version
 
 
@@ -70,6 +71,122 @@ def get_hitemp_database_manager_class():
     from radis.api.hitempapi import HITEMPDatabaseManager
 
     return HITEMPDatabaseManager
+
+
+def init_exomol_manager(
+    instance,
+    *,
+    path,
+    local_databases,
+    molecule,
+    nurange,
+    engine,
+    crit,
+    broadf,
+    broadf_download,
+    skip_optional_data,
+    bkgdatm,
+):
+    """Initialize ExoMol backend manager on an existing instance.
+
+    This keeps backend/version-specific constructor kwargs localized in the
+    adapter while preserving inheritance-based architecture.
+    """
+    exomol_manager_class = get_exomol_mdb_class()
+    if not exomol_init_needs_bkgdatm():
+        exomol_manager_class.__init__(
+            instance,
+            path,
+            local_databases=local_databases,
+            molecule=molecule,
+            name="EXOMOL-{molecule}",
+            nurange=nurange,
+            engine=engine,
+            crit=crit,
+            broadf=broadf,
+            broadf_download=broadf_download,
+            cache=True,
+            skip_optional_data=skip_optional_data,
+        )
+    else:
+        exomol_manager_class.__init__(
+            instance,
+            path,
+            local_databases=local_databases,
+            molecule=molecule,
+            name="EXOMOL-{molecule}",
+            nurange=nurange,
+            engine=engine,
+            crit=crit,
+            bkgdatm=bkgdatm,  # uses radis <= 0.15.2
+            broadf=broadf,
+            cache=True,
+            skip_optional_data=skip_optional_data,
+        )
+
+
+def init_hitran_manager(
+    instance,
+    *,
+    molecule,
+    local_databases,
+    engine,
+    nonair_broadening,
+):
+    """Initialize HITRAN backend manager on an existing instance."""
+    hitran_manager_class = get_hitran_database_manager_class()
+    extra_params = "all" if nonair_broadening else None
+    hitran_manager_class.__init__(
+        instance,
+        molecule=molecule,
+        name="HITRAN-{molecule}",
+        local_databases=local_databases,
+        engine=engine,
+        verbose=True,
+        parallel=True,
+        extra_params=extra_params,
+    )
+
+
+def init_hitemp_manager(
+    instance,
+    *,
+    molecule,
+    local_databases,
+    engine,
+):
+    """Initialize HITEMP backend manager on an existing instance.
+
+    Handles RADIS databank-name collisions for pre-registered environments.
+    """
+    hitemp_manager_class = get_hitemp_database_manager_class()
+    db_name = f"HITEMP-{molecule}"
+    try:
+        hitemp_manager_class.__init__(
+            instance,
+            molecule=molecule,
+            name=db_name,
+            local_databases=local_databases,
+            engine=engine,
+            verbose=True,
+            chunksize=100000,
+            parallel=True,
+        )
+    except ValueError as exc:
+        if "already registered in radis.json" not in str(exc):
+            raise
+        local_tag = Path(local_databases).expanduser().resolve().name or "local"
+        db_name = f"HITEMP-{molecule}-{local_tag}"
+        hitemp_manager_class.__init__(
+            instance,
+            molecule=molecule,
+            name=db_name,
+            local_databases=local_databases,
+            engine=engine,
+            verbose=True,
+            chunksize=100000,
+            parallel=True,
+        )
 
 
 def get_hit2df_func():

--- a/src/exojax/database/exomol/api.py
+++ b/src/exojax/database/exomol/api.py
@@ -20,8 +20,8 @@ from exojax.database.core.line_strength import line_strength_numpy
 from exojax.database.molinfo import isotope_molmass
 from exojax.database._common.radis_adapter import (
     exomol_broadening_mode,
-    exomol_init_needs_bkgdatm,
     get_exomol_mdb_class,
+    init_exomol_manager,
     supports_exomol_broadf_download,
     warn_if_exomol_broadf_download_unsupported,
 )
@@ -114,34 +114,19 @@ class MdbExomol(CapiMdbExomol):
         wavenum_min, wavenum_max = self.set_wavenum(nurange)
         self.engine = _set_engine(engine)
 
-        if not exomol_init_needs_bkgdatm():
-            super().__init__(
-                str(self.path),
-                local_databases=local_databases,
-                molecule=self.simple_molecule_name,
-                name="EXOMOL-{molecule}",
-                nurange=[wavenum_min, wavenum_max],
-                engine=self.engine,
-                crit=crit,
-                broadf=self.broadf,
-                broadf_download=self.broadf_download,
-                cache=True,
-                skip_optional_data=self.skip_optional_data,
-            )
-        else:
-            super().__init__(
-                str(self.path),
-                local_databases=local_databases,
-                molecule=self.simple_molecule_name,
-                name="EXOMOL-{molecule}",
-                nurange=[wavenum_min, wavenum_max],
-                engine=self.engine,
-                crit=crit,
-                bkgdatm=self.bkgdatm,  # uses radis <= 0.15.2
-                broadf=self.broadf,
-                cache=True,
-                skip_optional_data=self.skip_optional_data,
-            )
+        init_exomol_manager(
+            self,
+            path=str(self.path),
+            local_databases=local_databases,
+            molecule=self.simple_molecule_name,
+            nurange=[wavenum_min, wavenum_max],
+            engine=self.engine,
+            crit=crit,
+            broadf=self.broadf,
+            broadf_download=getattr(self, "broadf_download", broadf_download),
+            skip_optional_data=self.skip_optional_data,
+            bkgdatm=self.bkgdatm,
+        )
 
         self.crit = crit
         self.elower_max = elower_max

--- a/src/exojax/database/hitemp/api.py
+++ b/src/exojax/database/hitemp/api.py
@@ -1,5 +1,4 @@
 from os.path import exists
-from pathlib import Path
 import jax.numpy as jnp
 import numpy as np
 from exojax.database._common.commonapi import MdbCommonHitempHitran
@@ -7,6 +6,7 @@ from exojax.database._common.isotope_functions import _convert_proper_isotope
 from exojax.database._common.radis_adapter import (
     get_hitemp_database_manager_class,
     get_hit2df_func,
+    init_hitemp_manager,
 )
 from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
@@ -82,36 +82,12 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         local_db_root = self.path.parent
         local_db_root = str(local_db_root) # convert to str for radis compatibility
 
-        db_name = f"HITEMP-{self.simple_molecule_name}"
-        try:
-            HITEMPDatabaseManager.__init__(
-                self,
-                molecule=self.simple_molecule_name,
-                name=db_name,
-                local_databases=local_db_root,
-                engine=self.engine,
-                verbose=True,
-                chunksize=100000,
-                parallel=True,
-            )
-        except ValueError as exc:
-            # Some environments have a pre-existing RADIS registration for the
-            # same databank name but a different local path. Retry with a local
-            # unique name to preserve behavior for the current dataset path.
-            if "already registered in radis.json" not in str(exc):
-                raise
-            local_tag = Path(local_db_root).expanduser().resolve().name or "local"
-            db_name = f"HITEMP-{self.simple_molecule_name}-{local_tag}"
-            HITEMPDatabaseManager.__init__(
-                self,
-                molecule=self.simple_molecule_name,
-                name=db_name,
-                local_databases=local_db_root,
-                engine=self.engine,
-                verbose=True,
-                chunksize=100000,
-                parallel=True,
-            )
+        init_hitemp_manager(
+            self,
+            molecule=self.simple_molecule_name,
+            local_databases=local_db_root,
+            engine=self.engine,
+        )
 
         if parfile is not None:
             hit2df = get_hit2df_func()

--- a/src/exojax/database/hitran/api.py
+++ b/src/exojax/database/hitran/api.py
@@ -2,7 +2,10 @@ import jax.numpy as jnp
 import numpy as np
 from exojax.database._common.commonapi import MdbCommonHitempHitran
 from exojax.database._common.isotope_functions import _convert_proper_isotope
-from exojax.database._common.radis_adapter import get_hitran_database_manager_class
+from exojax.database._common.radis_adapter import (
+    get_hitran_database_manager_class,
+    init_hitran_manager,
+)
 from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
 HITRANDatabaseManager = get_hitran_database_manager_class()
@@ -75,22 +78,13 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
         )
 
         # HITRAN ONLY FUNCTIONALITY
-        if nonair_broadening:
-            self.nonair_broadening = True
-            extra_params = "all"
-        else:
-            self.nonair_broadening = False
-            extra_params = None
-
-        HITRANDatabaseManager.__init__(
+        self.nonair_broadening = bool(nonair_broadening)
+        init_hitran_manager(
             self,
             molecule=self.simple_molecule_name,
-            name="HITRAN-{molecule}",
             local_databases=self.path.parent,
             engine=self.engine,
-            verbose=True,
-            parallel=True,
-            extra_params=extra_params,
+            nonair_broadening=self.nonair_broadening,
         )
 
         # Get list of all expected local files for this database:


### PR DESCRIPTION
## Summary

  Implements Issue 3 from RADIS_ADAPTER_API_REVIEW.md with a minimal, safe refactor: keep current inheritance model, but
  move backend manager initialization logic into adapter factory-style helpers to reduce constructor/init leakage in
  ExoJAX DB modules.

  ## What changed

  ### Adapter: factory-style init helpers

  Updated radis_adapter.py to add:

  - init_exomol_manager(...)
  - init_hitran_manager(...)
  - init_hitemp_manager(...)

  These helpers encapsulate RADIS manager constructor details and backend-specific init behavior.

  Included in adapter-localized logic:

  - ExoMol legacy/new init argument split (bkgdatm vs broadf_download path).
  - HITRAN non-air broadening extra_params selection.
  - HITEMP databank registration collision retry logic.

  ### Call sites switched to adapter init helpers

  - exomol/api.py
      - Replaced direct backend __init__ branching with init_exomol_manager(...).
  - hitran/api.py
      - Replaced direct HITRANDatabaseManager.__init__(...) with init_hitran_manager(...).
  - hitemp/api.py
      - Replaced direct HITEMPDatabaseManager.__init__(...) block (including collision fallback) with
        init_hitemp_manager(...).

  ## Scope / non-goals

  - No packaging changes.
  - No native backend added.
  - No broad architecture rewrite.
  - Inheritance remains unchanged for MdbExomol, MdbHitran, MdbHitemp.
  - No numerical behavior changes intended.

  ## Remaining class-returning APIs (still present)

  - get_exomol_mdb_class()
  - get_hitran_database_manager_class()
  - get_hitemp_database_manager_class()

  These remain because class inheritance is still the active architecture; removing them would require a larger
  composition/facade redesign outside this issue.

  ## Boundary improvement achieved

  - Reduced inheritance lock-in at initialization boundary:
      - DB modules now contain fewer RADIS constructor/version/init details.
      - More backend-specific init behavior is localized in adapter.
  - Full inheritance lock-in is not removed yet (intentionally out of scope).

  ## Validation

  Targeted tests passed:

  - tests/unittests/database/api/api_test.py
  - tests/unittests/database/api/api_line_strength_test.py
  - tests/unittests/database/api/api_eq_method_test.py
  - tests/unittests/database/api/customapi_test.py

  Result: 19 passed. 
 
  Also, all of the unit tests passed
