### PR TITLE
Warn for insufficient instrumental profile vrmax (check_vrmax)

### DIFF
--- a/documents/userguide/sop.rst
+++ b/documents/userguide/sop.rst
@@ -7,7 +7,7 @@ In the post-radiative transfer, the observed spectrum differs from the raw spect
 For instance, it might experience rotational broadening due to the planet's rotation, wavelength shifts 
 due to differences in line-of-sight velocities, or the influence of the instrument's profile (IP). 
 In ExoJAX, these responses to the spectrum are termed the "Spectral Operator" (``sop``). 
-Within the ``spec.specop`` module, classes like ``SopRotation`` and ``SopInstProfile`` allow for the easy handling of these responses.
+Within the ``postproc.specop`` module, classes like ``SopRotation`` and ``SopInstProfile`` allow for the easy handling of these responses.
 
 
 SopRotation
@@ -29,6 +29,48 @@ See
 :doc:`../tutorials/get_started`
 again for example.
 
+Velocity range for a Gaussian instrumental profile
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The instrumental resolving power is supplied through the Gaussian standard
+deviation passed to ``ipgauss``; it is not inferred from the bin spacing of
+``nu_grid``. For an instrumental resolving power :math:`R_\mathrm{inst}`,
+
+.. math::
+
+    \beta_\mathrm{inst}
+    = \frac{c}{2\sqrt{2\ln 2}\,R_\mathrm{inst}},
+
+where :math:`\beta_\mathrm{inst}` is in km/s. The velocity range should cover
+at least five Gaussian standard deviations:
+
+.. math::
+
+    \mathtt{vrmax} \geq 5\beta_\mathrm{inst}.
+
+``SopInstProfile.check_vrmax`` performs this check explicitly and emits a
+``UserWarning`` if the configured range is too small. ``ipgauss`` also calls
+this check automatically.
+
+For repeated JIT-compiled calculations such as NumPyro NUTS, determine
+``vrmax`` and create ``SopInstProfile`` before starting the inference. This
+keeps the velocity-grid shape fixed throughout the calculation.
+
+.. code:: python
+
+    from exojax.postproc.specop import SopInstProfile
+    from exojax.utils.instfunc import resolution_to_gaussian_std
+
+    Rinst = 3000.0
+    beta_inst = resolution_to_gaussian_std(Rinst)
+    vrmax_inst = 5.0 * beta_inst
+
+    sop_inst = SopInstProfile(nu_grid, vrmax=vrmax_inst)
+    sop_inst.check_vrmax(beta_inst)
+
+    # This call repeats the same check before applying the convolution.
+    spectrum_inst = sop_inst.ipgauss(spectrum, beta_inst)
+
 
 Convolution methods available in sop
 ---------------------------------------
@@ -43,7 +85,6 @@ which divides the input into a suitable number of parts and performs FFT on each
 Try the following option during the initialization of ``sop``:
 
 - ``convolution_method = "exojax.signal.ola"`` : Overlap-and-Add convolution, One can change the number of the division by ``sop.ola_ndiv`` (default=4).
-
 
 
 

--- a/src/exojax/postproc/specop.py
+++ b/src/exojax/postproc/specop.py
@@ -8,6 +8,7 @@
 """
 
 import pathlib
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -273,6 +274,48 @@ class SopInstProfile(SopCommonConv):
     ):
         super().__init__(nu_grid, vrmax, convolution_method)
 
+    def check_vrmax(self, standard_deviation):
+        """Check vrmax for a Gaussian instrumental profile.
+
+        The instrumental resolution is represented by standard_deviation;
+        the model wavenumber grid is intentionally not used in this check.
+        This method is intended for an explicit check before JIT compilation
+        and is also called automatically by ipgauss.
+
+        Args:
+            standard_deviation (float): standard deviation of the Gaussian
+                instrumental profile in km/s
+
+        Warns:
+            UserWarning: if vrmax covers fewer than five standard deviations
+        """
+        try:
+            standard_deviation = float(standard_deviation)
+        except (TypeError, ValueError):
+            # A traced value cannot be checked without a runtime callback.
+            return
+
+        if not np.isfinite(standard_deviation) or standard_deviation <= 0.0:
+            return
+
+        required_nsigma = 5.0
+        required_velocity_span = required_nsigma * standard_deviation
+        if self.vrmax < required_velocity_span:
+            covered_nsigma = self.vrmax / standard_deviation
+            warnings.warn(
+                "`vrmax` for the Gaussian instrumental profile is too small: "
+                f"vrmax={self.vrmax:.3g} km/s covers "
+                f"{covered_nsigma:.3g} Gaussian standard deviations for "
+                f"standard_deviation={standard_deviation:.3g} km/s. "
+                f"Use `vrmax >= {required_velocity_span:.3g} km/s` when "
+                "constructing `SopInstProfile` to cover at least "
+                f"{required_nsigma:g} standard deviations. "
+                "For a variable standard deviation, set `vrmax` "
+                "from its maximum expected value before JIT compilation.",
+                UserWarning,
+                stacklevel=2,
+            )
+
     def ipgauss(self, spectrum, standard_deviation):
         """Gaussian Instrumental Profile
 
