### PR TITLE
Rotation for transmission spectroscopy

### DIFF
--- a/src/exojax/atm/amclouds.py
+++ b/src/exojax/atm/amclouds.py
@@ -26,7 +26,7 @@ def mixing_ratio_cloud_pressure(pressure, cloud_base_pressure, fsed, mr_cloud_ba
     """
     return jnp.where(
         cloud_base_pressure > pressure,
-        mr_cloud_base * (pressure / cloud_base_pressure) ** (fsed / kc),
+        mr_cloud_base * (pressure / cloud_base_pressure) ** (fsed * kc),
         0.0,
     )
 

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -18,7 +18,7 @@ from exojax.postproc.spin_rotation import (
     convolve_rigid_rotation,
     convolve_rigid_rotation_ola,
     convolve_rigid_rotation_trans,
-    # convolve_rigid_rotation_ola_trans,
+    convolve_rigid_rotation_ola_trans,
     rigid_rotation_trans_theta
 )
 from exojax.utils.grids import grid_resolution, velocity_grid, delta_velocity_from_resolution
@@ -262,7 +262,16 @@ class SopRotation(SopCommonConv):
         dv = delta_velocity_from_resolution(self.resolution)
 
         if int_grid == "velocity":
-            return convolve_rigid_rotation_trans(spectrum, self.vrarray, dv, vsini)
+            if (
+                self.convolution_method == self.convolution_method_list[0]
+            ):  # "exojax.signal.convolve"
+                return convolve_rigid_rotation_trans(spectrum, self.vrarray, dv, vsini)
+            elif (
+                self.convolution_method == self.convolution_method_list[1]
+            ):  # "exojax.signal.olaconv"
+                div_length = self.check_ola_reducible(spectrum)
+                folded_spectrum = spectrum.reshape((self.ola_ndiv, div_length))
+                return convolve_rigid_rotation_ola_trans(folded_spectrum, self.vrarray, dv, vsini)
         elif int_grid == "theta":
             if vsini <= dv:
                 raise ValueError("delta velocity from resolution exceeds the rotational velocity. Try again with higher resolution.")

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -11,7 +11,6 @@ import pathlib
 
 import numpy as np
 import pandas as pd
-import jax.numpy as jnp
 
 from exojax.postproc.response import ipgauss, ipgauss_ola, sampling
 from exojax.postproc.spin_rotation import (

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -18,8 +18,7 @@ from exojax.postproc.spin_rotation import (
     convolve_rigid_rotation,
     convolve_rigid_rotation_ola,
     convolve_rigid_rotation_trans,
-    convolve_rigid_rotation_ola_trans,
-    rigid_rotation_trans_theta
+    convolve_rigid_rotation_ola_trans
 )
 from exojax.utils.grids import grid_resolution, velocity_grid, delta_velocity_from_resolution
 from exojax.utils.photometry import apparent_magnitude
@@ -244,44 +243,27 @@ class SopRotation(SopCommonConv):
         else:
             raise ValueError("No convolution_method.")
 
-    def rigid_rotation_trans(self, spectrum, vsini, int_grid="velocity"):
+    def rigid_rotation_trans(self, spectrum, vsini):
         """apply a rigid rotation for transmission geometry
 
         Args:
             spectrum (nd array): 1D spectrum
             vsini (float): V sini in km/s
-            int_grid: integration over velocity or theta grids
-
-        Raises:
-            ValueError: _description_
 
         Returns:
             nd array: rotationally broaden spectrum
         """
         dv = delta_velocity_from_resolution(self.resolution)
-
-        if int_grid == "velocity":
-            if (
-                self.convolution_method == self.convolution_method_list[0]
-            ):  # "exojax.signal.convolve"
-                return convolve_rigid_rotation_trans(spectrum, self.vrarray, dv, vsini)
-            elif (
-                self.convolution_method == self.convolution_method_list[1]
-            ):  # "exojax.signal.olaconv"
-                div_length = self.check_ola_reducible(spectrum)
-                folded_spectrum = spectrum.reshape((self.ola_ndiv, div_length))
-                return convolve_rigid_rotation_ola_trans(folded_spectrum, self.vrarray, dv, vsini)
-        elif int_grid == "theta":
-            if vsini <= dv:
-                raise ValueError("delta velocity from resolution exceeds the rotational velocity. Try again with higher resolution.")
-            else:
-                # define dtheta by the velocity grid resolution (equal to pi/2 - arccos(dv/vsini))
-                dtheta = jnp.arcsin(dv/vsini)
-                Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
-                theta_array = (jnp.arange(Nt) + 0.5) / Nt * jnp.pi
-                return rigid_rotation_trans_theta(spectrum, self.nu_grid, theta_array, vsini)
-        else:
-            raise ValueError("No int_method.")
+        if (
+            self.convolution_method == self.convolution_method_list[0]
+        ):  # "exojax.signal.convolve"
+            return convolve_rigid_rotation_trans(spectrum, self.vrarray, dv, vsini)
+        elif (
+            self.convolution_method == self.convolution_method_list[1]
+        ):  # "exojax.signal.olaconv"
+            div_length = self.check_ola_reducible(spectrum)
+            folded_spectrum = spectrum.reshape((self.ola_ndiv, div_length))
+            return convolve_rigid_rotation_ola_trans(folded_spectrum, self.vrarray, dv, vsini)
 
 
 class SopInstProfile(SopCommonConv):

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -258,7 +258,6 @@ class SopRotation(SopCommonConv):
         Returns:
             nd array: rotationally broaden spectrum
         """
-        self.resolution = grid_resolution("ESLOG", self.nu_grid)
         dv = delta_velocity_from_resolution(self.resolution)
 
         if int_grid == "velocity":

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -11,13 +11,17 @@ import pathlib
 
 import numpy as np
 import pandas as pd
+import jax.numpy as jnp
 
 from exojax.postproc.response import ipgauss, ipgauss_ola, sampling
 from exojax.postproc.spin_rotation import (
     convolve_rigid_rotation,
     convolve_rigid_rotation_ola,
+    convolve_rigid_rotation_trans,
+    # convolve_rigid_rotation_ola_trans,
+    rigid_rotation_trans_theta
 )
-from exojax.utils.grids import grid_resolution, velocity_grid
+from exojax.utils.grids import grid_resolution, velocity_grid, delta_velocity_from_resolution
 from exojax.utils.photometry import apparent_magnitude
 
 
@@ -239,6 +243,37 @@ class SopRotation(SopCommonConv):
             )
         else:
             raise ValueError("No convolution_method.")
