### PR TITLE
Source function method for ArtEmisScat

### DIFF
--- a/documents/userguide/rtransfer.rst
+++ b/documents/userguide/rtransfer.rst
@@ -23,13 +23,18 @@ See :doc:`../userguide/rtransfer_ibased_pure` for the details of the `ibased` me
 For emission with scattering in ExoJAX, there are implementations for treating the scattering component as an effective reflectivity 
 using **the flux-adding treatment** (`Robinson and Crisp 2018 <https://www.sciencedirect.com/science/article/pii/S0022407317305101?via%3Dihub>`_), 
 and as an effective transmission using the **LART** method.
-These are the fbased computation.
+These are flux-based computations.
+``ArtEmisScat`` also supports SFM-2st, where SFM stands for the source function method
+(Toon et al. 1989), with Toon hemispheric-mean two-stream fluxes
+(``rtsolver="sfm2st_toon_hemispheric_mean"``). This scheme first computes the two-stream fluxes,
+then evaluates the emission spectrum by the intensity-based formal solution.
 Regarding reflected light in ExoJAX, the flux-adding treatment can be utilized.
 
 See :doc:`../userguide/rtransfer_fbased` for the details of the `fbased` method for reflection and/or emission with scattering.
 
-All of the ``fbased`` schemes are currently based on the two-stream approximation, althogh the ``ibased`` schemes can specify the number of the streams. 
-In the future, other ibased schemes for scattering/reflection is planned, but as of January 2025, it has not yet been implemented.
+All of the ``fbased`` schemes are currently based on the two-stream approximation, although the ``ibased`` schemes can specify the number of the streams.
+The SFM-2st emission solver uses a two-stream source function and an intensity-based angular integration with a configurable number of streams.
+Other ibased schemes for scattering/reflection are planned but have not yet been implemented.
 
 For transmission spectroscopy in ExoJAX, the options are primarily limited to differences in the integration methods. 
 Both the Trapezoid integration method and the method using Simpson's rule are available.
@@ -71,4 +76,3 @@ See the following APIs for the details of these art classes:
 - `exojax.spec.atmrt.ArtReflectEmis <../exojax/exojax.spec.html#exojax.spec.atmrt.ArtReflectEmis>`_
 - `exojax.spec.atmrt.ArtTransPure <../exojax/exojax.spec.html#exojax.spec.atmrt.ArtTransPure>`_
 - `exojax.spec.atmrt.ArtAbsPure <../exojax/exojax.spec.html#exojax.spec.atmrt.ArtAbsPure>`_
-

--- a/documents/userguide/rtransfer_fbased.rst
+++ b/documents/userguide/rtransfer_fbased.rst
@@ -1,8 +1,11 @@
 Flux-based Reflection, Emission with Scattering
 ------------------------------------------------------
 
-As of January 2025, the radiative transfer solution in ExoJAX, including scattering and reflection, is based on a flux-based two-stream approximation. 
-By default, the method employs the flux-adding treatment (Robinson and Crisp 2018) as the scheme for solving.
+ExoJAX supports flux-based two-stream radiative transfer for scattering and reflection.
+For emission with scattering, ExoJAX also supports SFM-2st, where SFM stands for the source
+function method (Toon et al. 1989). It uses Toon hemispheric-mean two-stream fluxes to construct
+source functions for the intensity-based formal solution.
+By default, the flux-based solvers employ the flux-adding treatment (Robinson and Crisp 2018).
 
 
 The flux-adding treatment solves the following two recurrence relations iteratively from the bottom upwards:
@@ -37,6 +40,34 @@ The outgoing flux is then computed as
 
 
 See Section 4.3 in `Paper II <https://arxiv.org/abs/2410.06900>`_ and Robinson and Crisp (2019) JQSRT, 211, 78 for further details on the two-stream approximation method.
+
+Emission with Scattering using SFM-2st
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ArtEmisScat`` supports SFM-2st by setting
+``rtsolver="sfm2st_toon_hemispheric_mean"``. The two-stream fluxes are used only to construct the layer source
+functions. The final outgoing spectrum is computed by the intensity-based formal solution, whose angular
+quadrature is controlled by ``nstream``.
+
+.. code:: python
+
+    from exojax.rt import ArtEmisScat
+
+    art = ArtEmisScat(
+        pressure_top=1.0e-5,
+        pressure_btm=1.0e1,
+        nlayer=200,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    F0 = art.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+    )
 
 Radiative transfer with scattering and reflection can be classified into three types:
 

