### PR TITLE
fixed a bug that occurs when fft_length is odd

### DIFF
--- a/src/exojax/signal/ola.py
+++ b/src/exojax/signal/ola.py
@@ -149,7 +149,8 @@ def olaconv(input_matrix_zeropad, fir_filter_zeropad, ndiv, div_length, filter_l
     ftilde = jnp.fft.rfft(fir_filter_zeropad)
     xtilde = jnp.fft.rfft(input_matrix_zeropad, axis=1)
     ytilde = xtilde * ftilde[jnp.newaxis, :]
-    ftarr = jnp.fft.irfft(ytilde, axis=1)
+    fft_length = np.shape(input_matrix_zeropad)[1]
+    ftarr = jnp.fft.irfft(ytilde, n=fft_length, axis=1)
     output_length = ola_output_length(ndiv, div_length, filter_length)
     fftval = overlap_and_add(ftarr, output_length, div_length)
     return fftval


### PR DESCRIPTION
I realized that when the fft_length is odd, ola rotation produces strange values at the edges of the sectors for the following reason.
[jnp.fft.rfft](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.fft.rfft.html) returns (n+1)/2 when n is odd, and (n/2)+1 when n is even. Since [jnp.fft.irfft](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.fft.irfft.html) returns 2 * (n_input-1) when the output dimension is not specified, the second shape of farr would result in n-1 when n is odd.

I attach a sample script below. For example, if you change the number of wavenumber grids from 3500 to 3504, you will not observe the bug.

While I know that it is inappropriate to apply a rigid rotation kernel for emission geometry to a transmission spectrum, I share a sample script below that artificially applies it to a transmission spectrum as well. This is because the bug is probably more pronounced when the difference in spectral values is small, as in the case of a transmission spectrum.

Thank you in advance.

```
from jax import config
config.update("jax_enable_x64", True)

from exojax.utils.grids import wavenumber_grid

nu_grid, wav, resolution = wavenumber_grid(
    22920.0, 23000.0, 3500, unit="AA", xsmode="premodit"
)
print("Resolution=", resolution)

from exojax.database.exomol.api import MdbExomol
mdb = MdbExomol(".database/CO/12C-16O/Li2015", nurange=nu_grid)

from exojax.opacity import OpaPremodit

molmass = mdb.molmass # we use molmass later
snap = mdb.to_snapshot() # extract snapshot from mdb
del mdb # save the memory

opa = OpaPremodit.from_snapshot(
    snap,
    nu_grid,
    auto_trange=(500.0, 1500.0),
    dit_grid_resolution=1.0,
)

# for ExoJAX<=2.2, use the following code instead
# opa = OpaPremodit(mdb,nu_grid,auto_trange=(500.0, 1500.0),dit_grid_resolution=1.0,)

from exojax.rt import ArtEmisPure

art = ArtEmisPure(
    nu_grid=nu_grid,
    pressure_btm=1.0e1,
    pressure_top=1.0e-5,
    nlayer=200,
    rtsolver="ibased",
    nstream=8,
)

art.change_temperature_range(500.0, 1500.0)
Tarr = art.powerlaw_temperature(1200.0, 0.1)

mmr_profile = art.constant_mmr_profile(0.01)

from exojax.utils.astrofunc import gravity_jupiter

gravity = gravity_jupiter(1.0, 10.0)

xsmatrix = opa.xsmatrix(Tarr, art.pressure)

dtau_CO = art.opacity_profile_xs(xsmatrix, mmr_profile, molmass, gravity)
vmrH2 = 0.855  # VMR of H2
mmw = 2.33  # mean molecular weight of the atmosphere

dtau = dtau_CO

F = art.run(dtau, Tarr)

from exojax.postproc.specop import SopRotation

sop_rot = SopRotation(nu_grid, vsini_max=100.0, convolution_method="exojax.signal.convolve")
sop_rot_ola = SopRotation(nu_grid, vsini_max=100.0, convolution_method="exojax.signal.ola")

vsini = 10.0
u1 = 0.0
u2 = 0.0
Frot = sop_rot.rigid_rotation(F, vsini, u1, u2)
Frot_ola = sop_rot_ola.rigid_rotation(F, vsini, u1, u2)

import matplotlib.pyplot as plt
fig = plt.figure(figsize=(15, 4))
plt.plot(nu_grid, F, label="raw spectrum")
plt.plot(nu_grid, Frot, label="rotated (convolve)")
plt.plot(nu_grid, Frot_ola, label="rotated (ola)")
plt.xlabel("wavenumber (cm-1)")
plt.ylabel("flux (erg/s/cm2/cm-1)")
plt.legend()



from exojax.rt import ArtTransPure

art = ArtTransPure(
    pressure_btm=1.0e1,
    pressure_top=1.0e-11,
    nlayer=200,
)

from exojax.utils.astrofunc import gravity_jupiter
from exojax.utils.constants import RJ
gravity_btm = gravity_jupiter(1.0, 1.0)
radius_btm = RJ

import jax.numpy as jnp
mmw = 2.33*jnp.ones_like(art.pressure)  # mean molecular weight of the atmosphere

Rp2 = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)

Frot = sop_rot.rigid_rotation(Rp2, vsini, u1, u2)
Frot_ola = sop_rot_ola.rigid_rotation(Rp2, vsini, u1, u2)

fig = plt.figure(figsize=(15, 4))
plt.plot(nu_grid, Rp2, label="raw spectrum")
plt.plot(nu_grid, Frot, label="rotated (convolve)")
plt.plot(nu_grid, Frot_ola, label="rotated (ola)")
plt.xlabel("wavenumber (cm-1)")
plt.ylabel("flux (erg/s/cm2/cm-1)")
plt.legend()
plt.show()
```
<img width="3128" height="1000" alt="スクリーンショット 2026-04-10 17 44 24" src="https://github.com/user-attachments/assets/deca484f-b523-4b8c-a63c-e20b5d0f01af" />