@@ -286,6 +329,7 @@ class SopInstProfile(SopCommonConv):
         Returns:
             array: IP applied spectrum
         """
+        self.check_vrmax(standard_deviation)
         if (
             self.convolution_method == self.convolution_method_list[0]
         ):  # "exojax.signal.convolve"

--- a/tests/unittests/postproc/response/response_test.py
+++ b/tests/unittests/postproc/response/response_test.py
@@ -1,4 +1,7 @@
+import warnings
+
 import numpy as np
+import pytest
 import jax.numpy as jnp
 from jax import jit
 from exojax.utils.grids import wavenumber_grid
@@ -125,6 +128,53 @@ def test_SopInstProfile():
     assert res < 1.e-4 #0.1% allowed
 
 
+def test_SopInstProfile_warns_from_vrmax_independent_of_nu_grid():
+    from exojax.postproc.specop import SopInstProfile
+
+    nu_grid = np.geomspace(4000.0, 8000.0, 100)
+    spectrum = np.ones_like(nu_grid)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        sop_inst = SopInstProfile(nu_grid, vrmax=10.0)
+
+    assert np.max(np.abs(np.asarray(sop_inst.vrarray))) > 5.0 * 3.0
+    with pytest.warns(UserWarning, match="`vrmax`.*too small"):
+        sop_inst.check_vrmax(standard_deviation=3.0)
+    with pytest.warns(UserWarning, match="`vrmax`.*too small"):
+        sop_inst.ipgauss(spectrum, standard_deviation=3.0)
+
+
+def test_SopInstProfile_does_not_warn_for_sufficient_vrmax():
+    from exojax.postproc.specop import SopInstProfile
+
+    nu_grid = np.geomspace(4000.0, 4000.4, 100)
+    spectrum = np.ones_like(nu_grid)
+    sop_inst = SopInstProfile(nu_grid, vrmax=10.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        sop_inst.ipgauss(spectrum, standard_deviation=2.0)
+
+
+def test_SopInstProfile_accepts_traced_standard_deviation():
+    from exojax.postproc.specop import SopInstProfile
+
+    nu_grid = np.geomspace(4000.0, 4000.4, 100)
+    spectrum = np.ones_like(nu_grid)
+    sop_inst = SopInstProfile(nu_grid, vrmax=10.0)
+    apply_ipgauss = jit(
+        lambda standard_deviation: sop_inst.ipgauss(
+            spectrum, standard_deviation
+        )
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = apply_ipgauss(3.0)
+
+    assert result.shape == spectrum.shape
+
+
 def test_ipgauss_variable_sampling_using_constant_beta_array(fig=False):
     nus, wav, resolution = wavenumber_grid(4000.0,
                                                4010.0,
@@ -193,4 +243,3 @@ if __name__ == "__main__":
     #test_SopInstProfile()
     #test_ipgauss_ola_sampling(fig=True)
     test_SopInstProfile_ola(fig=True)
-    


### PR DESCRIPTION
## Summary

- add `SopInstProfile.check_vrmax` to validate the velocity range used
by a Gaus
sian instrumental profile
- warn automatically from `SopInstProfile.ipgauss` when `vrmax` covers
fewer tha
n five Gaussian standard deviations
- keep the check independent of the bin spacing of `nu_grid`
- document how to choose a fixed `vrmax` before JIT-compiled NumPyro
NUTS calcul
ations

## Motivation

For low instrumental resolving power, the Gaussian standard deviation
can become
  comparable to or larger than the configured `vrmax`. The kernel is
then silentl
y truncated by the fixed velocity range and renormalized, producing a
narrower i
nstrumental profile than requested.

The new check uses

\[
\mathrm{vrmax} \geq 5\beta_\mathrm{inst},
\qquad
\beta_\mathrm{inst}
= \frac{c}{2\sqrt{2\ln 2}\,R_\mathrm{inst}}.
\]

The model-grid resolution is intentionally not used in this truncation
check. Sa
mpling adequacy is a separate concern.

## Usage

```python
from exojax.postproc.specop import SopInstProfile
from exojax.utils.instfunc import resolution_to_gaussian_std

Rinst = 3000.0
beta_inst = resolution_to_gaussian_std(Rinst)

# Fix the velocity-grid shape before JIT/NUTS compilation.
vrmax_inst = 5.0 * beta_inst
sop_inst = SopInstProfile(nu_grid, vrmax=vrmax_inst)

# Optional explicit preflight check. ipgauss also performs this check.
sop_inst.check_vrmax(beta_inst)
spectrum_inst = sop_inst.ipgauss(spectrum, beta_inst)
```

For the usual case where `Rinst` is fixed outside a NumPyro model, this
keeps th
e velocity-grid shape constant and does not introduce recompilation
during NUTS.
  Traced standard deviations are skipped to avoid runtime host callbacks.

## Validation

- `pytest -q tests/unittests/postproc/response`: 20 passed
- `ruff check src/exojax/postproc/specop.py
tests/unittests/postproc/response/re
sponse_test.py`
- `git diff --check`

Closes #725.