--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -8,6 +8,7 @@ from exojax.rt.rtransfer import (
     rtrun_emis_pureabs_ibased_linsap,
     rtrun_emis_scat_fluxadding_toonhm,
     rtrun_emis_scat_lart_toonhm,
+    rtrun_emis_scat_sfm2st_toonhm,
     initialize_gaussian_quadrature,
     setrt_toonhm,
 )
@@ -412,6 +413,7 @@ class ArtEmisScat(ArtCommon):
         nlayer=100,
         nu_grid=None,
         rtsolver="fluxadding_toon_hemispheric_mean",
+        nstream=8,
     ):
         """initialization of ArtEmisScat
 
@@ -422,11 +424,16 @@ class ArtEmisScat(ArtCommon):
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
             rtsolver (str): Radiative Transfer Solver,
                 "fluxadding_toon_hemispheric_mean" (default),
-                "lart_toon_hemispheric_mean"
+                "lart_toon_hemispheric_mean",
+                "sfm2st_toon_hemispheric_mean"
+            nstream (int, optional): the number of streams for SFM-2st.
+                Defaults to 8.
 
         """
         super().__init__(pressure_top, pressure_btm, nlayer, nu_grid)
         self.rtsolver = rtsolver
+        self.nstream = nstream
+        self.mus, self.weights = initialize_gaussian_quadrature(self.nstream)
         self.method = "emission_with_scattering_using_" + self.rtsolver
 
     def run(
@@ -480,6 +487,16 @@ class ArtEmisScat(ArtCommon):
                 dtau, single_scattering_albedo, asymmetric_parameter, sourcef
             )
 
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            spectrum = rtrun_emis_scat_sfm2st_toonhm(
+                dtau,
+                single_scattering_albedo,
+                asymmetric_parameter,
+                sourcef,
+                self.mus,
+                self.weights,
+            )
+
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
@@ -518,6 +535,15 @@ class ArtEmisScat(ArtCommon):
         elif self.rtsolver == "fluxadding_toon_hemispheric_mean":
             spectrum = rtrun_emis_scat_fluxadding_toonhm(
                 dtau_2d, ssa_2d, g_2d, sourcef
+            )
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            spectrum = rtrun_emis_scat_sfm2st_toonhm(
+                dtau_2d,
+                ssa_2d,
+                g_2d,
+                sourcef,
+                self.mus,
+                self.weights,
             )
         else:
             raise ValueError(f"Unknown rtsolver for CKD: {self.rtsolver}")

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -17,6 +17,8 @@
     -- pure absorption 
     --- isothermal: rtrun_emis_pureabs_ibased
     --- linear source approximation: rtrun_emis_pureabs_ibased_linsap
+    -- scattering
+    --- SFM-2st: rtrun_emis_scat_sfm2st
 
     - transmision: 
     -- trapezoid integration: rtrun_trans_pureabs_trapezoid
@@ -39,6 +41,7 @@ from exojax.rt.twostream import (
     compute_tridiag_diagonals_and_vector,
     set_scat_trans_coeffs,
     solve_fluxadding_twostream,
+    solve_fluxadding_twostream_fluxes,
     solve_lart_twostream,
 )
 from exojax.special.expn import E1
@@ -452,6 +455,64 @@ def rtrun_emis_scat_fluxadding_toonhm(
     )
 
     return spectrum