+
+    def rigid_rotation_trans(self, spectrum, vsini, int_grid="velocity"):
+        """apply a rigid rotation for transmission geometry
+
+        Args:
+            spectrum (nd array): 1D spectrum
+            vsini (float): V sini in km/s
+            int_grid: integration over velocity or theta grids
+
+        Raises:
+            ValueError: _description_
+
+        Returns:
+            nd array: rotationally broaden spectrum
+        """
+        self.resolution = grid_resolution("ESLOG", self.nu_grid)
+        dv = delta_velocity_from_resolution(self.resolution)
+
+        if int_grid == "velocity":
+            return convolve_rigid_rotation_trans(spectrum, self.vrarray, dv, vsini)
+        elif int_grid == "theta":
+            if vsini <= dv:
+                raise ValueError("delta velocity from resolution exceeds the rotational velocity. Try again with higher resolution.")
+            else:
+                # define dtheta by the velocity grid resolution (equal to pi/2 - arccos(dv/vsini))
+                dtheta = jnp.arcsin(dv/vsini)
+                Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
+                theta_array = (jnp.arange(Nt) + 0.5) / Nt * jnp.pi
+                return rigid_rotation_trans_theta(spectrum, self.nu_grid, theta_array, vsini)
+        else:
+            raise ValueError("No int_method.")
 
 
 class SopInstProfile(SopCommonConv):

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -172,30 +172,43 @@ def integrated_rotkernel_trans(x1, x2):
     return int_kernel
 
 
-@jit
-def rigid_rotation_trans_theta(F0, nu_grid, theta_array, vsini):
-    """Apply the Rotation response to a spectrum F for transmission geometry with equal theta grid.
+def generate_equal_theta_array(Nt, hemisphere=True):
+    """generate equal theta array
 
-    Note:
-        Equal theta grid is used, so the velocity grid is not uniform
+    Args:
+        Nt (int): number of theta array
+        hemisphere (bool): If true, provide grids from 0 to pi
+
+    Returns:
+        array: theta array
+     """
+    if hemisphere:
+        theta_array = (jnp.arange(Nt) + 0.5) / Nt * jnp.pi
+    else:
+        theta_array = (jnp.arange(Nt) + 0.5) / Nt * 2. * jnp.pi
+    return theta_array
+
+@jit
+def rv_profile(F0, nu_grid, rv_array, weight_array):
+    """Apply the user-specified radial velocity response to a spectrum F
 
     Args:
         F0: original spectrum (F0)
         nu_grid: wavenumber grid in cm-1
-        theta_array: fix-sized theta array
-        vsini: V sini for rotation (km/s)
+        rv_array: radial velocity array
+        weight_array: weight corresponding to the rv_array
 
     Return:
         response-applied spectrum (F)
     """
-    RV_array = vsini * jnp.cos(theta_array)
-
-    def f(acc, rv):
+    def f(acc, ipt):
+        rv, weight = ipt
         sp_sft = sampling(nu_grid, nu_grid, F0, rv)
-        acc = acc + sp_sft
+        acc = acc + sp_sft * weight
         return acc, None
 
     acc0 = jnp.zeros_like(F0)
-    acc, _ = scan(f, acc0, RV_array)
+    ipt = [rv_array, weight_array]
+    acc, _ = scan(f, acc0, ipt)
 
-    return acc/len(theta_array)
+    return acc/jnp.sum(weight_array)

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -167,7 +167,7 @@ def integrated_rotkernel_trans(x1, x2):
     # clip outside the [-vsini, vsini] range
     x1_c = jnp.clip(x1, -1., 1.)
     x2_c = jnp.clip(x2, -1., 1.)
-    int_kernel = jnp.abs(jnp.arcsin(x2_c) - jnp.arcsin(x1_c)) / jnp.pi
+    int_kernel = (jnp.arcsin(x2_c) - jnp.arcsin(x1_c)) / jnp.pi
     return int_kernel
 
 
@@ -177,7 +177,7 @@ def integrated_rotkernel_trans_jvp(primals, tangents):
     ux1, ux2 = tangents
     x1_2 = x1 * x1
     x2_2 = x2 * x2
-    dHdx1 = jnp.where(x1_2 < 1.0, 1./jnp.sqrt(1. - x1_2)/jnp.pi, 0.0)
+    dHdx1 = jnp.where(x1_2 < 1.0, -1./jnp.sqrt(1. - x1_2)/jnp.pi, 0.0)
     dHdx2 = jnp.where(x2_2 < 1.0, 1./jnp.sqrt(1. - x2_2)/jnp.pi, 0.0)
 
     primal_out = integrated_rotkernel_trans(x1, x2)

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -63,7 +63,7 @@ def convolve_rigid_rotation(F0, vr_array, vsini, u1=0.0, u2=0.0):
 
 @custom_jvp
 def rotkernel(x, u1, u2):
-    """rotation kernel w/ the quadratic limb darkening law, the numerator of (54) in Kawahara+2022
+    """rotation kernel w/ the quadratic limb darkening law, the numerator of (56) in Kawahara+2022
 
     Args:
         x: x variable
@@ -153,7 +153,7 @@ def convolve_rigid_rotation_trans(F0, vr_array, dv, vsini):
     return convolved_signal
 
 
-@jit
+@custom_jvp
 def integrated_rotkernel_trans(x1, x2):
     """integrated rotation kernel
 
@@ -169,6 +169,20 @@ def integrated_rotkernel_trans(x1, x2):
     x2_c = jnp.clip(x2, -1., 1.)
     int_kernel = jnp.abs(jnp.arcsin(x2_c) - jnp.arcsin(x1_c)) / jnp.pi
     return int_kernel
