### PR TITLE
database: guard hitran and hitemp manager base imports

### DIFF
--- a/src/exojax/database/hitemp/api.py
+++ b/src/exojax/database/hitemp/api.py
@@ -10,7 +10,20 @@ from exojax.database._common.radis_adapter import (
 )
 from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
-HITEMPDatabaseManager = get_hitemp_database_manager_class()
+# Inheritance remains for compatibility; backend init details should stay in
+# adapter/backend helpers.
+try:
+    HITEMPDatabaseManager = get_hitemp_database_manager_class()
+except ImportError as exc:
+    if "requires RADIS" not in str(exc):
+        raise
+    _missing_radis_exc = exc
+
+    class HITEMPDatabaseManager:
+        """Fallback manager used when RADIS is unavailable at import time."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(str(_missing_radis_exc)) from _missing_radis_exc
 
 
 class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
@@ -82,6 +95,7 @@ class MdbHitemp(MdbCommonHitempHitran, HITEMPDatabaseManager):
         local_db_root = self.path.parent
         local_db_root = str(local_db_root) # convert to str for radis compatibility
 
+        # Keep backend manager constructor and collision handling localized.
         init_hitemp_manager(
             self,
             molecule=self.simple_molecule_name,

--- a/src/exojax/database/hitran/api.py
+++ b/src/exojax/database/hitran/api.py
@@ -8,7 +8,20 @@ from exojax.database._common.radis_adapter import (
 )
 from exojax.database.contracts import MDBMeta, Lines, MDBSnapshot
 
-HITRANDatabaseManager = get_hitran_database_manager_class()
+# Inheritance remains for compatibility; backend init details should stay in
+# adapter/backend helpers.
+try:
+    HITRANDatabaseManager = get_hitran_database_manager_class()
+except ImportError as exc:
+    if "requires RADIS" not in str(exc):
+        raise
+    _missing_radis_exc = exc
+
+    class HITRANDatabaseManager:
+        """Fallback manager used when RADIS is unavailable at import time."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(str(_missing_radis_exc)) from _missing_radis_exc
 
 class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
     """molecular database of HITRAN
@@ -79,6 +92,7 @@ class MdbHitran(MdbCommonHitempHitran, HITRANDatabaseManager):
 
         # HITRAN ONLY FUNCTIONALITY
         self.nonair_broadening = bool(nonair_broadening)
+        # Keep backend manager constructor semantics out of this call site.
         init_hitran_manager(
             self,
             molecule=self.simple_molecule_name,

--- a/tests/unittests/database/api/hitran_hitemp_import_safety_test.py
+++ b/tests/unittests/database/api/hitran_hitemp_import_safety_test.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+
+import pytest
+
+
+def _import_hitran_api_with_missing_manager(monkeypatch):
+    from exojax.database._common import radis_adapter
+
+    def _raise_missing_radis():
+        raise ImportError(
+            "HITRAN database manager access requires RADIS. "
+            "Install it with `pip install radis`."
+        )
+
+    monkeypatch.setattr(radis_adapter, "get_hitran_database_manager_class", _raise_missing_radis)
+    monkeypatch.delitem(sys.modules, "exojax.database.hitran.api", raising=False)
+    return importlib.import_module("exojax.database.hitran.api")
+
+
+def _import_hitemp_api_with_missing_manager(monkeypatch):
+    from exojax.database._common import radis_adapter
+
+    def _raise_missing_radis():
+        raise ImportError(
+            "HITEMP database manager access requires RADIS. "
+            "Install it with `pip install radis`."
+        )
+
+    monkeypatch.setattr(radis_adapter, "get_hitemp_database_manager_class", _raise_missing_radis)
+    monkeypatch.delitem(sys.modules, "exojax.database.hitemp.api", raising=False)
+    return importlib.import_module("exojax.database.hitemp.api")
+
+
+def test_hitran_api_import_survives_missing_radis_manager(monkeypatch):
+    module = _import_hitran_api_with_missing_manager(monkeypatch)
+    assert hasattr(module, "MdbHitran")
+
+
+def test_hitemp_api_import_survives_missing_radis_manager(monkeypatch):
+    module = _import_hitemp_api_with_missing_manager(monkeypatch)
+    assert hasattr(module, "MdbHitemp")
+
+
+def test_hitran_fallback_manager_use_fails_with_clear_importerror(monkeypatch):
+    module = _import_hitran_api_with_missing_manager(monkeypatch)
+    with pytest.raises(ImportError, match="requires RADIS"):
+        module.HITRANDatabaseManager()
+
+
+def test_hitemp_fallback_manager_use_fails_with_clear_importerror(monkeypatch):
+    module = _import_hitemp_api_with_missing_manager(monkeypatch)
+    with pytest.raises(ImportError, match="requires RADIS"):
+        module.HITEMPDatabaseManager()


### PR DESCRIPTION
## Summary

  This PR reduces import-time breakpoints in exojax.database.hitran.api and exojax.database.hitemp.api by guarding
  module-level backend manager class resolution when RADIS is missing.

  It follows the same narrow import-safety approach already used for ExoMol. No packaging, backend selector,
  architecture redesign, or numerical behavior changes are included.

  ## What changed

  ### 1) Guarded manager-base resolution in HITRAN API

  File:

  - src/exojax/database/hitran/api.py

  Before:

  - Module import unconditionally resolved:
      - HITRANDatabaseManager = get_hitran_database_manager_class()
  - Missing RADIS caused import-time hard failure.

  After:

  - Wrapped resolution in try/except ImportError.
  - If and only if the adapter error is the normalized missing-RADIS form ("requires RADIS"), define a tiny fallback
    HITRANDatabaseManager.
  - Fallback __init__ raises the same clear ImportError when used.
  - Unrelated errors are still raised (not swallowed).

  ### 2) Guarded manager-base resolution in HITEMP API

  File:

  - src/exojax/database/hitemp/api.py

  Before:

  - Module import unconditionally resolved:
      - HITEMPDatabaseManager = get_hitemp_database_manager_class()

  After:

  - Same guarded pattern as HITRAN.
  - Adds fallback HITEMPDatabaseManager that raises the normalized missing-RADIS ImportError when used.
  - Preserves loud failure for unrelated errors.

  ### 3) Focused import-safety tests

  File:

  - tests/unittests/database/api/hitran_hitemp_import_safety_test.py

  Added tests that verify:

  - import exojax.database.hitran.api succeeds when backend manager resolution fails only due to normalized missing-
    RADIS ImportError.
  - import exojax.database.hitemp.api succeeds under same condition.
  - Fallback manager usage raises clear ImportError containing "requires RADIS".

  ## Behavior impact

  - Import-time hard dependency pressure is reduced for HITRAN/HITEMP API modules.
  - Runtime behavior remains the same in RADIS-backed environments.
  - If RADIS-backed functionality is actually used without RADIS, failure remains clear and explicit.

  ## Intentionally out of scope

  - Full optional-RADIS support.
  - Inheritance architecture redesign.
  - Packaging/dependency changes.
  - Backend selection changes.
  - Broad runtime decoupling from hapi or other backend ecosystem dependencies.

  ## Validation

  Commands run:

  1. pytest -q tests/unittests/database/api/hitran_hitemp_import_safety_test.py tests/unittests/database/api/
     exomol_import_safety_test.py
  2. pytest -q tests/unittests/database/api/optional_import_pressure_test.py tests/unittests/database/api_radis/
     radis_adapter_contract_test.py tests/unittests/multi/multimol/test_multimol_snapshot_support.py

  Result:

  - All targeted tests passed.
  - All of the unit tests passed