### PR TITLE
docs: define minimal backend interface contract

### DIFF
--- a/BACKEND_INTERFACE_MINIMAL_CONTRACT.md
+++ b/BACKEND_INTERFACE_MINIMAL_CONTRACT.md
@@ -1,0 +1,148 @@
+# Backend Interface Minimal Contract (Current ExoJAX)
+
+This note defines the minimal backend-facing contract that ExoJAX core currently relies on, based on existing code paths.
+
+Scope references:
+- `src/exojax/database/_common/radis_adapter.py`
+- Core call sites in `src/exojax/database/**` and `src/exojax/utils/**`
+- Positioning note: `RADIS_BACKEND_POSITIONING.md`
+
+## Purpose
+
+ExoJAX core should depend on backend capabilities and data/query helpers, not backend package internals.
+The current implementation backend is RADIS (`radis_adapter.py`).
+
+## Contract categories
+
+## 1) Identity / label translation
+
+Current helpers:
+- `get_molecule(molecule_identifier)`
+- `get_molecule_identifier(simple_molecule_name)`
+- `get_isotope_name(simple_molecule_name, isotope)`
+- `get_isotope_name_dict()`
+
+Used by:
+- `src/exojax/database/_common/commonapi.py`
+- `src/exojax/database/_common/hitranapi.py`
+- `src/exojax/database/multimol.py`
+- `src/exojax/utils/molname.py`
+- `src/exojax/utils/mollabel.py`
+
+Contract status:
+- Stable backend-facing contract: yes (`get_molecule`, `get_molecule_identifier`, `get_isotope_name`)
+- Transitional: `get_isotope_name_dict()` (dict schema is backend-shaped)
+- Non-contract details that should stay hidden: backend database class names and internal table layout.
+
+## 2) Metadata/data lookup helpers
+
+Current helpers:
+- `get_exomol_database_list_func()`
+- `get_hit2df_func()`
+
+Used by:
+- `src/exojax/database/multimol.py`
+- `src/exojax/database/hitemp/api.py`
+
+Contract status:
+- Stable backend-facing contract: partially (callers currently receive raw backend callables)
+- Transitional: yes (callable-returning style leaks backend function signatures)
+- Non-contract details: concrete RADIS function paths (`radis.api.*`).
+
+## 3) Partition-function queries
+
+Current helper:
+- `get_partition_function_value(molecule_identifier, isotope, temperature)`
+
+Used by:
+- `src/exojax/database/_common/commonapi.py`
+
+Contract status:
+- Stable backend-facing contract: yes (value-oriented, backend-neutral input/output)
+- Transitional: no major issues in current usage
+- Non-contract details: backend class construction (`PartFuncTIPS`) should remain adapter-internal.
+
+## 4) Capability / feature queries
+
+Current helpers:
+- `supports_exomol_broadf_download()`
+- `exomol_init_needs_bkgdatm()`
+- `exomol_broadening_mode()`
+- `warn_if_exomol_broadf_download_unsupported()`
+
+Used by:
+- `src/exojax/database/exomol/api.py`
+
+Contract status:
+- Stable backend-facing contract: yes for capability checks (`supports_*`, mode queries)
+- Transitional: warning helper is policy-specific but acceptable for now
+- Non-contract details: raw backend version branching should not reappear in call sites.
+
+## 5) Manager/object initialization helpers
+
+Current helpers:
+- `init_exomol_manager(...)`
+- `init_hitran_manager(...)`
+- `init_hitemp_manager(...)`
+
+Used by:
+- `src/exojax/database/exomol/api.py`
+- `src/exojax/database/hitran/api.py`
+- `src/exojax/database/hitemp/api.py`
+
+Contract status:
+- Stable backend-facing contract: yes as an initialization boundary
+- Transitional: still inheritance-based; helpers initialize backend managers on `self`
+- Non-contract details: backend constructor kwargs/version quirks should remain inside these helpers.
+
+## 6) Activation/setup behavior (current state)
+
+Current state:
+- Backend-specific activation/setup is partially localized via capability + init helpers.
+- Core classes still perform ExoJAX-level workflow (`load`, masking, activate) in their own modules.
+
+Contract status:
+- Stable backend-facing contract: partial
+- Transitional: yes (inheritance lock-in remains)
+- Non-contract details: backend manager internals and MRO assumptions should not spread further.
+
+## Legacy / transitional APIs (do not expand)
+
+Class-returning helpers (legacy transitional):
+- `get_exomol_mdb_class()`
+- `get_hitran_database_manager_class()`
+- `get_hitemp_database_manager_class()`
+
+Reason:
+- Required by current inheritance architecture.
+- Should not be expanded into new call sites; prefer value/capability/init helpers.
+
+Low-level version primitive (adapter-internal primitive):
+- `get_radis_version()`
+
+Reason:
+- Used to implement capability helpers inside adapter.
+- ExoJAX call sites should not branch on this directly.
+
+## What must not leak from backend to core
+
+- Raw backend version comparisons.
+- Backend constructor keyword/version compatibility branches.
+- Backend exception-string coupling outside adapter where avoidable.
+- Direct dependency on backend class APIs when a value/query helper can be used.
+
+## What can remain RADIS-specific for now
+
+- Adapter internals that call RADIS constructors and APIs.
+- Transitional class-returning helpers needed for current inheritance.
+- Existing backend-specific warning text in adapter compatibility helpers.
+
+## Minimal first implementation target for a future native backend
+
+A future native backend should first implement the currently used backend-facing helper families:
+1. Identity/label translation (`get_molecule`, `get_molecule_identifier`, `get_isotope_name`)
+2. Partition-function value query (`get_partition_function_value`)
+3. Capability queries for ExoMol-like branches (`supports_*`, mode helpers)
+4. Manager initialization helpers (`init_*_manager`)
+
+Once those are available, ExoJAX core call sites can remain mostly unchanged while backend internals differ.