+
+
+@integrated_rotkernel_trans.defjvp
+def integrated_rotkernel_trans_jvp(primals, tangents):
+    x1, x2 = primals
+    ux1, ux2 = tangents
+    x1_2 = x1 * x1
+    x2_2 = x2 * x2
+    dHdx1 = jnp.where(x1_2 < 1.0, 1./jnp.sqrt(1. - x1_2)/jnp.pi, 0.0)
+    dHdx2 = jnp.where(x2_2 < 1.0, 1./jnp.sqrt(1. - x2_2)/jnp.pi, 0.0)
+
+    primal_out = integrated_rotkernel_trans(x1, x2)
+    tangent_out = dHdx1 * ux1 + dHdx2 * ux2
+    return primal_out, tangent_out
 
 
 def generate_equal_theta_array(Nt, hemisphere=True):

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -1,8 +1,11 @@
 import jax.numpy as jnp
 from jax import custom_jvp, jit
+from jax.lax import scan
 
 from exojax.signal.convolve import convolve_same
 from exojax.signal.ola import generate_zeropad, ola_lengths, olaconv
+from exojax.utils.grids import grid_resolution, delta_velocity_from_resolution
+from exojax.postproc.response import sampling
 
 
 @jit
@@ -99,3 +102,43 @@ def rotkernel_jvp(primals, tangents):
     primal_out = rotkernel(x, u1, u2)
     tangent_out = dHdx * ux + dHdu1 * uu1 + dHdu2 * uu2
     return primal_out, tangent_out
+
+
+def rigid_rotation_trans_theta(nu_grid, F0, vsini):
+    """Apply the Rotation response to a spectrum F for transmission geometry with equal theta grid.
+
+    Note:
+        Equal theta grid is used, so the velocity grid is not uniform
+
+    Args:
+        nu_grid: wavenumber grid
+        F0: original spectrum (F0)
+        vsini: V sini for rotation (km/s)
+
+    Raises:
+        ValueError: _description_
+
+    Return:
+        response-applied spectrum (F)
+    """
+    res = grid_resolution("ESLOG", nu_grid)
+    dv = delta_velocity_from_resolution(res)
+    if vsini <= dv:
+        raise ValueError("delta velocity from resolution exceeds the rotational velocity. Try again with higher resolution.")
+    else:
+        # define dtheta by the velocity grid resolution (equal to pi/2 - arccos(dv/vsini))
+        dtheta = jnp.arcsin(dv/vsini)
+        Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
+        theta_array = (jnp.arange(Nt) + 0.5) / Nt * jnp.pi
+
+        RV_array = vsini * jnp.cos(theta_array)
+
+        def f(acc, rv):
+            sp_sft = sampling(nu_grid, nu_grid, F0, rv)
+            acc = acc + sp_sft
+            return acc, None
+
+        acc0 = jnp.zeros_like(F0)
+        acc, _ = scan(f, acc0, RV_array)
+
+        return acc/Nt

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -4,7 +4,6 @@ from jax.lax import scan
 
 from exojax.signal.convolve import convolve_same
 from exojax.signal.ola import generate_zeropad, ola_lengths, olaconv
-from exojax.utils.grids import grid_resolution, delta_velocity_from_resolution
 from exojax.postproc.response import sampling
 
 

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -16,7 +16,6 @@ def convolve_rigid_rotation_ola(folded_F0, vr_array, vsini, u1=0.0, u2=0.0):
         folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
         vr_array: fix-sized vr array for kernel, see utils.dvgrid_rigid_rotation
         vsini: V sini for rotation (km/s)
-        RV: radial velocity
         u1: Limb-darkening coefficient 1
         u2: Limb-darkening coefficient 2
 
@@ -104,41 +103,99 @@ def rotkernel_jvp(primals, tangents):
     return primal_out, tangent_out
 
 
-def rigid_rotation_trans_theta(nu_grid, F0, vsini):
+# @jit
+# def convolve_rigid_rotation_ola_trans(folded_F0, vr_array, dv, vsini):
+#     """Apply the Rotation response to a transmission spectrum F (No OLA and No cuDNN).
+
+#     Args:
+#         folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
+#         vr_array: fix-sized vr array for kernel, see utils.dvgrid_rigid_rotation
+#         dv:
+#         vsini: V sini for rotation (km/s)
+
+#     Return:
+#         response-applied spectrum (F)
+#     """
+#     int_kernel = integrated_rotkernel_trans((vr_array-0.5*dv)/vsini, (vr_array+0.5*dv)/vsini)
+#     int_kernel = int_kernel / jnp.sum(int_kernel, axis=0)
+
+#     ndiv, div_length, filter_length = ola_lengths(folded_F0, int_kernel)
+#     F0_hat, int_kernel_hat = generate_zeropad(folded_F0, int_kernel)
+#     ola = olaconv(F0_hat, int_kernel_hat, ndiv, div_length, filter_length)
+
+#     edge = int((len(int_kernel) - 1) / 2)
+#     convolved_signal = ola[edge:-edge]
+
+#     return convolved_signal
+
+
+@jit
+def convolve_rigid_rotation_trans(F0, vr_array, dv, vsini):
+    """Apply the Rotation response to a transmission spectrum F (No OLA and No cuDNN).
+
+    Args:
+        F0: original spectrum (F0)
+        vr_array: fix-sized vr array for kernel, see utils.dvgrid_rigid_rotation
+        dv: velocity grid width
+        vsini: V sini for rotation (km/s)
+
+    Return:
+        response-applied spectrum (F)
+    """
+    int_kernel = integrated_rotkernel_trans((vr_array-0.5*dv)/vsini, (vr_array+0.5*dv)/vsini)
+    int_kernel = int_kernel / jnp.sum(int_kernel, axis=0)
+
+    #==== still require cuDNN in Oct.15 2022================
+    #convolved_signal = jnp.convolve(F0,kernel,mode="same")
+    #=======================================================
+
+    convolved_signal = convolve_same(F0, int_kernel)
+
+    return convolved_signal
+
+
+@jit
+def integrated_rotkernel_trans(x1, x2):
+    """integrated rotation kernel
+
+    Args:
+        x1: Velocity at bin_edge / vsini
+        x2: Velocity at bin_edge / vsini
+
+    Return:
+        integrated rotational kernel
+    """
+    # clip outside the [-vsini, vsini] range
+    x1_c = jnp.clip(x1, -1., 1.)
+    x2_c = jnp.clip(x2, -1., 1.)
+    int_kernel = jnp.abs(jnp.arcsin(x2_c) - jnp.arcsin(x1_c)) / jnp.pi
+    return int_kernel
+
+
+@jit
+def rigid_rotation_trans_theta(F0, nu_grid, theta_array, vsini):
     """Apply the Rotation response to a spectrum F for transmission geometry with equal theta grid.
 
     Note:
         Equal theta grid is used, so the velocity grid is not uniform
 
     Args:
-        nu_grid: wavenumber grid
         F0: original spectrum (F0)
+        nu_grid: wavenumber grid in cm-1
+        theta_array: fix-sized theta array
         vsini: V sini for rotation (km/s)
-
-    Raises:
-        ValueError: _description_
 
     Return:
         response-applied spectrum (F)
     """
