### PR TITLE
Add hydrogen direct line opacity support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ CO/
 tests/unittests/H2O/
 tests/unittests/CO/
 src/exojax/data/testdata/CO/*.h5
+
+# Local Codex review and scratch outputs
+implementation_candidates/
+volatiles_codes/
+volatiles_artifacts/

--- a/src/exojax/database/__init__.py
+++ b/src/exojax/database/__init__.py
@@ -24,6 +24,7 @@ _ALIAS: Final[dict[str, str]] = {
     "AdbVald": "exojax.database.vald.api:AdbVald",
     "AdbSepVald": "exojax.database.vald.api:AdbSepVald",
     "AdbKurucz": "exojax.database.kurucz.api:AdbKurucz",
+    "AdbHydrogen": "exojax.database.hydrogen.api:AdbHydrogen",
     "PdbCloud": "exojax.database.pardb:PdbCloud",
     "CdbCIA": "exojax.database.cia.api:CdbCIA",
 }

--- a/src/exojax/database/__init__.pyi
+++ b/src/exojax/database/__init__.pyi
@@ -6,6 +6,7 @@ from exojax.database.hargreaves.api import MdbHargreaves as MdbHargreaves
 from exojax.database.vald.api import AdbVald as AdbVald
 from exojax.database.vald.api import AdbSepVald as AdbSepVald
 from exojax.database.kurucz.api import AdbKurucz as AdbKurucz
+from exojax.database.hydrogen.api import AdbHydrogen as AdbHydrogen
 from exojax.database.exomolhr.api import XdbExomolHR as XdbExomolHR
 from exojax.database.pardb import PdbCloud as PdbCloud
 from exojax.database.cia.api import CdbCIA as CdbCIA

--- a/src/exojax/database/contracts.py
+++ b/src/exojax/database/contracts.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
-from typing import Optional, Literal
+from typing import Any, Optional, Literal, Protocol
 
 import numpy as np
+
+ArrayLike = Any
 
 
 @dataclass(frozen=True)
@@ -45,3 +47,31 @@ class MDBSnapshot:
     n_air: Optional[np.ndarray] = None
     gamma_air: Optional[np.ndarray] = None
 
+
+class DirectLineDatabase(Protocol):
+    """Contract for line databases used by direct Voigt opacity calculators."""
+
+    dbtype: str
+    Tref: float
+
+    nu_lines: ArrayLike
+    logsij0: ArrayLike
+    A: ArrayLike
+    elower: ArrayLike
+    line_masses: ArrayLike
+
+    def generate_jnp_arrays(self) -> None:
+        """Generate JAX arrays."""
+        ...
+
+    def qr_interp_lines(self, T: float, Tref: float) -> ArrayLike:
+        """Interpolate partition-function ratios for selected lines.
+
+        Args:
+            T: Temperature in K.
+            Tref: Reference temperature in K.
+
+        Returns:
+            Partition-function ratios.
+        """
+        ...

--- a/src/exojax/database/core_atom/io.py
+++ b/src/exojax/database/core_atom/io.py
@@ -7,7 +7,8 @@ from io import BytesIO
 import numpy as np
 import pandas as pd
 
-from exojax.utils.constants import ccgs, ecgs, eV2wn, mecgs
+from exojax.database.core_atom.transition import einstein_a_from_loggf
+from exojax.utils.constants import eV2wn
 
 PeriodicTable = np.zeros([119], dtype=object)
 PeriodicTable[:] = [
@@ -380,13 +381,7 @@ def read_kurucz(kuruczf):
     jupper = jupper[::-1]
     glower = jlower * 2 + 1
     gupper = jupper * 2 + 1
-    A = (
-        10**loggf
-        / gupper
-        * (ccgs * nu_lines) ** 2
-        * (8 * np.pi**2 * ecgs**2)
-        / (mecgs * ccgs**3)
-    )
+    A = einstein_a_from_loggf(nu_lines, loggf, gupper)
     gamRad = gamRad[::-1]
     gamSta = gamSta[::-1]
     gamvdW = gamvdW[::-1]
@@ -445,12 +440,8 @@ def pickup_param(ExAll):
     ExAll["gupper"] = ExAll["jupper"] * 2 + 1
     ExAll["glower"] = ExAll["jlower"] * 2 + 1
     # notes4Tako#どうせ比をとるので電子の縮退度等の係数は落ちる.(MyLog2017.rtf)
-    ExAll["A"] = (
-        10 ** ExAll["loggf"]
-        / ExAll["gupper"]
-        * (ccgs * ExAll["nu_lines"]) ** 2
-        * (8 * np.pi**2 * ecgs**2)
-        / (mecgs * ccgs**3)
+    ExAll["A"] = einstein_a_from_loggf(
+        ExAll["nu_lines"], ExAll["loggf"], ExAll["gupper"]
     )
 
     A = ExAll["A"].to_numpy()
@@ -641,5 +632,4 @@ def load_pf_Barklem2016():
     pfTdat = pd.read_csv(io.StringIO(pfT_str), sep="\s+")
     pfdat = pd.read_csv(BytesIO(pffdata), sep="\s+", comment="#", names=pfTdat.columns)
     return pfTdat, pfdat
-
 

--- a/src/exojax/database/core_atom/transition.py
+++ b/src/exojax/database/core_atom/transition.py
@@ -1,0 +1,42 @@
+"""Atomic transition parameter conversions."""
+
+import numpy as np
+
+from exojax.utils.constants import ccgs
+from exojax.utils.constants import ecgs
+from exojax.utils.constants import mecgs
+
+
+def einstein_a_from_loggf(nu_lines, loggf, gupper):
+    """Convert log gf values to Einstein A coefficients.
+
+    Args:
+        nu_lines: Line-center wavenumbers in cm-1.
+        loggf: Log10 of lower-state statistical weight times oscillator strength.
+        gupper: Upper-state statistical weights.
+
+    Returns:
+        Einstein A coefficients in s-1.
+    """
+    return (
+        10**loggf
+        / gupper
+        * (ccgs * nu_lines) ** 2
+        * (8.0 * np.pi**2 * ecgs**2)
+        / (mecgs * ccgs**3)
+    )
+
+
+def einstein_a_from_oscillator_strength(nu_lines, f_lu, glower, gupper):
+    """Convert absorption oscillator strengths to Einstein A coefficients.
+
+    Args:
+        nu_lines: Line-center wavenumbers in cm-1.
+        f_lu: Absorption oscillator strengths.
+        glower: Lower-state statistical weights.
+        gupper: Upper-state statistical weights.
+
+    Returns:
+        Einstein A coefficients in s-1.
+    """
+    return einstein_a_from_loggf(nu_lines, np.log10(glower * f_lu), gupper)

--- a/src/exojax/database/hydrogen/__init__.py
+++ b/src/exojax/database/hydrogen/__init__.py
@@ -1,0 +1,5 @@
+"""Hydrogen atomic database."""
+
+from exojax.database.hydrogen.api import AdbHydrogen
+
+__all__ = ["AdbHydrogen"]

--- a/src/exojax/database/hydrogen/api.py
+++ b/src/exojax/database/hydrogen/api.py
@@ -12,10 +12,10 @@ from exojax.database.core_atom.io import load_pf_Barklem2016
 from exojax.database.core_atom.io import pick_ionE
 from exojax.database.core_atom.line_strength import line_strength_atom
 from exojax.database.core_atom.pf import interp_QT_284
+from exojax.database.core_atom.transition import (
+    einstein_a_from_oscillator_strength,
+)
 from exojax.utils.constants import Tref_original
-from exojax.utils.constants import ccgs
-from exojax.utils.constants import ecgs
-from exojax.utils.constants import mecgs
 
 __all__ = ["AdbHydrogen"]
 
@@ -92,7 +92,7 @@ class AdbHydrogen:
         self._iion = np.ones_like(upper)
 
         f_lu = np.array([_BALMER_F_LU[int(n)] for n in upper])
-        self._A = _einstein_a_from_oscillator_strength(
+        self._A = einstein_a_from_oscillator_strength(
             self.nu_lines,
             f_lu,
             _hydrogen_level_degeneracy(lower),
@@ -263,14 +263,3 @@ def _hydrogen_level_energy_cm(n):
 def _hydrogen_level_degeneracy(n):
     return 2.0 * np.asarray(n, dtype=float) ** 2
 
-
-def _einstein_a_from_oscillator_strength(nu_lines, f_lu, glower, gupper):
-    return (
-        8.0
-        * np.pi**2
-        * ecgs**2
-        * nu_lines**2
-        * glower
-        * f_lu
-        / (mecgs * ccgs * gupper)
-    )

--- a/src/exojax/database/hydrogen/api.py
+++ b/src/exojax/database/hydrogen/api.py
@@ -1,0 +1,276 @@
+"""Hydrogen atomic database."""
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.database.core.line_strength import line_strength
+from exojax.database.core_atom.io import load_atomicdata
+from exojax.database.core_atom.io import load_ionization_energies
+from exojax.database.core_atom.io import load_pf_Barklem2016
+from exojax.database.core_atom.io import pick_ionE
+from exojax.database.core_atom.line_strength import line_strength_atom
+from exojax.database.core_atom.pf import interp_QT_284
+from exojax.utils.constants import Tref_original
+from exojax.utils.constants import ccgs
+from exojax.utils.constants import ecgs
+from exojax.utils.constants import mecgs
+
+__all__ = ["AdbHydrogen"]
+
+_BALMER_F_LU = {
+    3: 0.6407,
+    4: 0.1193,
+    5: 0.0446,
+    6: 0.0221,
+    7: 0.0127,
+    8: 0.00803,
+    9: 0.00543,
+    10: 0.00384,
+}
+
+_HYDROGEN_RYDBERG_CM = 109677.5834
+
+
+class AdbHydrogen:
+    """Atomic database for hydrogen lines."""
+
+    def __init__(
+        self,
+        nurange=(-np.inf, np.inf),
+        margin=0.0,
+        crit=0.0,
+        series="balmer",
+        n_upper_min=3,
+        n_upper_max=10,
+        gpu_transfer=True,
+        vmr_fraction=None,
+    ):
+        """Initialize hydrogen atomic lines.
+
+        Args:
+            nurange: Wavenumber range in cm-1.
+            margin: Margin added to the wavenumber range in cm-1.
+            crit: Reference line-strength lower cutoff.
+            series: Hydrogen series name. Only ``"balmer"`` is supported.
+            n_upper_min: Minimum upper principal quantum number.
+            n_upper_max: Maximum upper principal quantum number.
+            gpu_transfer: If True, create JAX arrays.
+            vmr_fraction: VMR fractions of H, He, and H2.
+        """
+        if series != "balmer":
+            raise NotImplementedError(
+                "AdbHydrogen currently supports only Balmer lines."
+            )
+
+        self.dbtype = "hydrogen"
+        self.series = series
+        self.nurange = [np.min(nurange), np.max(nurange)]
+        self.margin = margin
+        self.crit = crit
+        if vmr_fraction is None:
+            self.vmrH, self.vmrHe, self.vmrHH = [0.0, 0.16, 0.84]
+        else:
+            self.vmrH, self.vmrHe, self.vmrHH = vmr_fraction
+
+        upper = np.arange(n_upper_min, n_upper_max + 1, dtype=int)
+        missing = [n for n in upper if n not in _BALMER_F_LU]
+        if missing:
+            raise ValueError(f"Missing Balmer oscillator strengths for n={missing}.")
+
+        lower = np.full_like(upper, 2)
+        self.n_lower = lower
+        self.n_upper = upper
+        self.nu_lines = _HYDROGEN_RYDBERG_CM * (1.0 / lower**2 - 1.0 / upper**2)
+        self._elower = _hydrogen_level_energy_cm(lower)
+        self._eupper = _hydrogen_level_energy_cm(upper)
+        self._gupper = _hydrogen_level_degeneracy(upper)
+        self._jlower = np.zeros_like(self.nu_lines)
+        self._jupper = np.zeros_like(self.nu_lines)
+        self._ielem = np.ones_like(upper)
+        self._iion = np.ones_like(upper)
+
+        f_lu = np.array([_BALMER_F_LU[int(n)] for n in upper])
+        self._A = _einstein_a_from_oscillator_strength(
+            self.nu_lines,
+            f_lu,
+            _hydrogen_level_degeneracy(lower),
+            self._gupper,
+        )
+        self._gamRad = np.log10(self._A)
+        self._gamSta = np.zeros_like(self.nu_lines)
+        self._vdWdamp = np.full_like(self.nu_lines, -99.0)
+
+        pfTdat, self.pfdat = load_pf_Barklem2016()
+        self.T_gQT = jnp.array(pfTdat.columns[1:], dtype=float)
+        self.gQT_284species = jnp.array(self.pfdat.iloc[:, 1:].to_numpy(dtype=float))
+        self.Tref = Tref_original
+        self.QTref_284 = np.array(
+            interp_QT_284(Tref_original, self.T_gQT, self.gQT_284species)
+        )
+        self._QTmask = self.make_QTmask()
+        self.Sij0 = line_strength_atom(
+            self._A,
+            self._gupper,
+            self.nu_lines,
+            self._elower,
+            self.QTref_284,
+            self._QTmask,
+        )
+
+        mask = (
+            (self.nu_lines > self.nurange[0] - self.margin)
+            * (self.nu_lines < self.nurange[1] + self.margin)
+            * (self.Sij0 > self.crit)
+        )
+        self.masking(mask)
+        if gpu_transfer:
+            self.generate_jnp_arrays()
+
+        ipccd = load_atomicdata()
+        self.solarA = jnp.array(
+            [ipccd[ipccd["ielem"] == 1].iat[0, 4]] * len(self.nu_lines)
+        )
+        self.atomicmass = jnp.array(
+            [ipccd[ipccd["ielem"] == 1].iat[0, 5]] * len(self.nu_lines)
+        )
+        self.line_masses = self.atomicmass
+        df_ionE = load_ionization_energies()
+        self.ionE = jnp.array([pick_ionE(1, 1, df_ionE)] * len(self.nu_lines))
+
+    def make_QTmask(self):
+        """Return the H I partition-function index.
+
+        Returns:
+            Index array for the H I partition function.
+        """
+        qtmask = np.where(self.pfdat["T[K]"] == "H_I")[0][0]
+        return np.full_like(self.nu_lines, qtmask, dtype=int)
+
+    def masking(self, mask):
+        """Apply a line mask.
+
+        Args:
+            mask: Boolean mask for selected lines.
+        """
+        self.n_lower = self.n_lower[mask]
+        self.n_upper = self.n_upper[mask]
+        self.nu_lines = self.nu_lines[mask]
+        self.Sij0 = self.Sij0[mask]
+        self._A = self._A[mask]
+        self._elower = self._elower[mask]
+        self._eupper = self._eupper[mask]
+        self._gupper = self._gupper[mask]
+        self._jlower = self._jlower[mask]
+        self._jupper = self._jupper[mask]
+        self._QTmask = self._QTmask[mask]
+        self._ielem = self._ielem[mask]
+        self._iion = self._iion[mask]
+        self._gamRad = self._gamRad[mask]
+        self._gamSta = self._gamSta[mask]
+        self._vdWdamp = self._vdWdamp[mask]
+        if len(self.nu_lines) < 1:
+            warnings.warn("No hydrogen lines are selected.", UserWarning)
+
+    def generate_jnp_arrays(self):
+        """Generate JAX arrays."""
+        self.dev_nu_lines = jnp.array(self.nu_lines)
+        self.logsij0 = jnp.array(np.log(self.Sij0))
+        self.A = jnp.array(self._A)
+        self.elower = jnp.array(self._elower)
+        self.eupper = jnp.array(self._eupper)
+        self.gupper = jnp.array(self._gupper)
+        self.jlower = jnp.array(self._jlower, dtype=int)
+        self.jupper = jnp.array(self._jupper, dtype=int)
+        self.QTmask = jnp.array(self._QTmask, dtype=int)
+        self.ielem = jnp.array(self._ielem, dtype=int)
+        self.iion = jnp.array(self._iion, dtype=int)
+        self.gamRad = jnp.array(self._gamRad)
+        self.gamSta = jnp.array(self._gamSta)
+        self.vdWdamp = jnp.array(self._vdWdamp)
+
+    def Atomic_gQT(self, atomspecies="H 1"):
+        """Return the H I partition-function grid.
+
+        Args:
+            atomspecies: Atomic species label.
+
+        Returns:
+            Partition-function grid.
+        """
+        if atomspecies != "H 1":
+            raise ValueError("AdbHydrogen contains only H 1.")
+        return self.gQT_284species[np.where(self.pfdat["T[K]"] == "H_I")][0]
+
+    def QT_interp(self, atomspecies, T):
+        """Interpolate the H I partition function.
+
+        Args:
+            atomspecies: Atomic species label.
+            T: Temperature in K.
+
+        Returns:
+            Partition function.
+        """
+        return jnp.interp(T, self.T_gQT, self.Atomic_gQT(atomspecies))
+
+    def qr_interp(self, atomspecies, T):
+        """Interpolate the H I partition-function ratio.
+
+        Args:
+            atomspecies: Atomic species label.
+            T: Temperature in K.
+
+        Returns:
+            Partition-function ratio Q(T)/Q(Tref).
+        """
+        qt = self.QT_interp(atomspecies, T)
+        qtref = self.QTref_284[self.make_QTmask()[0]]
+        return qt / qtref
+
+    def qr_interp_lines(self, T, Tref):
+        """Interpolate H I partition-function ratios for selected lines.
+
+        Args:
+            T: Temperature in K.
+            Tref: Reference temperature in K.
+
+        Returns:
+            Partition-function ratios for each line.
+        """
+        qt = self.QT_interp("H 1", T)
+        qtref = self.QT_interp("H 1", Tref)
+        return jnp.ones_like(self.logsij0) * qt / qtref
+
+    def line_strength(self, T):
+        """Compute line strengths at temperature.
+
+        Args:
+            T: Temperature in K.
+
+        Returns:
+            Line strengths in cm.
+        """
+        qr = self.qr_interp_lines(T, self.Tref)
+        return line_strength(T, self.logsij0, self.nu_lines, self.elower, qr, self.Tref)
+
+
+def _hydrogen_level_energy_cm(n):
+    return _HYDROGEN_RYDBERG_CM * (1.0 - 1.0 / np.asarray(n, dtype=float) ** 2)
+
+
+def _hydrogen_level_degeneracy(n):
+    return 2.0 * np.asarray(n, dtype=float) ** 2
+
+
+def _einstein_a_from_oscillator_strength(nu_lines, f_lu, glower, gupper):
+    return (
+        8.0
+        * np.pi**2
+        * ecgs**2
+        * nu_lines**2
+        * glower
+        * f_lu
+        / (mecgs * ccgs * gupper)
+    )

--- a/src/exojax/opacity/lpf/api.py
+++ b/src/exojax/opacity/lpf/api.py
@@ -138,18 +138,24 @@ class OpaDirect(OpaCalc):
             gammaL = gamma_hitran(
                 P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
             ) + gamma_natural(self.mdb.A)
+            line_masses = self.mdb.molmass
         elif dbtype == "exomol":
             qt = self.mdb.qr_interp(T, Tref_original)
             gammaL = gamma_exomol(
                 P, T, self.mdb.n_Texp, self.mdb.alpha_ref
             ) + gamma_natural(self.mdb.A)
+            line_masses = self.mdb.molmass
+        elif dbtype == "hydrogen":
+            qt = self.mdb.qr_interp_lines(T, Tref_original)
+            gammaL = gamma_natural(self.mdb.A)
+            line_masses = self.mdb.line_masses
         else:
             raise ValueError(
                 f"Unsupported database type for xsvector: '{dbtype}'. "
-                "Supported types: hitran, exomol"
+                "Supported types: hitran, exomol, hydrogen"
             )
 
-        sigmaD = doppler_sigma(self.mdb.nu_lines, T, self.mdb.molmass)
+        sigmaD = doppler_sigma(self.mdb.nu_lines, T, line_masses)
         Sij = line_strength(
             T, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower, qt, Tref_original
         )
@@ -219,6 +225,22 @@ class OpaDirect(OpaCalc):
             sigmaDM = self._vmap_doppler_sigma(
                 self.mdb.nu_lines, Tarr, self.mdb.molmass
             )
+        elif dbtype == "hydrogen":
+            qt = vmap(self.mdb.qr_interp_lines, (0, None))(Tarr, Tref_original)
+            gammaLM = gamma_natural(self.mdb.A)[None, :] + jnp.zeros(
+                (len(Tarr), 1)
+            )
+            SijM = self._vmap_line_strength(
+                Tarr,
+                self.mdb.logsij0,
+                self.mdb.nu_lines,
+                self.mdb.elower,
+                qt,
+                Tref_original,
+            )
+            sigmaDM = self._vmap_doppler_sigma(
+                self.mdb.nu_lines, Tarr, self.mdb.line_masses
+            )
         elif dbtype in ("kurucz", "vald"):
             qt_284 = vmap(interp_QT_284, (0, None, None))(
                 Tarr, self.mdb.T_gQT, self.mdb.gQT_284species
@@ -283,7 +305,7 @@ class OpaDirect(OpaCalc):
         else:
             raise ValueError(
                 f"Unsupported database type for xsmatrix: '{dbtype}'. "
-                "Supported types: hitran, exomol, kurucz, vald"
+                "Supported types: hitran, exomol, hydrogen, kurucz, vald"
             )
 
         return xsmatrix_lpf(numatrix, sigmaDM, gammaLM, SijM)


### PR DESCRIPTION
## Summary

  This PR adds the first minimal support for hydrogen atomic line opacity in ExoJAX.

  It implements the first milestone of Issue #722:

  1. AdbHydrogen / AtomicLineDatabase API

  The scope is intentionally limited to the database/API foundation and natural+Doppler Voigt opacity through
  `OpaDirect`. Stark profiles, profile backend refactoring, and layer-wise velocity fields are left for follow-up PRs.

  ## Changes

  - Add `DirectLineDatabase` protocol for direct line opacity calculators.
  - Add `AdbHydrogen` as a minimal hydrogen Balmer line database.
  - Generate Balmer line centers from the Rydberg formula.
  - Provide hydrogen line strengths, Einstein A coefficients, lower-state energies, and line masses.
  - Add `qr_interp_lines(T, Tref)` for H I partition-function ratio handling.
  - Enable `OpaDirect` to compute hydrogen opacity with Doppler + natural Voigt profiles.
  - Export the hydrogen database API from `exojax.database`.
  - Ignore local scratch directories used during implementation.

  ## Scope

  Implemented:

  - Hydrogen Balmer line database
  - Atomic/direct-line database contract
  - `OpaDirect` hydrogen branch
  - Natural + Doppler Voigt opacity for hydrogen lines

  Not implemented in this PR:

  - `OpaDirect` profile backend refactoring
  - Stark broadening/template profiles
  - Layer-wise radial velocity field
  - Barklem/Piskunov/O'Mara H-H self-broadening
  - VALD/Kurucz Adb refactoring

  ## Design Notes

  This PR keeps the implementation deliberately small. `AdbHydrogen` is introduced as a clean reference implementation
  for a future atomic line database API, without touching the existing VALD/Kurucz pathways.

  The intended longer-term direction is:

  1. `AdbHydrogen` / `AtomicLineDatabase` API
  2. `OpaDirect` profile backend refactoring
  3. Hydrogen Stark profile support
  4. Layer-wise radial velocity shifts

  `OpaDirect` remains the appropriate opacity calculator for hydrogen Balmer lines because the target use case involves
  a small number of atomic lines.

  ## Verification

  - Ran Python compile checks for the modified modules.
  - Ran a smoke test using `AdbHydrogen` with `OpaDirect`.
  - Confirmed finite `xsvector` and `xsmatrix` outputs.


  python -m py_compile \
  src/exojax/database/contracts.py \
  src/exojax/database/hydrogen/api.py \
  src/exojax/opacity/lpf/api.py


  Smoke-tested:

  - `xsvector` shape: `(200,)`
  - `xsmatrix` shape: `(2, 200)`
  - outputs finite
