### PR TITLE
database: normalize missing RADIS import errors in adapter

### DIFF
--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -11,15 +11,36 @@ ExoJAX call sites should prefer these adapter helpers over embedding RADIS
 constructor/version semantics directly.
 """
 import warnings
+from importlib import import_module
 from pathlib import Path
 from packaging import version
 
 
+def _raise_missing_radis_import_error(exc, feature):
+    """Raise a normalized ImportError when RADIS itself is missing."""
+    missing_name = getattr(exc, "name", "")
+    if missing_name == "radis" or missing_name.startswith("radis."):
+        msg = f"{feature} requires RADIS. Install it with `pip install radis`."
+        raise ImportError(msg) from exc
+    raise exc
+
+
+def _import_attr(module_path, attr_name, feature):
+    """Import an attribute and normalize missing-RADIS errors."""
+    try:
+        module = import_module(module_path)
+    except ModuleNotFoundError as exc:
+        _raise_missing_radis_import_error(exc, feature)
+    return getattr(module, attr_name)
+
+
 def get_radis_version():
     """Return ``radis.__version__``."""
-    from radis import __version__ as radis_version
-
-    return radis_version
+    try:
+        radis_module = import_module("radis")
+    except ModuleNotFoundError as exc:
+        _raise_missing_radis_import_error(exc, "RADIS version check")
+    return radis_module.__version__
 
 
 def supports_exomol_broadf_download():
@@ -54,30 +75,39 @@ def exomol_broadening_mode():
 
 def get_auto_memory_mapping_engine():
     """Return RADIS auto-selected memory mapping engine."""
-    from radis.api.dbmanager import get_auto_MEMORY_MAPPING_ENGINE
-
+    get_auto_MEMORY_MAPPING_ENGINE = _import_attr(
+        "radis.api.dbmanager",
+        "get_auto_MEMORY_MAPPING_ENGINE",
+        "RADIS-backed engine auto-selection",
+    )
     return get_auto_MEMORY_MAPPING_ENGINE()
 
 
 def get_exomol_mdb_class():
     """Return RADIS common-API ExoMol MDB class."""
-    from radis.api.exomolapi import MdbExomol
-
-    return MdbExomol
+    return _import_attr(
+        "radis.api.exomolapi",
+        "MdbExomol",
+        "ExoMol database manager access",
+    )
 
 
 def get_hitran_database_manager_class():
     """Return RADIS HITRAN database manager class."""
-    from radis.api.hitranapi import HITRANDatabaseManager
-
-    return HITRANDatabaseManager
+    return _import_attr(
+        "radis.api.hitranapi",
+        "HITRANDatabaseManager",
+        "HITRAN database manager access",
+    )
 
 
 def get_hitemp_database_manager_class():
     """Return RADIS HITEMP database manager class."""
-    from radis.api.hitempapi import HITEMPDatabaseManager
-
-    return HITEMPDatabaseManager
+    return _import_attr(
+        "radis.api.hitempapi",
+        "HITEMPDatabaseManager",
+        "HITEMP database manager access",
+    )
 
 
 def init_exomol_manager(
@@ -198,50 +228,64 @@ def init_hitemp_manager(
 
 def get_hit2df_func():
     """Return ``radis.api.hitranapi.hit2df`` for lazy call-sites."""
-    from radis.api.hitranapi import hit2df
-
-    return hit2df
+    return _import_attr("radis.api.hitranapi", "hit2df", "HITRAN/HITEMP parser access")
 
 
 def get_exomol_database_list_func():
     """Return ``radis.api.exomolapi.get_exomol_database_list`` lazily."""
-    from radis.api.exomolapi import get_exomol_database_list
-
-    return get_exomol_database_list
+    return _import_attr(
+        "radis.api.exomolapi",
+        "get_exomol_database_list",
+        "ExoMol dataset discovery",
+    )
 
 
 def get_molecule(molecule_identifier):
     """Return RADIS simple molecule name from identifier."""
-    from radis.db.classes import get_molecule as _get_molecule
-
+    _get_molecule = _import_attr(
+        "radis.db.classes",
+        "get_molecule",
+        "molecule-name lookup",
+    )
     return _get_molecule(molecule_identifier)
 
 
 def get_molecule_identifier(simple_molecule_name):
     """Return RADIS HITRAN molecule identifier from simple name."""
-    from radis.db.classes import get_molecule_identifier as _get_molecule_identifier
-
+    _get_molecule_identifier = _import_attr(
+        "radis.db.classes",
+        "get_molecule_identifier",
+        "molecule-identifier lookup",
+    )
     return _get_molecule_identifier(simple_molecule_name)
 
 
 def get_partition_function_value(molecule_identifier, isotope, temperature):
     """Return partition function value for molecule/isotope at temperature."""
-    from radis.levels.partfunc import PartFuncTIPS
-
+    PartFuncTIPS = _import_attr(
+        "radis.levels.partfunc",
+        "PartFuncTIPS",
+        "partition-function query",
+    )
     partfunc = PartFuncTIPS(molecule_identifier, isotope)
     return partfunc.at(T=temperature)
 
 
 def get_isotope_name(simple_molecule_name, isotope):
     """Return exact isotope name for molecule/isotope pair."""
-    from radis.db.molparam import MolParams
-
+    MolParams = _import_attr(
+        "radis.db.molparam",
+        "MolParams",
+        "isotope-name lookup",
+    )
     molparams = MolParams()
     return molparams.get(simple_molecule_name, isotope, "isotope_name")
 
 
 def get_isotope_name_dict():
     """Return ``radis.db.molparam.isotope_name_dict`` lazily."""
-    from radis.db.molparam import isotope_name_dict
-
-    return isotope_name_dict
+    return _import_attr(
+        "radis.db.molparam",
+        "isotope_name_dict",
+        "isotope-name table lookup",
+    )

--- a/tests/unittests/database/api_radis/radis_adapter_contract_test.py
+++ b/tests/unittests/database/api_radis/radis_adapter_contract_test.py
@@ -9,12 +9,48 @@ import pytest
 from exojax.database._common import radis_adapter
 
 
+def _block_radis_imports(monkeypatch):
+    real_import_module = radis_adapter.import_module
+
+    def guarded_import_module(module_name):
+        if module_name == "radis" or module_name.startswith("radis."):
+            raise ModuleNotFoundError("No module named 'radis'", name="radis")
+        return real_import_module(module_name)
+
+    monkeypatch.setattr(radis_adapter, "import_module", guarded_import_module)
+
+    loaded = [k for k in sys.modules if k == "radis" or k.startswith("radis.")]
+    for module_name in loaded:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+
 def _install_module(monkeypatch, module_name, **attrs):
     module = types.ModuleType(module_name)
     for key, value in attrs.items():
         setattr(module, key, value)
     monkeypatch.setitem(sys.modules, module_name, module)
     return module
+
+
+@pytest.mark.parametrize(
+    "func,args",
+    [
+        (radis_adapter.get_radis_version, ()),
+        (radis_adapter.get_auto_memory_mapping_engine, ()),
+        (radis_adapter.get_exomol_mdb_class, ()),
+        (radis_adapter.get_hit2df_func, ()),
+        (radis_adapter.get_molecule_identifier, ("CO",)),
+        (radis_adapter.get_partition_function_value, (5, 1, 296.0)),
+        (radis_adapter.get_isotope_name, ("CO", 1)),
+    ],
+)
+def test_missing_radis_errors_are_normalized_to_importerror(monkeypatch, func, args):
+    _block_radis_imports(monkeypatch)
+    with pytest.raises(ImportError) as excinfo:
+        func(*args)
+    message = str(excinfo.value)
+    assert "requires RADIS" in message
+    assert "pip install radis" in message
 
 
 def test_identity_translation_helpers_roundtrip_and_isotope_name(monkeypatch):


### PR DESCRIPTION
## Summary

  This PR makes a narrow, adapter-layer improvement toward optional RADIS support by normalizing missing-RADIS import
  failures into clear ExoJAX-oriented ImportError messages.

  It does not change packaging, backend selection, architecture, or numerical behavior.

  ## What changed

  ### 1) Adapter-side error normalization

  Updated:

  - src/exojax/database/_common/radis_adapter.py

  Added a small internal normalization pattern:

  - _raise_missing_radis_import_error(exc, feature)
  - _import_attr(module_path, attr_name, feature)

  Behavior:

  - If RADIS is missing, adapter helper calls now raise:
      - ImportError("<feature> requires RADIS. Install it with pip install radis.")
  - Lazy import behavior is preserved.

  ### 2) Focused tests for missing-RADIS behavior

  Updated:

  - tests/unittests/database/api_radis/radis_adapter_contract_test.py

  Added a focused contract test:

  - test_missing_radis_errors_are_normalized_to_importerror

  It simulates missing RADIS at the adapter import boundary and asserts:

  - error type is ImportError
  - message includes:
      - "requires RADIS"
      - "pip install radis"

  ## Adapter helpers now covered by normalization

  - get_radis_version
  - get_auto_memory_mapping_engine
  - get_exomol_mdb_class
  - get_hitran_database_manager_class
  - get_hitemp_database_manager_class
  - get_hit2df_func
  - get_exomol_database_list_func
  - get_molecule
  - get_molecule_identifier
  - get_partition_function_value
  - get_isotope_name
  - get_isotope_name_dict

  ## Explicitly not addressed in this PR

  - Import-time inheritance breakpoints in:
      - exojax.database.exomol.api
      - exojax.database.hitran.api
      - exojax.database.hitemp.api
  - Eager import behavior in:
      - exojax.database.api
      - exojax.database.multimol
  - Packaging/dependency declarations
  - Backend architecture redesign / native backend support

  ## Validation

  Pytest commands run:

  1. pytest -q tests/unittests/database/api_radis/radis_adapter_contract_test.py (initial check)
  2. pytest -q tests/unittests/database/api_radis/radis_adapter_contract_test.py (final)

  Final result:

  - 20 passed
  - all of the unit tests passed 