-    res = grid_resolution("ESLOG", nu_grid)
-    dv = delta_velocity_from_resolution(res)
-    if vsini <= dv:
-        raise ValueError("delta velocity from resolution exceeds the rotational velocity. Try again with higher resolution.")
-    else:
-        # define dtheta by the velocity grid resolution (equal to pi/2 - arccos(dv/vsini))
-        dtheta = jnp.arcsin(dv/vsini)
-        Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
-        theta_array = (jnp.arange(Nt) + 0.5) / Nt * jnp.pi
+    RV_array = vsini * jnp.cos(theta_array)
 
-        RV_array = vsini * jnp.cos(theta_array)
+    def f(acc, rv):
+        sp_sft = sampling(nu_grid, nu_grid, F0, rv)
+        acc = acc + sp_sft
+        return acc, None
 
-        def f(acc, rv):
-            sp_sft = sampling(nu_grid, nu_grid, F0, rv)
-            acc = acc + sp_sft
-            return acc, None
+    acc0 = jnp.zeros_like(F0)
+    acc, _ = scan(f, acc0, RV_array)
 
-        acc0 = jnp.zeros_like(F0)
-        acc, _ = scan(f, acc0, RV_array)
-
-        return acc/Nt
+    return acc/len(theta_array)

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -202,7 +202,7 @@ def generate_equal_theta_array(Nt, hemisphere=True):
     return theta_array
 
 @jit
-def rv_profile(F0, nu_grid, rv_array, weight_array):
+def apply_weighted_rv_shifts(F0, nu_grid, rv_array, weight_array):
     """Apply the user-specified radial velocity response to a spectrum F
 
     Args:

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -5,6 +5,7 @@ from jax.lax import scan
 from exojax.signal.convolve import convolve_same
 from exojax.signal.ola import generate_zeropad, ola_lengths, olaconv
 from exojax.postproc.response import sampling
+from exojax.utils.constants import c
 
 
 @jit
@@ -224,4 +225,9 @@ def apply_weighted_rv_shifts(F0, nu_grid, rv_array, weight_array):
     ipt = [rv_array, weight_array]
     acc, _ = scan(f, acc0, ipt)
 
-    return acc/jnp.sum(weight_array)
+    acc = acc/jnp.sum(weight_array)
+
+    acc = jnp.where(nu_grid >= jnp.min(nu_grid / (1.0 + jnp.min(rv_array)/c)), acc, 0.0)
+    acc = jnp.where(nu_grid <= jnp.max(nu_grid / (1.0 + jnp.max(rv_array)/c)), acc, 0.0)
+
+    return acc

--- a/src/exojax/postproc/spin_rotation.py
+++ b/src/exojax/postproc/spin_rotation.py
@@ -103,30 +103,30 @@ def rotkernel_jvp(primals, tangents):
     return primal_out, tangent_out
 
 
-# @jit
-# def convolve_rigid_rotation_ola_trans(folded_F0, vr_array, dv, vsini):
-#     """Apply the Rotation response to a transmission spectrum F (No OLA and No cuDNN).
+@jit
+def convolve_rigid_rotation_ola_trans(folded_F0, vr_array, dv, vsini):
+    """Apply the Rotation response to a transmission spectrum F (OLA).
 
-#     Args:
-#         folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
-#         vr_array: fix-sized vr array for kernel, see utils.dvgrid_rigid_rotation
-#         dv:
-#         vsini: V sini for rotation (km/s)
+    Args:
+        folded_F0: original spectrum (F0) folded to (ndiv, div_length) form
+        vr_array: fix-sized vr array for kernel, see utils.dvgrid_rigid_rotation
+        dv: velocity grid width
+        vsini: V sini for rotation (km/s)
 
-#     Return:
-#         response-applied spectrum (F)
-#     """
-#     int_kernel = integrated_rotkernel_trans((vr_array-0.5*dv)/vsini, (vr_array+0.5*dv)/vsini)
-#     int_kernel = int_kernel / jnp.sum(int_kernel, axis=0)
+    Return:
+        response-applied spectrum (F)
+    """
+    int_kernel = integrated_rotkernel_trans((vr_array-0.5*dv)/vsini, (vr_array+0.5*dv)/vsini)
+    int_kernel = int_kernel / jnp.sum(int_kernel, axis=0)
 
-#     ndiv, div_length, filter_length = ola_lengths(folded_F0, int_kernel)
-#     F0_hat, int_kernel_hat = generate_zeropad(folded_F0, int_kernel)
-#     ola = olaconv(F0_hat, int_kernel_hat, ndiv, div_length, filter_length)
+    ndiv, div_length, filter_length = ola_lengths(folded_F0, int_kernel)
+    F0_hat, int_kernel_hat = generate_zeropad(folded_F0, int_kernel)
+    ola = olaconv(F0_hat, int_kernel_hat, ndiv, div_length, filter_length)
 
-#     edge = int((len(int_kernel) - 1) / 2)
-#     convolved_signal = ola[edge:-edge]
+    edge = int((len(int_kernel) - 1) / 2)
+    convolved_signal = ola[edge:-edge]
 
-#     return convolved_signal
+    return convolved_signal
 
 
 @jit

--- a/src/exojax/signal/ola.py
+++ b/src/exojax/signal/ola.py
@@ -149,7 +149,8 @@ def olaconv(input_matrix_zeropad, fir_filter_zeropad, ndiv, div_length, filter_l
     ftilde = jnp.fft.rfft(fir_filter_zeropad)
     xtilde = jnp.fft.rfft(input_matrix_zeropad, axis=1)
     ytilde = xtilde * ftilde[jnp.newaxis, :]
-    ftarr = jnp.fft.irfft(ytilde, axis=1)
+    fft_length = np.shape(input_matrix_zeropad)[1]
+    ftarr = jnp.fft.irfft(ytilde, n=fft_length, axis=1)
     output_length = ola_output_length(ndiv, div_length, filter_length)
     fftval = overlap_and_add(ftarr, output_length, div_length)
     return fftval

--- a/src/exojax/utils/astrofunc.py
+++ b/src/exojax/utils/astrofunc.py
@@ -4,7 +4,7 @@
 * That's why we need this module.
 """
 
