### PR TITLE
database: defer eager imports in api and multimol

### DIFF
--- a/src/exojax/database/api.py
+++ b/src/exojax/database/api.py
@@ -12,14 +12,24 @@ This shim will be removed in a future **major** release.
 """
 from __future__ import annotations
 
+import importlib
 import warnings
 
-# Real implementations now live in the sub-packages
-from .exomol.api import MdbExomol as _MdbExomol
-from .hitemp.api import MdbHitemp as _MdbHitemp
-from .hitran.api import MdbHitran as _MdbHitran
-
 __all__ = ["MdbExomol", "MdbHitemp", "MdbHitran"]
+
+_ALIASES = {
+    "MdbExomol": ("exojax.database.exomol.api", "MdbExomol"),
+    "MdbHitemp": ("exojax.database.hitemp.api", "MdbHitemp"),
+    "MdbHitran": ("exojax.database.hitran.api", "MdbHitran"),
+}
+
+
+def _resolve(name: str):
+    module_path, attr = _ALIASES[name]
+    module = importlib.import_module(module_path)
+    resolved = getattr(module, attr)
+    globals()[name] = resolved
+    return resolved
 
 
 def __getattr__(name: str):
@@ -31,7 +41,7 @@ def __getattr__(name: str):
             DeprecationWarning,
             stacklevel=2,
         )
-        return _MdbExomol
+        return _resolve(name)
     if name == "MdbHitemp":
         warnings.warn(
             "exojax.database.api.MdbHitemp is deprecated. "
@@ -39,7 +49,7 @@ def __getattr__(name: str):
             DeprecationWarning,
             stacklevel=2,
         )
-        return _MdbHitemp
+        return _resolve(name)
     if name == "MdbHitran":
         warnings.warn(
             "exojax.database.api.MdbHitran is deprecated. "
@@ -47,11 +57,5 @@ def __getattr__(name: str):
             DeprecationWarning,
             stacklevel=2,
         )
-        return _MdbHitran
+        return _resolve(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-# Eager bindings for static type checkers and IDEs
-MdbExomol = _MdbExomol
-MdbHitemp = _MdbHitemp
-MdbHitran = _MdbHitran

--- a/src/exojax/database/multimol.py
+++ b/src/exojax/database/multimol.py
@@ -5,10 +5,48 @@ import numpy as np
 
 from exojax.database.contracts import MDBSnapshot
 from exojax.opacity import OpaPremodit
-from exojax.database.exomol.api import MdbExomol
-from exojax.database.hitran.api import MdbHitran
-from exojax.database.hitemp.api import MdbHitemp
-from exojax.test.emulate_mdb import mock_mdbExomol
+
+# Lazily imported RADIS-backed classes to reduce import-time pressure.
+MdbExomol = None
+MdbHitran = None
+MdbHitemp = None
+mock_mdbExomol = None
+
+
+def _load_mdb_exomol():
+    global MdbExomol
+    if MdbExomol is None:
+        from exojax.database.exomol.api import MdbExomol as _MdbExomol
+
+        MdbExomol = _MdbExomol
+    return MdbExomol
+
+
+def _load_mdb_hitran():
+    global MdbHitran
+    if MdbHitran is None:
+        from exojax.database.hitran.api import MdbHitran as _MdbHitran
+
+        MdbHitran = _MdbHitran
+    return MdbHitran
+
+
+def _load_mdb_hitemp():
+    global MdbHitemp
+    if MdbHitemp is None:
+        from exojax.database.hitemp.api import MdbHitemp as _MdbHitemp
+
+        MdbHitemp = _MdbHitemp
+    return MdbHitemp
+
+
+def _load_mock_mdb_exomol():
+    global mock_mdbExomol
+    if mock_mdbExomol is None:
+        from exojax.test.emulate_mdb import mock_mdbExomol as _mock_mdbExomol
+
+        mock_mdbExomol = _mock_mdbExomol
+    return mock_mdbExomol
 
 
 class MultiMDBCollection(list):
@@ -174,8 +212,9 @@ class MultiMol:
                 print("Sets mdb for ", simple_molecule_name)
                 try:
                     if self.dbmulti[k][i] in ["ExoMol", "exomol"]:
+                        mdb_exomol_class = _load_mdb_exomol()
                         mdb_k.append(
-                            MdbExomol(
+                            mdb_exomol_class(
                                 os.path.join(
                                     self.database_root_path, self.db_dirs[k][i]
                                 ),
@@ -187,8 +226,9 @@ class MultiMol:
                             )
                         )
                     elif self.dbmulti[k][i] in ["HITRAN12", "hitran12"]:
+                        mdb_hitran_class = _load_mdb_hitran()
                         mdb_k.append(
-                            MdbHitran(
+                            mdb_hitran_class(
                                 os.path.join(
                                     self.database_root_path, self.db_dirs[k][i]
                                 ),
@@ -200,8 +240,9 @@ class MultiMol:
                             )
                         )
                     elif self.dbmulti[k][i] in ["HITEMP", "hitemp"]:
+                        mdb_hitemp_class = _load_mdb_hitemp()
                         mdb_k.append(
-                            MdbHitemp(
+                            mdb_hitemp_class(
                                 os.path.join(
                                     self.database_root_path, self.db_dirs[k][i]
                                 ),
@@ -213,7 +254,8 @@ class MultiMol:
                             )
                         )
                     elif self.dbmulti[k][i] in ["SAMPLE"]:
-                        mdb_k.append(mock_mdbExomol(simple_molecule_name))
+                        mock_mdb_exomol_func = _load_mock_mdb_exomol()
+                        mdb_k.append(mock_mdb_exomol_func(simple_molecule_name))
 
                 except Exception as e:
                     if "No line found in " in e.args:

--- a/tests/unittests/database/api/optional_import_pressure_test.py
+++ b/tests/unittests/database/api/optional_import_pressure_test.py
@@ -1,0 +1,72 @@
+import builtins
+import importlib
+import sys
+
+
+_BLOCKED_MODULES = (
+    "exojax.database.exomol.api",
+    "exojax.database.hitran.api",
+    "exojax.database.hitemp.api",
+    "exojax.test.emulate_mdb",
+)
+
+
+def _block_eager_backend_imports(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in _BLOCKED_MODULES:
+            raise ModuleNotFoundError(
+                f"blocked eager import in test: {name}",
+                name=name,
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+
+def _clear_modules(monkeypatch, module_names):
+    for module_name in module_names:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+
+def test_database_api_import_avoids_eager_radis_backed_modules(monkeypatch):
+    _clear_modules(
+        monkeypatch,
+        [
+            "exojax.database.api",
+            "exojax.database.exomol.api",
+            "exojax.database.hitran.api",
+            "exojax.database.hitemp.api",
+        ],
+    )
+    _block_eager_backend_imports(monkeypatch)
+
+    module = importlib.import_module("exojax.database.api")
+
+    assert module.__name__ == "exojax.database.api"
+    assert "exojax.database.exomol.api" not in sys.modules
+    assert "exojax.database.hitran.api" not in sys.modules
+    assert "exojax.database.hitemp.api" not in sys.modules
+
+
+def test_multimol_import_avoids_eager_radis_backed_modules(monkeypatch):
+    _clear_modules(
+        monkeypatch,
+        [
+            "exojax.database.multimol",
+            "exojax.database.exomol.api",
+            "exojax.database.hitran.api",
+            "exojax.database.hitemp.api",
+            "exojax.test.emulate_mdb",
+        ],
+    )
+    _block_eager_backend_imports(monkeypatch)
+
+    module = importlib.import_module("exojax.database.multimol")
+
+    assert module.__name__ == "exojax.database.multimol"
+    assert "exojax.database.exomol.api" not in sys.modules
+    assert "exojax.database.hitran.api" not in sys.modules
+    assert "exojax.database.hitemp.api" not in sys.modules
+    assert "exojax.test.emulate_mdb" not in sys.modules


### PR DESCRIPTION
## Summary

  This PR reduces eager-import breakpoints identified in the optional-RADIS audit by deferring RADIS-backed imports in
  two modules:

  - src/exojax/database/api.py
  - src/exojax/database/multimol.py

  The goal is import-time resilience only. No packaging, backend architecture, inheritance model, or numerical behavior
  changes are included.

  ## What changed

  ### 1) exojax.database.api is now lazy

  File:

  - src/exojax/database/api.py

  Before:

  - Module eagerly imported:
      - exojax.database.exomol.api
      - exojax.database.hitemp.api
      - exojax.database.hitran.api
  - This made import exojax.database.api an immediate breakpoint when RADIS-backed modules could not load.

  After:

  - Added a tiny alias map + resolver:
      - _ALIASES
      - _resolve(name)
  - __getattr__ now resolves imports on demand.
  - Deprecation warnings and public names are preserved.

  ### 2) exojax.database.multimol defers RADIS-backed class imports

  File:

  - src/exojax/database/multimol.py

  Before:

  - Top-level imports eagerly loaded:
      - MdbExomol, MdbHitran, MdbHitemp
      - mock_mdbExomol
  - This made import exojax.database.multimol an immediate breakpoint.

  After:

  - Replaced eager imports with tiny local lazy loaders:
      - _load_mdb_exomol()
      - _load_mdb_hitran()
      - _load_mdb_hitemp()
      - _load_mock_mdb_exomol()
  - MultiMol.multimdb() now imports backend classes only in the branch that needs them.
  - Existing semantics are preserved.

  ### 3) Focused tests for import-pressure reduction

  File:

  - tests/unittests/database/api/optional_import_pressure_test.py

  Added tests that verify:

  - import exojax.database.api does not eagerly import RADIS-backed DB API modules.
  - import exojax.database.multimol does not eagerly import RADIS-backed DB API modules or exojax.test.emulate_mdb.

  ## Breakpoints reduced

  - src/exojax/database/api.py eager breakpoint reduced.
  - src/exojax/database/multimol.py eager breakpoint reduced.

  ## Breakpoints intentionally left for later

  Still import-time hard breakpoints due to inheritance binding in:

  - src/exojax/database/exomol/api.py
  - src/exojax/database/hitran/api.py
  - src/exojax/database/hitemp/api.py

  These require inheritance-layer work and are explicitly out of scope for this PR.

  ## Validation

  Commands run:

  1. pytest -q tests/unittests/database/api/optional_import_pressure_test.py
  2. pytest -q tests/unittests/multi/multimol/test_multimol_snapshot_support.py tests/unittests/database/api_radis/
     radis_adapter_contract_test.py

  Result:

  - All tests passed.
  - All of the unittests passed.