### PR TITLE
database: guard exomol base resolution at import time

### DIFF
--- a/src/exojax/database/exomol/api.py
+++ b/src/exojax/database/exomol/api.py
@@ -31,7 +31,20 @@ from exojax.database._common.setradis import _set_engine
 from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
 __all__ = ["MdbExomol"]
-CapiMdbExomol = get_exomol_mdb_class()
+# Inheritance remains for compatibility; backend-specific init/version logic
+# should stay in the RADIS backend adapter helpers.
+try:
+    CapiMdbExomol = get_exomol_mdb_class()
+except ImportError as exc:
+    if "requires RADIS" not in str(exc):
+        raise
+    _missing_radis_exc = exc
+
+    class CapiMdbExomol:
+        """Fallback base class used when RADIS is unavailable at import time."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(str(_missing_radis_exc)) from _missing_radis_exc
 
 
 class MdbExomol(CapiMdbExomol):
@@ -114,6 +127,7 @@ class MdbExomol(CapiMdbExomol):
         wavenum_min, wavenum_max = self.set_wavenum(nurange)
         self.engine = _set_engine(engine)
 
+        # Keep RADIS constructor differences localized in backend layer.
         init_exomol_manager(
             self,
             path=str(self.path),

--- a/tests/unittests/database/api/exomol_import_safety_test.py
+++ b/tests/unittests/database/api/exomol_import_safety_test.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+
+import pytest
+
+
+def _import_exomol_api_with_missing_base(monkeypatch):
+    from exojax.database._common import radis_adapter
+
+    def _raise_missing_radis():
+        raise ImportError(
+            "ExoMol database manager access requires RADIS. "
+            "Install it with `pip install radis`."
+        )
+
+    monkeypatch.setattr(radis_adapter, "get_exomol_mdb_class", _raise_missing_radis)
+    monkeypatch.delitem(sys.modules, "exojax.database.exomol.api", raising=False)
+    return importlib.import_module("exojax.database.exomol.api")
+
+
+def test_exomol_api_import_survives_missing_radis_base(monkeypatch):
+    module = _import_exomol_api_with_missing_base(monkeypatch)
+    assert hasattr(module, "MdbExomol")
+
+
+def test_exomol_class_use_fails_with_clear_importerror_when_radis_missing(monkeypatch):
+    module = _import_exomol_api_with_missing_base(monkeypatch)
+    with pytest.raises(ImportError, match="requires RADIS"):
+        module.CapiMdbExomol()


### PR DESCRIPTION
## Summary

  This PR reduces the import-time breakpoint in exojax.database.exomol.api by guarding backend base-class resolution
  when RADIS is missing.

  It is intentionally narrow: no packaging changes, no backend selector changes, no inheritance architecture rewrite,
  and no numerical behavior changes.

  ## What changed

  ### 1) Guarded base resolution in exomol/api.py

  File:

  - src/exojax/database/exomol/api.py

  Before:

  - Module import unconditionally executed:
      - CapiMdbExomol = get_exomol_mdb_class()
  - If RADIS was missing, importing exojax.database.exomol.api hard-failed immediately.

  After:

  - Base resolution is now wrapped:
      - try get_exomol_mdb_class()
      - if adapter raises normalized missing-RADIS ImportError ("requires RADIS"), define a minimal fallback base class
        locally
  - Fallback base class raises that same clear ImportError when used.

  Effect:

  - Importing exojax.database.exomol.api is less likely to hard-fail solely because RADIS is absent.
  - Runtime usage that actually needs RADIS still fails clearly and consistently.

  ### 2) Focused import-safety tests

  File:

  - tests/unittests/database/api/exomol_import_safety_test.py

  Added tests to verify:

  - exojax.database.exomol.api can still import when base-class lookup is unavailable due missing-RADIS ImportError.
  - Using the fallback base raises clear ImportError containing "requires RADIS".

  ## What this PR intentionally does not do

  - No redesign of MdbExomol inheritance architecture.
  - No attempt to make all runtime ExoMol operations work without RADIS.
  - No packaging/dependency changes.
  - No changes to hitran/api.py or hitemp/api.py import-time base binding in this PR.

  ## Remaining limitations

  - If base resolution fails for reasons other than normalized missing-RADIS ImportError, module import still fails
    (intended for safety).
  - MdbExomol runtime paths still require RADIS-backed functionality.

  ## Validation

  Commands run:

  1. pytest -q tests/unittests/database/api/exomol_import_safety_test.py
  2. pytest -q tests/unittests/database/api/exomol_import_safety_test.py tests/unittests/database/api/
     optional_import_pressure_test.py tests/unittests/database/api_radis/radis_adapter_contract_test.py tests/unittests/
     multi/multimol/test_multimol_snapshot_support.py
  3. pytest -q tests/unittests/database/api/exomol_import_safety_test.py tests/unittests/database/api/
     optional_import_pressure_test.py tests/unittests/database/api_radis/radis_adapter_contract_test.py tests/unittests/
     multi/multimol/test_multimol_snapshot_support.py (final)

  Final result:

  - All targeted tests passed.