+
+
+@jit
+def rtrun_emis_scat_sfm2st_toonhm(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+    mus,
+    weights,
+):
+    """Radiative transfer for emission with scattering using SFM-2st.
+
+    The two-stream fluxes are computed with Toon hemispheric mean and
+    converted into layer source functions. The final intensity transfer
+    reuses the isothermal-layer intensity-based pure absorption solver.
+
+    Args:
+        dtau (2D array): Optical depth matrix, dtau (N_layer, N_nus).
+        single_scattering_albedo (2D array): Single scattering albedo.
+        asymmetric_parameter (2D array): Asymmetric parameter.
+        source_matrix (2D array): Source matrix in pi B scale.
+        mus (1D array): Gaussian quadrature cosine angles.
+        weights (1D array): Gaussian quadrature weights.
+
+    Returns:
+        1D array: Emission spectrum.
+    """
+
+    _, Nnus = dtau.shape
+    source_surface = jnp.zeros(Nnus)
+    reflectivity_surface = jnp.zeros(Nnus)
+
+    trans_coeff, scat_coeff, reduced_piB, _, _, _ = setrt_toonhm(
+        dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
+    )
+
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        trans_coeff,
+        scat_coeff,
+        reduced_piB,
+        reflectivity_surface,
+        source_surface,
+    )
+
+    flux_plus_layer = 0.5 * (flux_plus[:-1] + flux_plus[1:])
+    flux_minus_layer = 0.5 * (flux_minus[:-1] + flux_minus[1:])
+
+    source_sfm = (1.0 - single_scattering_albedo) * source_matrix + (
+        0.5
+        * single_scattering_albedo
+        * (
+            (1.0 + asymmetric_parameter) * flux_plus_layer
+            + (1.0 - asymmetric_parameter) * flux_minus_layer
+        )
+    )
+
+    return rtrun_emis_pureabs_ibased(dtau, source_sfm, mus, weights)
 
 
 def setrt_toonhm(dtau, single_scattering_albedo, asymmetric_parameter, source_matrix):

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -27,39 +27,146 @@ def solve_fluxadding_twostream(
         Effective reflectivity (hat(R^plus)), Effective source (hat(S^plus))
     """
 
-    nlayer, _ = trans_coeff.shape
+    Rplus, Splus = compute_fluxadding_coeffs(
+        trans_coeff,
+        scat_coeff,
+        reduced_source_function,
+        reflectivity_bottom,
+        source_bottom,
+    )
+    return Rplus[0], Splus[0]
+
+
+def compute_fluxadding_coeffs(
+    trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom
+):
+    """Computes upward effective reflection/source at all interfaces.
+
+    Args:
+        trans_coeff: Transmission coefficient (Nlayer, Nnus).
+        scat_coeff: Scattering coefficient (Nlayer, Nnus).
+        reduced_source_function: Reduced source function (Nlayer, Nnus).
+        reflectivity_bottom: Bottom boundary reflectivity (Nnus).
+        source_bottom: Bottom boundary source (Nnus).
+
+    Returns:
+        tuple: Rplus, Splus, each with shape (Nlayer + 1, Nnus).
+    """
+
     pihatB = (1.0 - trans_coeff - scat_coeff) * reduced_source_function
 
     # bottom reflection
-    Rphat0 = scat_coeff[nlayer - 1, :] + trans_coeff[
-        nlayer - 1, :
-    ] ** 2 * reflectivity_bottom / (
-        1.0 - scat_coeff[nlayer - 1, :] * reflectivity_bottom
-    )
-    Sphat0 = pihatB[nlayer - 1, :] + trans_coeff[nlayer - 1, :] * (
-        source_bottom + pihatB[nlayer - 1, :] * reflectivity_bottom
-    ) / (1.0 - scat_coeff[nlayer - 1, :] * reflectivity_bottom)
+    Rplus_bottom = reflectivity_bottom
+    Splus_bottom = source_bottom
 
     def f(carry_ip1, arr):
-        Rphat_prev, Sphat_prev = carry_ip1
+        Rplus_prev, Splus_prev = carry_ip1
         scat_coeff_i, trans_coeff_i, pihatB_i = arr
-        denom = 1.0 - scat_coeff_i * Rphat_prev
-        Sphat_each = (
-            pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom
+        denom = 1.0 - scat_coeff_i * Rplus_prev
+        Splus_each = (
+            pihatB_i + trans_coeff_i * (Splus_prev + pihatB_i * Rplus_prev) / denom
         )
-        Rphat_each = scat_coeff_i + trans_coeff_i**2 * Rphat_prev / denom
-        RS = [Rphat_each, Sphat_each]
-        return RS, 0
+        Rplus_each = scat_coeff_i + trans_coeff_i**2 * Rplus_prev / denom
+        RS = [Rplus_each, Splus_each]
+        return RS, RS
 
     # main loop
     arrin = [
-        scat_coeff[nlayer - 2 :: -1],
-        trans_coeff[nlayer - 2 :: -1],
-        pihatB[nlayer - 2 :: -1],
+        scat_coeff[::-1],
+        trans_coeff[::-1],
+        pihatB[::-1],
     ]
-    RS, _ = scan(f, [Rphat0, Sphat0], arrin)
+    _, stackedRS = scan(f, [Rplus_bottom, Splus_bottom], arrin)
+    Rplus_reverse, Splus_reverse = stackedRS
 
-    return RS
+    Rplus = jnp.vstack([Rplus_reverse[::-1], Rplus_bottom])
+    Splus = jnp.vstack([Splus_reverse[::-1], Splus_bottom])
+    return Rplus, Splus
+
+
+def compute_fluxadding_downward_coeffs(
+    trans_coeff, scat_coeff, reduced_source_function, source_top=None
+):
+    """Computes downward effective reflection/source at all interfaces.
+
+    The top boundary is expressed as:
+    F_0^- = 0 * F_0^+ + source_top.
+
+    Args:
+        trans_coeff: Transmission coefficient (Nlayer, Nnus).
+        scat_coeff: Scattering coefficient (Nlayer, Nnus).
+        reduced_source_function: Reduced source function (Nlayer, Nnus).
+        source_top: Top boundary incoming flux (Nnus). Defaults to zero.
+
+    Returns:
+        tuple: Rminus, Sminus, each with shape (Nlayer + 1, Nnus).
+    """
+
+    _, Nnus = trans_coeff.shape
+    if source_top is None:
+        source_top = jnp.zeros(Nnus)
+
+    pihatB = (1.0 - trans_coeff - scat_coeff) * reduced_source_function
+    Rminus_top = jnp.zeros(Nnus)
+    Sminus_top = source_top
+
+    def f(carry_i, arr):
+        Rminus_prev, Sminus_prev = carry_i
+        scat_coeff_i, trans_coeff_i, pihatB_i = arr
+        denom = 1.0 - scat_coeff_i * Rminus_prev
+        Sminus_each = (
+            pihatB_i + trans_coeff_i * (Sminus_prev + pihatB_i * Rminus_prev) / denom
+        )
+        Rminus_each = scat_coeff_i + trans_coeff_i**2 * Rminus_prev / denom
+        RS = [Rminus_each, Sminus_each]
+        return RS, RS
+
+    arrin = [scat_coeff, trans_coeff, pihatB]
+    _, stackedRS = scan(f, [Rminus_top, Sminus_top], arrin)
+    Rminus_layers, Sminus_layers = stackedRS
+
+    Rminus = jnp.vstack([Rminus_top, Rminus_layers])
+    Sminus = jnp.vstack([Sminus_top, Sminus_layers])
+    return Rminus, Sminus
+
+
+def solve_fluxadding_twostream_fluxes(
+    trans_coeff,
+    scat_coeff,
+    reduced_source_function,
+    reflectivity_bottom,
+    source_bottom,
+    source_top=None,
+):
+    """Computes two-stream upward and downward fluxes at all interfaces.
+
+    Args:
+        trans_coeff: Transmission coefficient (Nlayer, Nnus).
+        scat_coeff: Scattering coefficient (Nlayer, Nnus).
+        reduced_source_function: Reduced source function (Nlayer, Nnus).
+        reflectivity_bottom: Bottom boundary reflectivity (Nnus).
+        source_bottom: Bottom boundary source (Nnus).
+        source_top: Top boundary incoming flux (Nnus). Defaults to zero.
+
+    Returns:
+        tuple: flux_plus, flux_minus, each with shape (Nlayer + 1, Nnus).
+    """
+
+    Rplus, Splus = compute_fluxadding_coeffs(
+        trans_coeff,
+        scat_coeff,
+        reduced_source_function,
+        reflectivity_bottom,
+        source_bottom,
+    )
+    Rminus, Sminus = compute_fluxadding_downward_coeffs(
+        trans_coeff, scat_coeff, reduced_source_function, source_top
+    )
+
+    denom = 1.0 - Rplus * Rminus
+    flux_plus = (Rplus * Sminus + Splus) / denom
+    flux_minus = Rminus * flux_plus + Sminus
+    return flux_plus, flux_minus
 
 
 def solve_lart_twostream(diagonal, lower_diagonal, upper_diagonal, vector, flux_bottom):

--- a/tests/unittests/rt/atmrt/emisscat_sfm2st_test.py
+++ b/tests/unittests/rt/atmrt/emisscat_sfm2st_test.py
@@ -1,0 +1,117 @@
+import jax.numpy as jnp
+import pytest
+
+from exojax.rt import ArtEmisPure, ArtEmisScat
+from exojax.rt.planck import piBarr
+from exojax.rt.rtransfer import rtrun_emis_pureabs_ibased
+
+
+def test_artemisscat_sfm2st_reduces_to_pure_absorption_ibased():
+    nlayer = 4
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau = jnp.full((nlayer, len(nu_grid)), 0.1)
+    single_scattering_albedo = jnp.zeros_like(dtau)
+    asymmetric_parameter = jnp.zeros_like(dtau)
+
+    art_pure = ArtEmisPure(nlayer=nlayer, nu_grid=nu_grid, rtsolver="ibased", nstream=8)
+    art_scat = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    expected = art_pure.run(dtau, temperature)
+    actual = art_scat.run(
+        dtau, single_scattering_albedo, asymmetric_parameter, temperature
+    )
+
+    assert actual == pytest.approx(expected)
+
+
+def test_rtrun_emis_scat_sfm2st_reduces_to_pure_absorption_ibased():
+    from exojax.rt.rtransfer import rtrun_emis_scat_sfm2st_toonhm
+
+    nlayer = 4
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau = jnp.full((nlayer, len(nu_grid)), 0.1)
+    single_scattering_albedo = jnp.zeros_like(dtau)
+    asymmetric_parameter = jnp.zeros_like(dtau)
+    art_pure = ArtEmisPure(nlayer=nlayer, nu_grid=nu_grid, rtsolver="ibased", nstream=8)
+    source_matrix = piBarr(temperature, nu_grid)
+
+    expected = rtrun_emis_pureabs_ibased(
+        dtau, source_matrix, art_pure.mus, art_pure.weights
+    )
+    actual = rtrun_emis_scat_sfm2st_toonhm(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        art_pure.mus,
+        art_pure.weights,
+    )
+
+    assert actual == pytest.approx(expected)
+
+
+def test_rtrun_emis_scat_sfm2st_returns_finite_flux_with_scattering():
+    from exojax.rt.rtransfer import rtrun_emis_scat_sfm2st_toonhm
+
+    nlayer = 4
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau = jnp.full((nlayer, len(nu_grid)), 0.1)
+    single_scattering_albedo = jnp.full_like(dtau, 0.5)
+    asymmetric_parameter = jnp.full_like(dtau, 0.1)
+    art_pure = ArtEmisPure(nlayer=nlayer, nu_grid=nu_grid, rtsolver="ibased", nstream=8)
+    source_matrix = piBarr(temperature, nu_grid)
+
+    spectrum = rtrun_emis_scat_sfm2st_toonhm(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        art_pure.mus,
+        art_pure.weights,
+    )
+
+    assert jnp.shape(spectrum) == jnp.shape(nu_grid)
+    assert jnp.all(jnp.isfinite(spectrum))
+    assert jnp.all(spectrum > 0.0)
+
+
+def test_artemisscat_sfm2st_ckd_reduces_to_pure_absorption_ibased_ckd():
+    nlayer = 4
+    ng = 3
+    nbands = 2
+    nu_bands = jnp.array([1000.0, 1005.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau_ckd = jnp.full((nlayer, ng, nbands), 0.1)
+    weights_ckd = jnp.array([0.2, 0.3, 0.5])
+    single_scattering_albedo = jnp.zeros((nlayer, nbands))
+    asymmetric_parameter = jnp.zeros((nlayer, nbands))
+
+    art_pure = ArtEmisPure(
+        nlayer=nlayer, nu_grid=nu_bands, rtsolver="ibased", nstream=8
+    )
+    art_scat = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_bands,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    expected = art_pure.run_ckd(dtau_ckd, temperature, weights_ckd, nu_bands)
+    actual = art_scat.run_ckd(
+        dtau_ckd,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        weights_ckd,
+        nu_bands,
+    )
+
+    assert actual == pytest.approx(expected)


### PR DESCRIPTION
## Summary

  This PR adds SFM-2st support for emission with scattering in `ArtEmisScat` (addresses #719 ).

  SFM-2st uses the source function method (SFM; Toon et al. 1989): it first computes upward and downward fluxes with
  the Toon hemispheric-mean two-stream approximation, then constructs layer source functions and evaluates the
  outgoing spectrum with the intensity-based formal solution.

  ## Changes

  - Added reusable flux-adding helper routines that expose interface fluxes:
    - upward effective reflection/source coefficients
    - downward effective reflection/source coefficients
    - solved interface `flux_plus` and `flux_minus`
  - Added low-level SFM-2st radiative transfer routine:
    - `rtrun_emis_scat_sfm2st_toonhm`
  - Added `ArtEmisScat` API support:
    - `rtsolver="sfm2st_toon_hemispheric_mean"`
    - `nstream` for the final intensity-based angular integration
  - Added CKD support for the SFM-2st path in `ArtEmisScat.run_ckd`
  - Added unit tests for:
    - pure absorption consistency with `ArtEmisPure` when `single_scattering_albedo = 0`
    - low-level pure absorption consistency
    - finite positive scattering output
    - CKD pure absorption consistency
  - Updated user guide documentation for SFM-2st, including the meaning of SFM and the Toon et al. 1989 reference.

  ## Notes

  - `incoming_flux` is not exposed in the public `ArtEmisScat` API.
  - The lower-level two-stream helper accepts a top source boundary internally, leaving room for future reflected-
  light extensions without changing the emission scattering public API.

  ## Tests

  Passed:

  ```bash
  pytest -q tests/unittests/rt/atmrt/emisscat_sfm2st_test.py
  pytest -q tests/unittests/rt/twostream/twostream_test.py tests/unittests/rt/twostream/toon_test.py
  pytest -q tests/unittests/multi/opart/opart_emis_scat_test.py