--- a/RADIS_BACKEND_POSITIONING.md
+++ b/RADIS_BACKEND_POSITIONING.md
@@ -1,0 +1,48 @@
+# RADIS Backend Positioning
+
+## Current role of `radis_adapter`
+
+`src/exojax/database/_common/radis_adapter.py` is the current RADIS-specific backend implementation layer for ExoJAX database code.
+
+It is not only an import shim. It also contains backend logic such as:
+- backend capability checks (for ExoMol feature support)
+- backend manager initialization helpers
+- backend compatibility/legacy-path handling
+- backend-specific collision handling around manager registration
+
+ExoJAX database call sites should prefer adapter helpers over embedding RADIS constructor/version details directly.
+
+## What logic should live in `radis_adapter`
+
+Good candidates for this layer:
+- backend capability/query functions (feature support checks)
+- backend manager construction/init wrappers/factories
+- backend-specific exception compatibility handling
+- backend data lookup helpers where ExoJAX only needs values
+
+Logic that should stay in ExoJAX call sites:
+- ExoJAX domain workflows and data flow
+- ExoJAX public API semantics
+- numerical/scientific behavior definitions
+
+## Legacy that still remains
+
+Class-returning APIs still exist:
+- `get_exomol_mdb_class()`
+- `get_hitran_database_manager_class()`
+- `get_hitemp_database_manager_class()`
+
+These remain because current DB classes still rely on inheritance from backend manager classes. This is an acknowledged transitional state.
+
+## How a future native backend can sit alongside RADIS
+
+A future native backend can be added as a parallel backend layer implementing the same adapter responsibilities:
+- capability/query helpers
+- manager/object creation helpers
+- backend-specific compatibility logic
+
+In that model, ExoJAX core call sites can remain stable while backend implementations vary behind the adapter boundary.
+
+## Naming note (not changed in this PR)
+
+A future low-risk naming cleanup may introduce a backend-neutral module name (for example, `backend_adapter.py`) with `radis_adapter.py` either delegating to it or remaining as the RADIS implementation module.

--- a/src/exojax/database/_common/commonapi.py
+++ b/src/exojax/database/_common/commonapi.py
@@ -5,6 +5,7 @@ import numpy as np
 from exojax.database.core.line_strength import line_strength_numpy
 from exojax.database._common.hitranapi import molecid_hitran
 from exojax.database._common.hitranapi import make_partition_function_grid_hitran
+# Backend-facing molecule/partition queries are consumed via adapter helpers.
 from exojax.database._common.radis_adapter import (
     get_molecule,
     get_partition_function_value,

--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -1,7 +1,14 @@
-"""RADIS dependency boundary for ExoJAX internals.
+"""RADIS backend implementation layer for ExoJAX database APIs.
 
-This module centralizes RADIS imports so exojax modules do not import RADIS
-directly. The goal is dependency isolation only; behavior is unchanged.
+This module is the current backend boundary between ExoJAX database code and
+RADIS-specific behavior. In addition to import indirection, this layer is the
+preferred home for backend-specific logic such as:
+- manager construction/init details
+- backend capability checks
+- backend compatibility shims and legacy-path handling
+
+ExoJAX call sites should prefer these adapter helpers over embedding RADIS
+constructor/version semantics directly.
 """
 import warnings
 from pathlib import Path


### PR DESCRIPTION
## Summary

  This PR is a documentation-oriented backend-boundary clarification step.
  It defines the minimal backend interface contract ExoJAX currently relies on, grounded in existing code, without
  changing architecture or runtime behavior.

  ## What changed

  ### 1) Added minimal backend contract note

  - Added BACKEND_INTERFACE_MINIMAL_CONTRACT.md

  This document defines:

  - minimal backend responsibilities ExoJAX core currently expects,
  - which helper categories are backend-common vs transitional vs RADIS-specific,
  - which APIs are legacy/transitional and should not be expanded,
  - what must not leak from backend to core,
  - what a future native backend would need to implement first.

  The contract is organized by concrete, current categories:

  - identity/label translation
  - metadata/data lookup helpers
  - partition-function queries
  - capability/feature queries
  - manager/object initialization helpers
  - activation/setup behavior (current state)

  ### 2) Added backend positioning note

  - Added RADIS_BACKEND_POSITIONING.md

  This clarifies that radis_adapter is the current RADIS backend implementation layer/boundary, not only an import shim.

  ### 3) Small terminology-alignment comments/docstrings

  - Updated module-level docstring in radis_adapter.py to explicitly describe backend-layer responsibilities.
  - Added a small clarifying comment in commonapi.py to reinforce adapter-mediated backend queries.

  ## Scope / non-goals

  - No packaging changes.
  - No native backend added.
  - No architecture redesign.
  - No numerical behavior changes.
  - No public ExoJAX API renames.

  ## Why

  This makes the backend boundary explicit and actionable for future work:

  - reduces ambiguity about what should live in backend layer vs core call sites,
  - marks legacy/transitional APIs clearly,
  - creates a concrete baseline for future backend expansion (including a native backend) with minimal churn in core
    modules.