-from exojax.utils.constants import gJ, gE
+from exojax.utils.constants import gJ, gE, RJ, RE
 from exojax.utils.constants import loggJ
 
 import jax.numpy as jnp
@@ -72,3 +72,20 @@ def gravity_earth(Rp, Mp):
         then gravity is given by (const.G*Mpcgs/Rpcgs**2)
     """
     return gE * Mp / Rp**2
+
+
+def rotational_velocity(Rp, P, unit_radius="jupiter"):
+    """rotational velocity in km/s
+
+    Args:
+        Rp: radius in the unit of Jovian or Earth radius
+        P: rotational period in days
+
+    Returns:
+        rotational velocity (km/s)
+    """
+    if unit_radius == "jupiter":
+        v_rot = 2. * jnp.pi * Rp * RJ * 1.e-5 / (P * 24. * 60. * 60.)
+    elif unit_radius == "earth":
+        v_rot = 2. * jnp.pi * Rp * RE * 1.e-5 / (P * 24. * 60. * 60.)
+    return v_rot

--- a/tests/unittests/postproc/response/spin_rotation_test.py
+++ b/tests/unittests/postproc/response/spin_rotation_test.py
@@ -1,3 +1,5 @@
+import os
+os.environ['CUDA_VISIBLE_DEVICES'] = '1'
 import pytest
 from exojax.postproc.spin_rotation import rotkernel
 import jax.numpy as jnp
@@ -154,8 +156,8 @@ def test_rotkernel(fig=False):
 
 
 if __name__ == "__main__":
-    #test_rotkernel(fig=True)
-    #test_convolve_rigid_rotation(1000,fig=True)
-    #test_convolve_rigid_rotation_ola(10000, fig=True)
-    #test_SopRotation(1000)
+    test_rotkernel(fig=True)
+    test_convolve_rigid_rotation(1000,fig=True)
+    test_convolve_rigid_rotation_ola(10000, fig=True)
+    test_SopRotation(1000)
     test_SopRotation_ola(10000, fig=True)

--- a/tests/unittests/postproc/response/spin_rotation_trans_test.py
+++ b/tests/unittests/postproc/response/spin_rotation_trans_test.py
@@ -1,0 +1,205 @@
+import pytest
+from exojax.postproc.spin_rotation import integrated_rotkernel_trans
+import jax.numpy as jnp
+import numpy as np
+from exojax.utils.grids import wavenumber_grid
+from exojax.utils.grids import velocity_grid
+from exojax.utils.grids import delta_velocity_from_resolution
+from exojax.postproc.spin_rotation import convolve_rigid_rotation_trans
+from exojax.postproc.spin_rotation import convolve_rigid_rotation_ola_trans
+from exojax.postproc.spin_rotation import generate_equal_theta_array, apply_weighted_rv_shifts
+import matplotlib.pyplot as plt
+        
+
+def _convolve_rigid_rotation_trans_np(resolution, F0, vsini):
+    """Apply the Rotation response to a spectrum F.
+
+    Args:
+        resolution: spectral resolution of wavenumber bin (ESLOG)
+        F0: original spectrum (F0)
+        vsini: V sini for rotation (km/s)
+
+    Return:
+        response-applied spectrum (F)
+    """
+    x = velocity_grid(resolution, vsini)
+    dv = delta_velocity_from_resolution(resolution)
+    int_kernel = integrated_rotkernel_trans((x-0.5*dv)/vsini, (x+0.5*dv)/vsini)
+    int_kernel = int_kernel / jnp.sum(int_kernel, axis=0)
+    #F = jnp.convolve(F0,kernel,mode="same")
+
+    #No OLA
+    input_length = len(F0)
+    filter_length = len(int_kernel)
+    #fft_length = input_length + filter_length - 1
+    convolved_signal = np.convolve(F0, int_kernel, mode="same")
+    return convolved_signal
+
+def test_SopRotation_trans(N=1000):
+    from jax import config
+    from exojax.postproc.specop import SopRotation
+    config.update("jax_enable_x64", True)
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               N,
+                                               xsmode="premodit")
+
+    F0 = np.ones_like(nus)
+    F0[250 - 5:250 + 5] = 0.5
+
+    vsini = 4.0
+    sos = SopRotation(nus, vsini)
+    
+    Frot = sos.rigid_rotation_trans(F0, vsini)
+    Frot_ = _convolve_rigid_rotation_trans_np(resolution, F0, vsini)
+    res = np.sqrt(np.sum(np.abs(1.0 - Frot / Frot_)**2))
+    assert res < 1.e-5
+
+
+def test_convolve_rigid_rotation_trans(N=1000, fig=False):
+    from jax import config
+    config.update("jax_enable_x64", True)
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               N,
+                                               xsmode="premodit")
+
+    F0 = np.ones_like(nus)
+    F0[250 - 5:250 + 5] = 0.5
+    vsini = 4.0
+    vr_array = velocity_grid(resolution, vsini)
+    dv = delta_velocity_from_resolution(resolution)
+
+    Frot = convolve_rigid_rotation_trans(F0, vr_array, dv, vsini)
+    Frot_ = _convolve_rigid_rotation_trans_np(resolution, F0, vsini)
+    
+    if fig:
+        _plotfig(Frot, Frot_)
+
+    res = np.sqrt(np.sum(np.abs(1.0 - Frot / Frot_)**2))
+    assert res < 1.e-5
+
+def test_convolve_rigid_rotation_trans_ola(N=10000, fig=False):
+    from jax import config
+    config.update("jax_enable_x64", True)
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               N,
+                                               xsmode="premodit")
+
+    F0 = np.ones_like(nus)
+    F0[2500 - 50:2500 + 50] = 0.5
+    vsini = 4.0
+    vr_array = velocity_grid(resolution, vsini)
+    input_matrix = F0.reshape((5,int(float(N)/5)))
+    dv = delta_velocity_from_resolution(resolution)
+
+    Frot = convolve_rigid_rotation_ola_trans(input_matrix, vr_array, dv, vsini)
+    Frot_ = _convolve_rigid_rotation_trans_np(resolution, F0, vsini)
+    if fig:
+        _plotfig(Frot, Frot_)
+    res = np.sqrt(np.sum(np.abs(1.0 - Frot / Frot_)**2))
+    assert res < 1.e-5
+
+def test_SopRotation_trans_ola(N=10000, fig=False):
+    from jax import config
+    from exojax.postproc.specop import SopRotation
+    config.update("jax_enable_x64", True)
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               N,
+                                               xsmode="premodit")
+
+    F0 = np.ones_like(nus)
+    F0[2500 - 50:2500 + 50] = 0.5
+    vsini = 4.0
+    
+    sos = SopRotation(nus, vsini, convolution_method = "exojax.signal.ola" )    
+    Frot = sos.rigid_rotation_trans(F0, vsini)
+    Frot_ = _convolve_rigid_rotation_trans_np(resolution, F0, vsini)
+
+    if fig:
+        _plotfig(Frot, Frot_)
+    res = np.sqrt(np.sum(np.abs(1.0 - Frot / Frot_)**2))
+    assert res < 1.e-5
+
+def _plotfig(Frot, Frot_):
+    figx = plt.figure()
+    ax = figx.add_subplot(211)
+    plt.plot(Frot_, label="numpy.convolve")
+    plt.plot(Frot, label="exojax")
+    plt.legend()
+    ax = figx.add_subplot(212)
+    plt.plot(1.0-Frot/Frot_, label="diff")
+    plt.legend()
+    plt.show()
+
+
+
+def test_integrated_rotkernel_trans(fig=False):
+    N = 201
+    x_1 = jnp.linspace(-2.0, 2.0, N)
+    dx = (jnp.max(x_1) - jnp.min(x_1)) / (N-1)
+    kernel_1 = integrated_rotkernel_trans(x_1-dx, x_1+dx)
+    N = 101
+    x_2 = jnp.linspace(-1.0, 1.0, N)
+    dx = (jnp.max(x_2) - jnp.min(x_2)) / (N-1)
+    kernel_2 = integrated_rotkernel_trans(x_2-dx, x_2+dx)
+    assert jnp.sum(kernel_1) == pytest.approx(1.999999)
+    assert jnp.sum(kernel_2) == pytest.approx(1.9998436)
+
+    if fig:
+        import matplotlib.pyplot as plt
+        plt.plot(x_1, kernel_1)
+        plt.plot(x_2, kernel_2)
+        plt.show()
+
+
+
+def test_generate_equal_theta_array():
+    Nt = 100
+    theta_array_1 = generate_equal_theta_array(Nt)
+    theta_array_2 = generate_equal_theta_array(Nt, hemisphere=False)
+    assert jnp.sum(theta_array_1) == pytest.approx(157.07964)
+    assert jnp.sum(theta_array_2) == pytest.approx(314.15927)
+
+def test_apply_weighted_rv_shifts(N=1000, fig=False):
+    from jax import config
+    from exojax.utils.constants import c
+    config.update("jax_enable_x64", True)
+    nus, wav, resolution = wavenumber_grid(4000.0,
+                                               4010.0,
+                                               N,
+                                               xsmode="premodit")
+
+    F0 = np.ones_like(nus)
+    F0[250 - 5:250 + 5] = 0.5
+    vsini = 4.0
+    dv = delta_velocity_from_resolution(resolution)
+    dtheta = jnp.arcsin(dv/vsini)
+    Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
+    theta_array = generate_equal_theta_array(Nt)
+    rv_array = jnp.cos(theta_array) * vsini
+    
+    Frot = apply_weighted_rv_shifts(F0, nus, rv_array, jnp.ones_like(rv_array))
+    Frot_ = _convolve_rigid_rotation_trans_np(resolution, F0, vsini)
+
+    # remove invalid edge points
+    mask = (nus >= jnp.min(nus / (1.0 + jnp.min(rv_array)/c))) * (nus <= jnp.max(nus / (1.0 + jnp.max(rv_array)/c)))
+    Frot = Frot[mask]
+    Frot_ = Frot_[mask]
+
+    if fig:
+        _plotfig(Frot, Frot_)
+
+    res = np.sqrt(np.sum(np.abs(1.0 - Frot / Frot_)**2))
+    assert res < 1.e-1
+
+if __name__ == "__main__":
+    test_integrated_rotkernel_trans(fig=True)
+    test_convolve_rigid_rotation_trans(1000,fig=True)
+    test_convolve_rigid_rotation_trans_ola(10000, fig=True)
+    test_SopRotation_trans(1000)
+    test_SopRotation_trans_ola(10000, fig=True)
+    test_generate_equal_theta_array()
+    test_apply_weighted_rv_shifts(N=10000, fig=True)

--- a/tests/unittests/utils/misc/astrofunc_test.py
+++ b/tests/unittests/utils/misc/astrofunc_test.py
@@ -1,15 +1,14 @@
-from exojax.utils.astrofunc import gravity_jupiter
+from exojax.utils.astrofunc import gravity_jupiter, gravity_earth
+from exojax.utils.astrofunc import rotational_velocity
 from exojax.utils.astrofunc import logg_jupiter
 from exojax.utils.astrofunc import square_radius_from_mass_logg
 import pytest
 
 def test_square_radius_from_mass_logg():
-
     Mp = 2.0
     logg = 4.0
     Rp2 = square_radius_from_mass_logg(Mp, logg)
     assert Rp2 == pytest.approx(0.4957154)
-    
 
 def test_getjov_logg():
     logg = logg_jupiter(1.0,1.0)
@@ -19,5 +18,17 @@ def test_getjov_gravity():
     g = gravity_jupiter(1.0,1.0)
     assert g == pytest.approx(2478.57730044555)
     
+def test_getearth_gravity():
+    g = gravity_earth(1.0,1.0)
+    assert g == pytest.approx(979.8398133669465)
+
+def test_getrot_velocity():
+    v_rot = rotational_velocity(1.0,1.0)
+    assert v_rot == pytest.approx(5.199044953482442)
+
 if __name__ == "__main__":
+    test_square_radius_from_mass_logg
     test_getjov_logg()
+    test_getjov_gravity()
+    test_getearth_gravity()
+    test_getrot_velocity()


### PR DESCRIPTION
Here is the pull request to include a rotation feature for the transmission spectrum (#540).

There are three options: convolution, OLA, and addition of RV-shifted spectra. The former two are preferred for cases with constant radial velocity along the annulus, such as rigid rotation, while the last one is suitable for non-constant cases, such as latitude-dependent winds. The function for the last option, ``apply_weighted_rv_shifts``, simply adds RV-shifted spectra using a user-specified RV array and corresponding weights, and thus can be used for general cases.

The following script confirms that the spectra for rigid rotation calculated using these three methods agree well. Please note that, due to differences in grid definitions between the first two methods (where the grid represents integrated values over each bin) and the last one, the final grid point differs between them. To avoid confusion and discard points where extrapolation is used, ``apply_weighted_rv_shifts`` [sets values outside the valid grid range to zero](https://github.com/ykawashima/exojax/blob/40f1e3b280dc47b3624151124e1f8fa8203f2082/src/exojax/postproc/spin_rotation.py#L230-L231).

I have also confirmed that retrieval with backward differentiation works and yields reasonable results for all three cases. For this purpose, I implemented a [custom_jvp for the rotation kernel](https://github.com/ykawashima/exojax/blob/40f1e3b280dc47b3624151124e1f8fa8203f2082/src/exojax/postproc/spin_rotation.py#L157-L186), as in the case of rigid rotation for the emission spectrum geometry (#211).

Thank you in advance. Note that I cherry-picked the commits pushed to the develop branch while I had been editing, as I wanted to incorporate the OLA bug fix (#705) to confirm the results of this pull request. It seems that they are included in this pull request as well. Please let me know if it would be better not to include such commits.

```
from jax import config
config.update("jax_enable_x64", True)

from exojax.utils.grids import wavenumber_grid

nu_grid, wav, resolution = wavenumber_grid(
    22920.0, 23000.0, 3500, unit="AA", xsmode="premodit"
)
print("Resolution=", resolution)

from exojax.database.exomol.api import MdbExomol
mdb = MdbExomol(".database/CO/12C-16O/Li2015", nurange=nu_grid)

from exojax.opacity import OpaPremodit
molmass = mdb.molmass # we use molmass later
snap = mdb.to_snapshot() # extract snapshot from mdb
del mdb # save the memory
opa = OpaPremodit.from_snapshot(snap, nu_grid, auto_trange=[500.0, 1500.0], dit_grid_resolution=1.0)

from exojax.rt import ArtTransPure

art = ArtTransPure(
    pressure_btm=1.0e1,
    pressure_top=1.0e-11,
    nlayer=200,
)

art.change_temperature_range(500.0, 1500.0)
Tarr = art.powerlaw_temperature(1200.0, 0.1)

mmr_profile = art.constant_mmr_profile(0.01)

import jax.numpy as jnp
from exojax.utils.astrofunc import gravity_jupiter
from exojax.utils.constants import RJ
gravity_btm = gravity_jupiter(1.0, 1.0)
radius_btm = RJ

mmw = 2.33*jnp.ones_like(art.pressure)  # mean molecular weight of the atmosphere
gravity = art.gravity_profile(Tarr, mmw, radius_btm, gravity_btm)

from exojax.database.contdb  import CdbCIA
from exojax.opacity import OpaCIA

cdb = CdbCIA(".database/H2-H2_2011.cia", nurange=nu_grid)
opacia = OpaCIA(cdb, nu_grid=nu_grid)

xsmatrix = opa.xsmatrix(Tarr, art.pressure)
logacia_matrix = opacia.logacia_matrix(Tarr)

dtau_CO = art.opacity_profile_xs(xsmatrix, mmr_profile, molmass, gravity)
vmrH2 = 0.855  # VMR of H2
dtaucia = art.opacity_profile_cia(logacia_matrix, Tarr, vmrH2, vmrH2, mmw[:, None], gravity)

dtau = dtau_CO + dtaucia

Rp2 = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)

from exojax.postproc.specop import SopRotation
sop_rot = SopRotation(nu_grid, vsini_max=100.0, convolution_method="exojax.signal.convolve")
sop_rot_ola = SopRotation(nu_grid, vsini_max=100.0, convolution_method="exojax.signal.ola")

from exojax.utils.astrofunc import rotational_velocity
vsini = rotational_velocity(1.0, 1.0)
print("vsini", vsini)

import time
ts = time.perf_counter()
Rp2_rot_velocity = sop_rot.rigid_rotation_trans(Rp2, vsini)
te = time.perf_counter()
print("convolve:", te-ts, "[s]")
ts = time.perf_counter()
Rp2_rot_velocity_ola = sop_rot_ola.rigid_rotation_trans(Rp2, vsini)
te = time.perf_counter()
print("ola:", te-ts, "[s]")

from exojax.utils.grids import delta_velocity_from_resolution
from exojax.postproc.spin_rotation import generate_equal_theta_array, apply_weighted_rv_shifts
# define dtheta by the velocity grid resolution (equal to pi/2 - arccos(dv/vsini))
dv = delta_velocity_from_resolution(resolution)
dtheta = jnp.arcsin(dv/vsini)
Nt = jnp.ceil(jnp.pi / dtheta).astype(jnp.int32)
theta_array = generate_equal_theta_array(Nt)
print(theta_array)
theta_array2 = generate_equal_theta_array(Nt, hemisphere=False)
print(theta_array2)
rv_array = jnp.cos(theta_array) * vsini
ts = time.perf_counter()
Rp2_rot_theta = apply_weighted_rv_shifts(Rp2, nu_grid, rv_array, jnp.ones_like(rv_array))
te = time.perf_counter()
print("theta:", te-ts, "[s]")

import matplotlib.pyplot as plt
fig = plt.figure(figsize=(12, 6))
ax = fig.add_subplot(111)
plt.plot(nu_grid, Rp2)
plt.plot(nu_grid, Rp2_rot_velocity, label='convolve')
plt.plot(nu_grid, Rp2_rot_velocity_ola, label='ola')
plt.plot(nu_grid, Rp2_rot_theta, label='theta')
plt.xlabel("wavenumber (cm-1)")
plt.legend()
plt.show()
# plt.savefig("output/comp_rot_method.pdf", bbox_inches='tight')

from exojax.postproc.specop import SopInstProfile
from exojax.utils.instfunc import resolution_to_gaussian_std

sop_inst = SopInstProfile(nu_grid, vrmax=1000.0)

RV = 40.0  # km/s
resolution_inst = 30000.0
beta_inst = resolution_to_gaussian_std(resolution_inst)
Rp2_inst_w_rot = sop_inst.ipgauss(Rp2_rot_velocity, beta_inst)
Rp2_inst_wo_rot = sop_inst.ipgauss(Rp2, beta_inst)

fig = plt.figure(figsize=(12, 6))
ax = fig.add_subplot(111)
plt.plot(nu_grid, Rp2_inst_w_rot, label="w/ rot")
plt.plot(nu_grid, Rp2_inst_wo_rot, label="w/o rot")
plt.xlabel("wavenumber (cm-1)")
plt.legend()
plt.show()
# plt.savefig("output/comp_rot_effect.pdf", bbox_inches='tight')

nu_obs = nu_grid[::5][:-50]


from numpy.random import normal
noise = 0.001
Fobs = sop_inst.sampling(Rp2_inst_w_rot, RV, nu_obs) + normal(0.0, noise, len(nu_obs))

fig = plt.figure(figsize=(12, 6))
ax = fig.add_subplot(111)

plt.errorbar(nu_obs, Fobs, noise, fmt=".", label="RV + IP (sampling)", color="gray",alpha=0.5)
plt.xlabel("wavenumber (cm-1)")
plt.legend()
plt.show()
# plt.savefig("output/Fobs.pdf", bbox_inches='tight')

def fspec(T0, alpha, mmr, radius_btm, gravity_btm, RV, vsini):
    """ computes planet radius sqaure spectrum

    Args:
        T0 (float): temperature at 1 bar
        alpha (float): power law index of temperature
        mmr (float): Mass mixing ratio of CO
        radius_btm (float): radius at the bottom in cm
        gravity_btm (float): gravity at the bottom in cm/s2
        RV (float): radial velocity in km/s
        vsini (float): radial rotational velocity in km/s

    Returns:
        _type_: _description_
    """

    Tarr = art.powerlaw_temperature(T0, alpha)
    gravity = art.gravity_profile(Tarr, mmw, radius_btm, gravity_btm)

    #molecule
    xsmatrix = opa.xsmatrix(Tarr, art.pressure)
    mmr_arr = art.constant_mmr_profile(mmr)
    dtau = art.opacity_profile_xs(xsmatrix, mmr_arr, molmass, gravity)
    #continuum
    logacia_matrix = opacia.logacia_matrix(Tarr)
    dtaucH2H2 = art.opacity_profile_cia(logacia_matrix, Tarr, vmrH2, vmrH2,
                                        mmw[:, None], gravity)
    #total tau
    dtau = dtau + dtaucH2H2
    Rp2 = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
    Rp2_rot_velocity = sop_rot.rigid_rotation_trans(Rp2, vsini)
    Rp2_inst = sop_inst.ipgauss(Rp2_rot_velocity, beta_inst)

    mu = sop_inst.sampling(Rp2_inst, RV, nu_obs)
    return mu

fig = plt.figure(figsize=(12, 3))

plt.plot(nu_obs, fspec(1200.0, 0.09, 0.01, RJ, gravity_jupiter(1.0, 1.0), 40.0, vsini),label="model")
plt.plot(nu_obs, fspec(1400.0, 0.12, 0.01, RJ, gravity_jupiter(1.0, 1.3), 20.0, vsini),label="model")
plt.show()
# plt.savefig("output/model.pdf", bbox_inches='tight')

from numpyro.infer import MCMC, NUTS
import numpyro.distributions as dist
import numpyro
from jax import random

def model_prob(spectrum):

    #atmospheric/spectral model parameters priors
    logg = numpyro.sample('logg', dist.Uniform(3.0, 4.0))
    RV = numpyro.sample('RV', dist.Uniform(35.0, 45.0))
    mmr = numpyro.sample('MMR', dist.Uniform(0.0, 0.015))
    T0 = numpyro.sample('T0', dist.Uniform(1000.0, 1500.0))
    alpha = numpyro.sample('alpha', dist.Uniform(0.05, 0.2))
    radius_btm = numpyro.sample('rb', dist.Normal(1.0,0.05))
    vsini = numpyro.sample('vsini', dist.Uniform(0.0, 10.0))

    mu = fspec(T0, alpha, mmr, radius_btm*RJ, 10**logg, RV, vsini)

    #noise model parameters priors
    sigmain = numpyro.sample('sigmain', dist.Exponential(1000.0))

    numpyro.sample('spectrum', dist.Normal(mu, sigmain), obs=spectrum)

rng_key = random.PRNGKey(0)
rng_key, rng_key_ = random.split(rng_key)
num_warmup, num_samples = 500, 1000
#kernel = NUTS(model_prob, forward_mode_differentiation=True)
kernel = NUTS(model_prob, forward_mode_differentiation=False)

mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
mcmc.run(rng_key_, spectrum=Fobs)
mcmc.print_summary()

from numpyro.diagnostics import hpdi
from numpyro.infer import Predictive
import jax.numpy as jnp

# SAMPLING
posterior_sample = mcmc.get_samples()
pred = Predictive(model_prob, posterior_sample, return_sites=['spectrum'])
predictions = pred(rng_key_, spectrum=None)
median_mu1 = jnp.median(predictions['spectrum'], axis=0)
hpdi_mu1 = hpdi(predictions['spectrum'], 0.9)

fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(15, 4.5))
ax.plot(nu_obs, median_mu1, color='C1')
ax.fill_between(nu_obs,
                hpdi_mu1[0],
                hpdi_mu1[1],
                alpha=0.3,
                interpolate=True,
                color='C1',
                label='90% area')
ax.errorbar(nu_obs, Fobs, noise, fmt=".", label="mock spectrum", color="black",alpha=0.5)
plt.xlabel('wavenumber (cm-1)', fontsize=16)
plt.legend(fontsize=14)
plt.tick_params(labelsize=14)
# plt.show()
plt.savefig("output/fit.pdf", bbox_inches='tight')

import arviz
pararr = ['T0', 'alpha', 'logg', 'MMR', 'radius_btm', 'RV']
arviz.plot_pair(arviz.from_numpyro(mcmc),
                kind='kde',
                divergences=False,
                marginals=True)
# plt.show()
plt.savefig("output/corner.pdf", bbox_inches='tight')
```