### PR TITLE
feat(opacity): add Diffgrid archive I/O

### DIFF
--- a/src/exojax/opacity/diffgrid/api.py
+++ b/src/exojax/opacity/diffgrid/api.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from exojax.opacity.base import OpaCalc
+from exojax.opacity.diffgrid.contracts import DiffgridInfo
 from exojax.opacity.diffgrid.core import cross_section_matrix
 from exojax.opacity.diffgrid.precompute import build_diffgrid_info
 
@@ -24,6 +25,8 @@ class OpaDiffgrid(OpaCalc):
         method: Always ``"diffgrid"`` for this calculator.
         teacher_method: Method name of the calculator used to build the table.
         diffgrid_info: Immutable table values and coordinates.
+        aux: User-specified auxiliary metadata restored from a saved archive.
+        user_meta: User provenance metadata restored from a saved archive.
     """
 
     def __init__(
@@ -65,26 +68,207 @@ class OpaDiffgrid(OpaCalc):
         super().__init__(base_opa.nu_grid)
         self.method = "diffgrid"
         self.teacher_method = getattr(base_opa, "method", None)
+        self.aux = {}
+        self.user_meta = {}
 
         for attribute in ("wavelength_order", "wav", "resolution", "molmass"):
             if hasattr(base_opa, attribute):
                 setattr(self, attribute, getattr(base_opa, attribute))
 
-        self.diffgrid_info = build_diffgrid_info(
+        diffgrid_info = build_diffgrid_info(
             base_opa,
             temperature_grid,
             pressure_grid,
             min_cross_section=min_cross_section,
         )
-        self.opainfo = self.diffgrid_info
-        self.pressure_grid = self.diffgrid_info.pressure_grid
-        self.temperature_grid = self.diffgrid_info.temperature_grid
-        self.inverse_temperature_grid = (
-            self.diffgrid_info.inverse_temperature_grid
+        self._apply_diffgrid_info(diffgrid_info)
+        self.ready = True
+
+    @classmethod
+    def from_saved_opa(
+        cls,
+        path: str,
+        *,
+        strict: bool = True,
+        allow_downgrade: bool = False,
+    ) -> "OpaDiffgrid":
+        """Restore a diffgrid calculator without its teacher or line database.
+
+        Args:
+            path: NPZ or Zarr diffgrid archive path.
+            strict: Require the current ExoJAX version and exact dtypes for the
+                device-resident Diffgrid table state. Set to ``False`` to
+                permit compatible dtype conversion.
+            allow_downgrade: Permit loading a different common opacity archive
+                schema version. The Diffgrid-specific schema must still match.
+
+        Returns:
+            A ready-to-use pressure-aligned diffgrid calculator.
+        """
+        from exojax.opacity.diffgrid.io import load_diffgrid_payload
+
+        arrays, meta = load_diffgrid_payload(
+            path,
+            strict=strict,
+            allow_downgrade=allow_downgrade,
         )
-        self.log_cross_section_grid = self.diffgrid_info.log_cross_section_grid
+        obj = cls.__new__(cls)
+        obj._init_from_saved_payload(arrays, meta, strict=strict)
+        return obj
+
+    def _init_from_saved_payload(self, arrays, meta, *, strict: bool) -> None:
+        """Rebuild calculator state from a validated archive payload."""
+        nu_grid = np.asarray(arrays["nu_grid"]).copy()
+        self._validate_active_nu_grid(nu_grid)
+        OpaCalc.__init__(self, nu_grid)
+        self.method = "diffgrid"
+
+        state = meta["opa_state"]
+        self.teacher_method = state.get("teacher_method")
+        optional_attributes = state.get("optional_attributes", {})
+        for attribute in ("wavelength_order", "resolution", "molmass"):
+            if attribute in optional_attributes:
+                setattr(self, attribute, optional_attributes[attribute])
+        if "wav" in arrays:
+            self.wav = np.asarray(arrays["wav"]).copy()
+
+        self.aux = dict(meta.get("aux", {}))
+        self.user_meta = dict(meta.get("user_meta", {}))
+
+        field_names = (
+            "pressure_grid",
+            "temperature_grid",
+            "inverse_temperature_grid",
+            "log_cross_section_grid",
+            "log_cross_section_derivative_grid",
+            "log_cross_section_floor",
+        )
+        converted = {
+            name: self._as_active_jax_array(name, arrays[name], strict)
+            for name in field_names
+        }
+        self._validate_active_saved_arrays(converted)
+        diffgrid_info = DiffgridInfo(**converted)
+        self._apply_diffgrid_info(diffgrid_info)
+        self.ready = True
+
+    @staticmethod
+    def _as_active_jax_array(name, values, strict: bool) -> jnp.ndarray:
+        """Convert a saved array while enforcing the strict dtype policy."""
+        host_array = np.asarray(values)
+        active_array = jnp.asarray(host_array)
+        if strict and np.dtype(active_array.dtype) != host_array.dtype:
+            raise ValueError(
+                f"Saved diffgrid array '{name}' has dtype {host_array.dtype}, "
+                f"but active JAX converts it to {active_array.dtype}. Enable "
+                "matching JAX precision or pass strict=False to allow a "
+                "compatible conversion."
+            )
+        return active_array
+
+    @staticmethod
+    def _validate_active_nu_grid(nu_grid: np.ndarray) -> None:
+        """Ensure the spectral coordinate survives active JAX conversion."""
+        active_nu_grid = np.asarray(jnp.asarray(nu_grid))
+        if not np.all(np.isfinite(active_nu_grid)) or np.any(
+            active_nu_grid <= 0.0
+        ):
+            raise ValueError(
+                "nu_grid must remain finite and positive in the active JAX "
+                "dtype."
+            )
+        if np.unique(active_nu_grid).size != active_nu_grid.size:
+            raise ValueError(
+                "nu_grid values must remain distinct in the active JAX dtype."
+            )
+
+    @staticmethod
+    def _validate_active_saved_arrays(arrays) -> None:
+        """Check invariants again after conversion to the active JAX dtype."""
+        active = {name: np.asarray(value) for name, value in arrays.items()}
+        pressure_grid = active["pressure_grid"]
+        temperature_grid = active["temperature_grid"]
+        inverse_temperature_grid = active["inverse_temperature_grid"]
+        value_grid = active["log_cross_section_grid"]
+        derivative_grid = active["log_cross_section_derivative_grid"]
+        log_floor = active["log_cross_section_floor"]
+
+        for name, coordinate in (
+            ("pressure_grid", pressure_grid),
+            ("temperature_grid", temperature_grid),
+            ("inverse_temperature_grid", inverse_temperature_grid),
+        ):
+            if not np.all(np.isfinite(coordinate)) or np.any(coordinate <= 0.0):
+                raise ValueError(
+                    f"{name} must remain finite and positive in the active "
+                    "JAX dtype."
+                )
+        if np.any(np.diff(inverse_temperature_grid) <= 0.0):
+            raise ValueError(
+                "inverse_temperature_grid must remain strictly increasing in "
+                "the active JAX dtype."
+            )
+        if np.any(np.diff(temperature_grid) >= 0.0):
+            raise ValueError(
+                "temperature_grid nodes must remain distinct and strictly "
+                "decreasing in the active JAX dtype."
+            )
+
+        expected_inverse_temperature = 1.0 / temperature_grid
+        coordinate_epsilons = [
+            np.finfo(coordinate.dtype).eps
+            for coordinate in (temperature_grid, inverse_temperature_grid)
+            if np.issubdtype(coordinate.dtype, np.floating)
+        ]
+        tolerance = 8.0 * max(
+            coordinate_epsilons,
+            default=np.finfo(np.float64).eps,
+        )
+        if not np.allclose(
+            inverse_temperature_grid,
+            expected_inverse_temperature,
+            rtol=tolerance,
+            atol=0.0,
+        ):
+            raise ValueError(
+                "temperature_grid and inverse_temperature_grid become "
+                "inconsistent in the active JAX dtype."
+            )
+
+        if not np.all(np.isfinite(value_grid)) or not np.all(
+            np.isfinite(derivative_grid)
+        ):
+            raise ValueError(
+                "Diffgrid table values must remain finite in the active JAX "
+                "dtype."
+            )
+        if not np.isfinite(log_floor).item():
+            raise ValueError(
+                "log_cross_section_floor must remain finite in the active JAX "
+                "dtype."
+            )
+        table_dtype = value_grid.dtype
+        if log_floor.item() < np.log(np.finfo(table_dtype).tiny):
+            raise ValueError(
+                "The saved cross-section floor is below the smallest normal "
+                "value in the active JAX dtype."
+            )
+        if log_floor.item() > np.log(np.finfo(table_dtype).max):
+            raise ValueError(
+                "The saved cross-section floor exceeds the largest finite "
+                "value in the active JAX dtype."
+            )
+
+    def _apply_diffgrid_info(self, diffgrid_info: DiffgridInfo) -> None:
+        """Attach a validated diffgrid table and rebuild host-side caches."""
+        self.diffgrid_info = diffgrid_info
+        self.opainfo = diffgrid_info
+        self.pressure_grid = diffgrid_info.pressure_grid
+        self.temperature_grid = diffgrid_info.temperature_grid
+        self.inverse_temperature_grid = diffgrid_info.inverse_temperature_grid
+        self.log_cross_section_grid = diffgrid_info.log_cross_section_grid
         self.log_cross_section_derivative_grid = (
-            self.diffgrid_info.log_cross_section_derivative_grid
+            diffgrid_info.log_cross_section_derivative_grid
         )
         self._pressure_grid_host = np.asarray(self.pressure_grid).copy()
         self._inverse_temperature_grid_host = np.asarray(
@@ -95,7 +279,6 @@ class OpaDiffgrid(OpaCalc):
             float(np.min(temperature_grid_host)),
             float(np.max(temperature_grid_host)),
         )
-        self.ready = True
 
     @staticmethod
     def _validate_teacher(base_opa) -> None:

--- a/src/exojax/opacity/diffgrid/io.py
+++ b/src/exojax/opacity/diffgrid/io.py
@@ -1,0 +1,595 @@
+"""Persistence helpers for pressure-layer aligned Diffgrid tables.
+
+The ``diffgrid@1`` format stores the arrays in ``REQUIRED_DIFFGRID_ARRAYS``
+plus optional ``wav``. NPZ artifacts use a sibling ``*_metadata.json`` file;
+Zarr artifacts store the same metadata as group attributes. Metadata declares
+every array's shape, dtype, and SHA-256 digest, where the digest covers the
+C-order bytes followed by the dtype and shape strings.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Literal, Tuple, TYPE_CHECKING
+
+import jax
+import jaxlib
+import numpy as np
+
+from exojax import __version__
+from exojax.opacity.io.serialization import SCHEMA_OPA_VERSION
+from exojax.opacity.io.serialization import _ensure_compatible_versions
+from exojax.opacity.io.serialization import _load
+from exojax.opacity.io.serialization import _load_from_npz
+from exojax.opacity.io.serialization import _load_from_zarr
+from exojax.opacity.io.serialization import _sha256_array
+from exojax.opacity.io.serialization import _validate_schema
+
+if TYPE_CHECKING:
+    from exojax.opacity.diffgrid.api import OpaDiffgrid
+
+
+DIFFGRID_SCHEMA_VERSION = "diffgrid@1"
+
+REQUIRED_DIFFGRID_ARRAYS = (
+    "nu_grid",
+    "pressure_grid",
+    "temperature_grid",
+    "inverse_temperature_grid",
+    "log_cross_section_grid",
+    "log_cross_section_derivative_grid",
+    "log_cross_section_floor",
+)
+
+_OPTIONAL_SCALAR_ATTRIBUTES = (
+    "wavelength_order",
+    "resolution",
+    "molmass",
+)
+
+_UNITS = {
+    "wavenumber": "cm^-1",
+    "pressure": "bar",
+    "temperature": "K",
+    "inverse_temperature": "K^-1",
+    "cross_section": "cm^2",
+    "log_cross_section_derivative": "K",
+}
+
+
+def _normalize_json_value(value: Any) -> Any:
+    """Convert a value to JSON-compatible Python primitives."""
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_normalize_json_value(item) for item in value]
+    if isinstance(value, np.ndarray) or isinstance(value, jax.Array):
+        return _normalize_json_value(np.asarray(value).tolist())
+    if isinstance(value, np.generic):
+        return _normalize_json_value(value.item())
+    if isinstance(value, (str, bool)) or value is None:
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TypeError("JSON metadata numbers must be finite.")
+        return value
+    raise TypeError(
+        "Metadata contains unsupported type "
+        f"{type(value).__name__}. Only JSON-serializable primitives, lists, "
+        "dicts, and NumPy or JAX scalars/arrays are allowed."
+    )
+
+
+def _normalize_json_mapping(name: str, value: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalize a metadata mapping and provide a focused type error."""
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping.")
+    return {str(key): _normalize_json_value(item) for key, item in value.items()}
+
+
+def _diffgrid_arrays(opa: OpaDiffgrid) -> Dict[str, np.ndarray]:
+    """Collect the self-contained Diffgrid payload from an initialized object."""
+    info = opa.diffgrid_info
+    arrays = {
+        "nu_grid": np.asarray(opa.nu_grid),
+        "pressure_grid": np.asarray(info.pressure_grid),
+        "temperature_grid": np.asarray(info.temperature_grid),
+        "inverse_temperature_grid": np.asarray(info.inverse_temperature_grid),
+        "log_cross_section_grid": np.asarray(info.log_cross_section_grid),
+        "log_cross_section_derivative_grid": np.asarray(
+            info.log_cross_section_derivative_grid
+        ),
+        "log_cross_section_floor": np.asarray(info.log_cross_section_floor),
+    }
+    if hasattr(opa, "wav"):
+        arrays["wav"] = np.asarray(opa.wav)
+    return arrays
+
+
+def _diffgrid_metadata(
+    opa: OpaDiffgrid,
+    arrays: Dict[str, np.ndarray],
+    extra_meta: Mapping[str, Any] | None,
+    aux: Mapping[str, Any] | None,
+) -> Dict[str, Any]:
+    """Build portable metadata for a Diffgrid archive."""
+    optional_attributes = {}
+    for attribute in _OPTIONAL_SCALAR_ATTRIBUTES:
+        if hasattr(opa, attribute):
+            optional_attributes[attribute] = _normalize_json_value(
+                getattr(opa, attribute)
+            )
+
+    meta: Dict[str, Any] = {
+        "schema_version": SCHEMA_OPA_VERSION,
+        "diffgrid_schema_version": DIFFGRID_SCHEMA_VERSION,
+        "opa_type": "OpaDiffgrid",
+        "exojax_version": __version__,
+        "jax_version": jax.__version__,
+        "jaxlib_version": jaxlib.__version__,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "units": dict(_UNITS),
+        "array_shapes": {
+            name: list(array.shape) for name, array in arrays.items()
+        },
+        "array_dtypes": {
+            name: str(array.dtype) for name, array in arrays.items()
+        },
+        "array_digests": {
+            name: _sha256_array(array) for name, array in arrays.items()
+        },
+        "opa_state": {
+            "teacher_method": _normalize_json_value(
+                getattr(opa, "teacher_method", None)
+            ),
+            "optional_attributes": optional_attributes,
+        },
+    }
+    if extra_meta is not None:
+        meta["user_meta"] = _normalize_json_mapping("extra_meta", extra_meta)
+    if aux is not None:
+        meta["aux"] = _normalize_json_mapping("aux", aux)
+    return meta
+
+
+def _npz_paths(path: str) -> Tuple[Path, Path]:
+    """Resolve the NPZ payload and sidecar metadata paths."""
+    path_string = str(path)
+    npz_path = Path(path_string if path_string.endswith(".npz") else path_string + ".npz")
+    metadata_path = npz_path.with_name(npz_path.stem + "_metadata.json")
+    return npz_path, metadata_path
+
+
+def _save_as_npz(
+    path: str, arrays: Dict[str, np.ndarray], meta: Dict[str, Any]
+) -> None:
+    """Write a compressed NPZ payload and its JSON metadata sidecar."""
+    npz_path, metadata_path = _npz_paths(path)
+    np.savez_compressed(npz_path, **arrays)
+    with metadata_path.open("w", encoding="utf-8") as stream:
+        json.dump(meta, stream, indent=4, sort_keys=True, allow_nan=False)
+
+
+def _save_as_zarr(
+    path: str, arrays: Dict[str, np.ndarray], meta: Dict[str, Any]
+) -> None:
+    """Write a Zarr v2 or v3 Diffgrid archive."""
+    import zarr
+
+    try:
+        major_version = int(zarr.__version__.split(".")[0])
+    except (AttributeError, TypeError, ValueError):
+        major_version = 2
+
+    path_string = str(path)
+    zarr_path = path_string if path_string.endswith(".zarr") else path_string + ".zarr"
+    group = zarr.open(zarr_path, mode="w")
+    if major_version >= 3:
+        from zarr import codecs
+
+        compressor = codecs.GzipCodec(level=1)
+        for name, array in arrays.items():
+            dataset = group.create_array(
+                name,
+                shape=array.shape,
+                dtype=array.dtype,
+                compressors=[compressor],
+            )
+            dataset[...] = array
+    else:
+        compressor = zarr.get_codec({"id": "zlib", "level": 1})
+        for name, array in arrays.items():
+            group.create_dataset(name, data=array, compressor=compressor)
+
+    group.attrs.update(meta)
+    close_group = getattr(group, "close", None)
+    if callable(close_group):
+        close_group()
+    else:
+        close_store = getattr(getattr(group, "store", None), "close", None)
+        if callable(close_store):
+            close_store()
+
+
+def _is_real_numeric(array: np.ndarray) -> bool:
+    """Return whether an array uses a non-boolean real numeric dtype."""
+    return np.issubdtype(array.dtype, np.integer) or np.issubdtype(
+        array.dtype, np.floating
+    )
+
+
+def _validate_coordinate(
+    name: str, array: np.ndarray, *, minimum_size: int
+) -> None:
+    """Validate a positive, finite, one-dimensional coordinate array."""
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if array.size < minimum_size:
+        raise ValueError(f"{name} must contain at least {minimum_size} values.")
+    if not _is_real_numeric(array):
+        raise ValueError(f"{name} must use a real numeric dtype.")
+    if not np.all(np.isfinite(array)) or np.any(array <= 0.0):
+        raise ValueError(f"{name} values must be finite and positive.")
+
+
+def _coordinate_rtol(*arrays: np.ndarray) -> float:
+    """Choose a reciprocal-coordinate tolerance from the stored dtypes."""
+    epsilons = [
+        float(np.finfo(array.dtype).eps)
+        for array in arrays
+        if np.issubdtype(array.dtype, np.floating)
+    ]
+    return 8.0 * max(epsilons, default=np.finfo(np.float64).eps)
+
+
+def _validate_array_values(arrays: Dict[str, np.ndarray]) -> None:
+    """Validate Diffgrid arrays without converting them to active JAX dtypes."""
+    missing = [name for name in REQUIRED_DIFFGRID_ARRAYS if name not in arrays]
+    if missing:
+        raise KeyError(f"Missing required Diffgrid arrays: {', '.join(missing)}")
+
+    for name in tuple(arrays):
+        arrays[name] = np.asarray(arrays[name])
+
+    nu_grid = arrays["nu_grid"]
+    pressure_grid = arrays["pressure_grid"]
+    temperature_grid = arrays["temperature_grid"]
+    inverse_temperature_grid = arrays["inverse_temperature_grid"]
+    log_cross_section_grid = arrays["log_cross_section_grid"]
+    derivative_grid = arrays["log_cross_section_derivative_grid"]
+    log_cross_section_floor = arrays["log_cross_section_floor"]
+
+    _validate_coordinate("nu_grid", nu_grid, minimum_size=1)
+    _validate_coordinate("pressure_grid", pressure_grid, minimum_size=1)
+    _validate_coordinate("temperature_grid", temperature_grid, minimum_size=2)
+    _validate_coordinate(
+        "inverse_temperature_grid", inverse_temperature_grid, minimum_size=2
+    )
+    if np.unique(nu_grid).size != nu_grid.size:
+        raise ValueError("nu_grid values must be distinct.")
+
+    comparison_dtype = np.result_type(
+        temperature_grid.dtype, inverse_temperature_grid.dtype, np.float64
+    )
+    temperature_for_comparison = temperature_grid.astype(
+        comparison_dtype, copy=False
+    )
+    inverse_for_comparison = inverse_temperature_grid.astype(
+        comparison_dtype, copy=False
+    )
+    if np.any(np.diff(inverse_for_comparison) <= 0.0):
+        raise ValueError("inverse_temperature_grid must be strictly increasing.")
+    if np.any(np.diff(temperature_for_comparison) >= 0.0):
+        raise ValueError(
+            "temperature_grid must be strictly decreasing to match "
+            "inverse_temperature_grid."
+        )
+    expected_inverse_temperature = 1.0 / temperature_for_comparison
+    if not np.allclose(
+        inverse_for_comparison,
+        expected_inverse_temperature,
+        rtol=_coordinate_rtol(temperature_grid, inverse_temperature_grid),
+        atol=0.0,
+    ):
+        raise ValueError(
+            "temperature_grid and inverse_temperature_grid are inconsistent."
+        )
+
+    for name, array in (
+        ("log_cross_section_grid", log_cross_section_grid),
+        ("log_cross_section_derivative_grid", derivative_grid),
+    ):
+        if not np.issubdtype(array.dtype, np.floating):
+            raise ValueError(f"{name} must use a floating dtype.")
+        if array.ndim != 3:
+            raise ValueError(f"{name} must be three-dimensional.")
+        if not np.all(np.isfinite(array)):
+            raise ValueError(f"{name} must contain only finite values.")
+
+    expected_shape = (
+        pressure_grid.size,
+        temperature_grid.size,
+        nu_grid.size,
+    )
+    if log_cross_section_grid.shape != expected_shape:
+        raise ValueError(
+            "log_cross_section_grid shape does not match the Diffgrid "
+            f"coordinates: expected {expected_shape}, got "
+            f"{log_cross_section_grid.shape}."
+        )
+    if derivative_grid.shape != expected_shape:
+        raise ValueError(
+            "log_cross_section_derivative_grid shape does not match the "
+            f"Diffgrid coordinates: expected {expected_shape}, got "
+            f"{derivative_grid.shape}."
+        )
+
+    if log_cross_section_floor.ndim != 0:
+        raise ValueError("log_cross_section_floor must be a scalar.")
+    if not np.issubdtype(log_cross_section_floor.dtype, np.floating):
+        raise ValueError("log_cross_section_floor must use a floating dtype.")
+    if not bool(np.isfinite(log_cross_section_floor)):
+        raise ValueError("log_cross_section_floor must be finite.")
+
+    if "wav" in arrays:
+        wav = arrays["wav"]
+        _validate_coordinate("wav", wav, minimum_size=nu_grid.size)
+        if wav.shape != nu_grid.shape:
+            raise ValueError("wav shape must match nu_grid.")
+
+
+def _require_metadata(meta: Dict[str, Any], keys: Tuple[str, ...]) -> None:
+    """Require metadata keys with a corruption-oriented error message."""
+    missing = [key for key in keys if key not in meta]
+    if missing:
+        raise KeyError(f"Missing required Diffgrid metadata: {', '.join(missing)}")
+
+
+def _validate_archive_metadata(
+    arrays: Dict[str, np.ndarray],
+    meta: Dict[str, Any],
+    *,
+    strict: bool,
+    allow_downgrade: bool,
+) -> None:
+    """Validate schemas, provenance, array declarations, and digests."""
+    _require_metadata(
+        meta,
+        (
+            "schema_version",
+            "diffgrid_schema_version",
+            "opa_type",
+            "exojax_version",
+            "jax_version",
+            "jaxlib_version",
+            "created_at",
+            "units",
+            "array_shapes",
+            "array_dtypes",
+            "array_digests",
+            "opa_state",
+        ),
+    )
+    _validate_schema(str(meta["schema_version"]), allow_downgrade)
+    if meta["diffgrid_schema_version"] != DIFFGRID_SCHEMA_VERSION:
+        raise ValueError(
+            "Saved Diffgrid schema "
+            f"{meta['diffgrid_schema_version']} differs from "
+            f"{DIFFGRID_SCHEMA_VERSION}."
+        )
+    if meta["opa_type"] != "OpaDiffgrid":
+        raise ValueError(
+            "Saved opa_type must be 'OpaDiffgrid'; got "
+            f"{meta['opa_type']!r}."
+        )
+    if strict:
+        _ensure_compatible_versions(str(meta["exojax_version"]))
+
+    if meta["units"] != _UNITS:
+        raise ValueError("Saved Diffgrid units do not match the supported units.")
+    for name in (
+        "exojax_version",
+        "jax_version",
+        "jaxlib_version",
+        "created_at",
+    ):
+        if not isinstance(meta[name], str):
+            raise ValueError(f"{name} metadata must be a string.")
+
+    for name in ("aux", "user_meta"):
+        if name in meta and not isinstance(meta[name], Mapping):
+            raise ValueError(f"{name} metadata must be a mapping.")
+
+    opa_state = meta["opa_state"]
+    if not isinstance(opa_state, Mapping):
+        raise ValueError("opa_state metadata must be a mapping.")
+    if "teacher_method" not in opa_state or "optional_attributes" not in opa_state:
+        raise ValueError(
+            "opa_state must contain teacher_method and optional_attributes."
+        )
+    if opa_state["teacher_method"] is not None and not isinstance(
+        opa_state["teacher_method"], str
+    ):
+        raise ValueError("teacher_method metadata must be a string or null.")
+    optional_attributes = opa_state["optional_attributes"]
+    if not isinstance(optional_attributes, Mapping):
+        raise ValueError("optional_attributes metadata must be a mapping.")
+    unknown_attributes = set(optional_attributes) - set(
+        _OPTIONAL_SCALAR_ATTRIBUTES
+    )
+    if unknown_attributes:
+        raise ValueError(
+            "Unsupported optional Diffgrid attributes: "
+            f"{', '.join(sorted(unknown_attributes))}."
+        )
+    if "wavelength_order" in optional_attributes and not isinstance(
+        optional_attributes["wavelength_order"], str
+    ):
+        raise ValueError("wavelength_order metadata must be a string.")
+    for name in ("resolution", "molmass"):
+        if name in optional_attributes:
+            value = optional_attributes[name]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"{name} metadata must be a finite number.")
+
+    array_shapes = meta["array_shapes"]
+    array_dtypes = meta["array_dtypes"]
+    array_digests = meta["array_digests"]
+    for name, declaration in (
+        ("array_shapes", array_shapes),
+        ("array_dtypes", array_dtypes),
+        ("array_digests", array_digests),
+    ):
+        if not isinstance(declaration, Mapping):
+            raise ValueError(f"{name} metadata must be a mapping.")
+
+    array_names = set(arrays)
+    missing_required_arrays = [
+        name for name in REQUIRED_DIFFGRID_ARRAYS if name not in arrays
+    ]
+    if missing_required_arrays:
+        raise KeyError(
+            "Missing required Diffgrid arrays: "
+            f"{', '.join(missing_required_arrays)}"
+        )
+    supported_array_names = set(REQUIRED_DIFFGRID_ARRAYS) | {"wav"}
+    unsupported_array_names = array_names - supported_array_names
+    if unsupported_array_names:
+        raise ValueError(
+            "Unsupported Diffgrid arrays: "
+            f"{', '.join(sorted(unsupported_array_names))}."
+        )
+    for name, declaration in (
+        ("array_shapes", array_shapes),
+        ("array_dtypes", array_dtypes),
+        ("array_digests", array_digests),
+    ):
+        declared_names = set(declaration)
+        if declared_names != array_names:
+            missing_arrays = declared_names - array_names
+            missing_metadata = array_names - declared_names
+            details = []
+            if missing_arrays:
+                details.append(
+                    "arrays missing from the payload: "
+                    + ", ".join(sorted(missing_arrays))
+                )
+            if missing_metadata:
+                details.append(
+                    "arrays missing metadata: "
+                    + ", ".join(sorted(missing_metadata))
+                )
+            raise ValueError(f"{name} keys do not match payload; {'; '.join(details)}.")
+
+    for name, array in arrays.items():
+        if name not in array_shapes:
+            raise KeyError(f"Missing shape metadata for Diffgrid array '{name}'.")
+        if name not in array_dtypes:
+            raise KeyError(f"Missing dtype metadata for Diffgrid array '{name}'.")
+        if name not in array_digests:
+            raise KeyError(f"Missing digest metadata for Diffgrid array '{name}'.")
+        saved_shape_values = array_shapes[name]
+        if not isinstance(saved_shape_values, (list, tuple)) or any(
+            isinstance(size, bool)
+            or not isinstance(size, (int, np.integer))
+            or size < 0
+            for size in saved_shape_values
+        ):
+            raise ValueError(
+                f"Invalid shape metadata for Diffgrid array '{name}'."
+            )
+        saved_shape = tuple(int(size) for size in saved_shape_values)
+        if saved_shape != array.shape:
+            raise ValueError(
+                f"Shape metadata mismatch for Diffgrid array '{name}': "
+                f"expected {saved_shape}, got {array.shape}."
+            )
+        if array_dtypes[name] != str(array.dtype):
+            raise ValueError(
+                f"Dtype metadata mismatch for Diffgrid array '{name}': "
+                f"expected {array_dtypes[name]!r}, got {str(array.dtype)!r}."
+            )
+
+    _validate_array_values(arrays)
+
+    for name, array in arrays.items():
+        digest = _sha256_array(array)
+        if array_digests[name] != digest:
+            raise ValueError(
+                f"Digest mismatch for Diffgrid array '{name}'. "
+                "Saved file may be corrupted."
+            )
+
+
+def saveopa_diffgrid(
+    opa: OpaDiffgrid,
+    path: str,
+    *,
+    format: Literal["zarr", "npz"] = "zarr",
+    extra_meta: Mapping[str, Any] | None = None,
+    aux: Mapping[str, Any] | None = None,
+) -> None:
+    """Persist a ready, self-contained ``OpaDiffgrid`` table."""
+    from exojax.opacity.diffgrid.api import OpaDiffgrid
+
+    if not isinstance(opa, OpaDiffgrid):
+        raise TypeError("saveopa_diffgrid expects an OpaDiffgrid instance.")
+    if not getattr(opa, "ready", False):
+        raise ValueError("OpaDiffgrid is not ready and cannot be saved.")
+    if not hasattr(opa, "diffgrid_info") or opa.diffgrid_info is None:
+        raise ValueError("OpaDiffgrid has no Diffgrid table to save.")
+    if format not in ("zarr", "npz"):
+        raise ValueError("format must be either 'zarr' or 'npz'.")
+    path_suffix = Path(path).suffix
+    conflicting_suffix = ".npz" if format == "zarr" else ".zarr"
+    if path_suffix == conflicting_suffix:
+        raise ValueError(
+            f"Path suffix '{path_suffix}' conflicts with format='{format}'."
+        )
+
+    arrays = _diffgrid_arrays(opa)
+    _validate_array_values(arrays)
+    meta = _diffgrid_metadata(opa, arrays, extra_meta, aux)
+    _validate_archive_metadata(
+        arrays,
+        meta,
+        strict=False,
+        allow_downgrade=False,
+    )
+    if format == "zarr":
+        _save_as_zarr(path, arrays, meta)
+    else:
+        _save_as_npz(path, arrays, meta)
+
+
+def load_diffgrid_payload(
+    path: str,
+    *,
+    strict: bool = True,
+    allow_downgrade: bool = False,
+) -> Tuple[Dict[str, np.ndarray], Dict[str, Any]]:
+    """Load and host-validate a self-contained Diffgrid archive."""
+    path_object = Path(path)
+    if path_object.suffix == ".npz":
+        arrays, meta = _load_from_npz(path_object)
+    elif path_object.suffix == ".zarr":
+        arrays, meta = _load_from_zarr(path_object)
+    else:
+        arrays, meta = _load(path)
+    _validate_archive_metadata(
+        arrays,
+        meta,
+        strict=strict,
+        allow_downgrade=allow_downgrade,
+    )
+    return arrays, meta

--- a/src/exojax/opacity/io/ioopa.py
+++ b/src/exojax/opacity/io/ioopa.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Literal
 
 from exojax.opacity.base import OpaCalc
 from exojax.opacity.ckd.api import OpaCKD
+from exojax.opacity.diffgrid.api import OpaDiffgrid
+from exojax.opacity.diffgrid.io import saveopa_diffgrid
 from exojax.opacity.lpf.api import OpaDirect
 from exojax.opacity.modit.api import OpaModit
 from exojax.opacity.premodit.api import OpaPremodit
@@ -20,10 +22,19 @@ def saveopa(
 ) -> None:
     """Generic entry point for persisting ``Opa*`` calculators to disk.
 
-    Currently only :class:`OpaPremodit` is implemented; other calculators raise
-    ``NotImplementedError`` placeholders (``saveopa_ckd``, ``saveopa_modit``,
-    ``saveopa_direct``) to document the expected extension points.
+    Diffgrid and PreMODIT calculators can be saved as NPZ or Zarr archives.
+    Other calculators raise ``NotImplementedError`` placeholders to document
+    the expected extension points.
     """
+    if isinstance(opa, OpaDiffgrid):
+        saveopa_diffgrid(
+            opa,
+            path,
+            format=format,
+            extra_meta=extra_meta,
+            aux=aux,
+        )
+        return
     if isinstance(opa, OpaPremodit):
         saveopa_premodit(
             opa,
@@ -48,5 +59,4 @@ def saveopa(
     raise TypeError(
         "saveopa does not support persisting instances of " f"{opa.__class__.__name__}."
     )
-
 

--- a/tests/unittests/opacity/diffgrid/diffgrid_io_test.py
+++ b/tests/unittests/opacity/diffgrid/diffgrid_io_test.py
@@ -1,0 +1,795 @@
+import hashlib
+import json
+
+import jax
+import jax.numpy as jnp
+import jaxlib
+import numpy as np
+import pytest
+
+from exojax import __version__
+from exojax.opacity import OpaDiffgrid
+from exojax.opacity import saveopa
+from exojax.opacity.io.serialization import _sha256_array
+from exojax.utils.grids import nu2wav
+from exojax.utils.instfunc import resolution_eslog
+
+
+ARRAY_KEYS = (
+    "nu_grid",
+    "pressure_grid",
+    "temperature_grid",
+    "inverse_temperature_grid",
+    "log_cross_section_grid",
+    "log_cross_section_derivative_grid",
+    "log_cross_section_floor",
+)
+
+
+class _AnalyticTeacher:
+    method = "analytic"
+    ready = True
+    wavelength_order = "descending"
+    molmass = 28.01
+
+    def __init__(self, dtype=np.float32):
+        self.nu_grid = np.asarray([1000.0, 1001.0, 1002.0], dtype=dtype)
+        self.wav = nu2wav(
+            self.nu_grid,
+            wavelength_order=self.wavelength_order,
+            unit="AA",
+        )
+        self.resolution = resolution_eslog(self.nu_grid)
+
+    def xsmatrix(self, temperature, pressure):
+        temperature = jnp.asarray(temperature)
+        pressure = jnp.asarray(pressure)
+        nu_grid = jnp.asarray(self.nu_grid, dtype=temperature.dtype)
+        temperature_factor = jnp.exp(-700.0 / temperature)
+        pressure_factor = 1.0 + 0.05 * jnp.log1p(pressure)
+        wavenumber_factor = 1.0 + 0.02 * (nu_grid - nu_grid[0])
+        return (
+            jnp.asarray(1.0e-22, dtype=temperature.dtype)
+            * temperature_factor[:, None]
+            * pressure_factor[:, None]
+            * wavenumber_factor[None, :]
+        )
+
+
+class _MinimalAnalyticTeacher:
+    method = "minimal-analytic"
+    ready = True
+    nu_grid = np.asarray([1000.0, 1001.0], dtype=np.float32)
+
+    def xsmatrix(self, temperature, pressure):
+        value = jnp.exp(-500.0 / jnp.asarray(temperature))
+        return jnp.broadcast_to(value[:, None], (len(pressure), len(self.nu_grid)))
+
+
+@pytest.fixture(scope="module")
+def diffgrid_case():
+    teacher = _AnalyticTeacher()
+    pressure_grid = np.asarray([0.1, 1.0], dtype=np.float32)
+    temperature_grid = np.asarray([700.0, 1000.0, 1500.0], dtype=np.float32)
+    opa = OpaDiffgrid(
+        teacher,
+        temperature_grid,
+        pressure_grid,
+        min_cross_section=1.0e-30,
+    )
+    return opa, teacher, pressure_grid
+
+
+def _metadata_path(npz_path):
+    return npz_path.with_name(npz_path.stem + "_metadata.json")
+
+
+def _read_npz_archive(npz_path):
+    with np.load(npz_path, allow_pickle=False) as archive:
+        arrays = {key: np.asarray(archive[key]) for key in archive.files}
+    with open(_metadata_path(npz_path), "r") as stream:
+        metadata = json.load(stream)
+    return arrays, metadata
+
+
+def _write_npz_archive(npz_path, arrays, metadata):
+    np.savez_compressed(npz_path, **arrays)
+    with open(_metadata_path(npz_path), "w") as stream:
+        json.dump(metadata, stream, indent=4)
+
+
+def _digest(array):
+    array = np.asarray(array)
+    digest = hashlib.sha256()
+    digest.update(array.tobytes(order="C"))
+    digest.update(str(array.dtype).encode())
+    digest.update(str(array.shape).encode())
+    return digest.hexdigest()
+
+
+def _refresh_array_metadata(metadata, key, array):
+    """Update the common metadata spellings used by opacity archives."""
+    array = np.asarray(array)
+    for container_name in ("array_digests", "digests"):
+        container = metadata.get(container_name)
+        if isinstance(container, dict) and key in container:
+            container[key] = _digest(array)
+    digest_key = f"{key}_digest"
+    if digest_key in metadata:
+        metadata[digest_key] = _digest(array)
+
+    for container_name in ("array_shapes", "shapes"):
+        container = metadata.get(container_name)
+        if isinstance(container, dict) and key in container:
+            container[key] = list(array.shape)
+    for container_name in ("array_dtypes", "dtypes"):
+        container = metadata.get(container_name)
+        if isinstance(container, dict) and key in container:
+            container[key] = str(array.dtype)
+
+
+def _assert_same_diffgrid(expected, actual):
+    assert actual.ready is True
+    assert actual.method == "diffgrid"
+    assert actual.teacher_method == expected.teacher_method
+    assert actual.opainfo is actual.diffgrid_info
+    for key in ARRAY_KEYS:
+        actual_array = (
+            actual.nu_grid
+            if key == "nu_grid"
+            else getattr(actual.diffgrid_info, key)
+        )
+        expected_array = (
+            expected.nu_grid
+            if key == "nu_grid"
+            else getattr(expected.diffgrid_info, key)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(actual_array),
+            np.asarray(expected_array),
+        )
+
+
+def test_npz_roundtrip_preserves_tables_metadata_and_optional_attributes(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "analytic_diffgrid"
+    aux = {
+        "labels": ["CO", 1],
+        "nested": {"values": np.asarray([1, 2], dtype=np.int32)},
+    }
+    user_meta = {"artifact": "offline-test", "revision": 2}
+
+    saveopa(opa, str(path), format="npz", aux=aux, extra_meta=user_meta)
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    _assert_same_diffgrid(opa, loaded)
+    assert loaded.aux == {
+        "labels": ["CO", 1],
+        "nested": {"values": [1, 2]},
+    }
+    assert loaded.user_meta == user_meta
+    assert loaded.molmass == pytest.approx(opa.molmass)
+    assert loaded.wavelength_order == opa.wavelength_order
+    np.testing.assert_array_equal(loaded.wav, opa.wav)
+    assert loaded.resolution == pytest.approx(opa.resolution)
+
+    arrays, metadata = _read_npz_archive(path.with_suffix(".npz"))
+    assert set(ARRAY_KEYS) <= set(arrays)
+    assert metadata["schema_version"] == "ioopa@1"
+    assert metadata["diffgrid_schema_version"] == "diffgrid@1"
+    assert metadata["opa_type"] == "OpaDiffgrid"
+    assert metadata["exojax_version"] == __version__
+    assert metadata["opa_state"]["teacher_method"] == "analytic"
+    assert metadata["units"] == {
+        "wavenumber": "cm^-1",
+        "pressure": "bar",
+        "temperature": "K",
+        "inverse_temperature": "K^-1",
+        "cross_section": "cm^2",
+        "log_cross_section_derivative": "K",
+    }
+    for key in ARRAY_KEYS:
+        assert metadata["array_shapes"][key] == list(arrays[key].shape)
+        assert metadata["array_dtypes"][key] == str(arrays[key].dtype)
+        assert metadata["array_digests"][key] == _sha256_array(arrays[key])
+
+
+def test_zarr_roundtrip_preserves_tables(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "analytic_diffgrid"
+    aux = {"provider": "external-catalog"}
+    user_meta = {"artifact": "zarr-test"}
+
+    saveopa(
+        opa,
+        str(path),
+        format="zarr",
+        aux=aux,
+        extra_meta=user_meta,
+    )
+    saveopa(
+        opa,
+        str(path),
+        format="npz",
+        aux={"provider": "npz-sibling"},
+    )
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".zarr")
+
+    _assert_same_diffgrid(opa, loaded)
+    assert loaded.aux == aux
+    assert loaded.user_meta == user_meta
+    assert loaded.molmass == pytest.approx(opa.molmass)
+    assert loaded.wavelength_order == opa.wavelength_order
+    np.testing.assert_array_equal(loaded.wav, opa.wav)
+    assert loaded.resolution == pytest.approx(opa.resolution)
+
+
+def test_loads_schema_compliant_npz_from_external_producer(tmp_path):
+    arrays = {
+        "nu_grid": np.asarray([1000.0, 1001.0], dtype=np.float32),
+        "pressure_grid": np.asarray([1.0, 0.1], dtype=np.float32),
+        "temperature_grid": np.asarray(
+            [1500.0, 1000.0, 700.0], dtype=np.float32
+        ),
+    }
+    arrays["inverse_temperature_grid"] = (
+        np.asarray(1.0, dtype=np.float32) / arrays["temperature_grid"]
+    )
+    arrays["log_cross_section_grid"] = np.asarray(
+        [
+            [[-52.0, -51.0], [-50.0, -49.0], [-48.0, -47.0]],
+            [[-51.0, -50.0], [-49.0, -48.0], [-47.0, -46.0]],
+        ],
+        dtype=np.float32,
+    )
+    arrays["log_cross_section_derivative_grid"] = np.zeros(
+        (2, 3, 2), dtype=np.float32
+    )
+    arrays["log_cross_section_floor"] = np.asarray(-80.0, dtype=np.float32)
+    metadata = {
+        "schema_version": "ioopa@1",
+        "diffgrid_schema_version": "diffgrid@1",
+        "opa_type": "OpaDiffgrid",
+        "exojax_version": __version__,
+        "jax_version": jax.__version__,
+        "jaxlib_version": jaxlib.__version__,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "units": {
+            "wavenumber": "cm^-1",
+            "pressure": "bar",
+            "temperature": "K",
+            "inverse_temperature": "K^-1",
+            "cross_section": "cm^2",
+            "log_cross_section_derivative": "K",
+        },
+        "array_shapes": {
+            name: list(array.shape) for name, array in arrays.items()
+        },
+        "array_dtypes": {
+            name: str(array.dtype) for name, array in arrays.items()
+        },
+        "array_digests": {
+            name: _digest(array) for name, array in arrays.items()
+        },
+        "opa_state": {
+            "teacher_method": "external-producer",
+            "optional_attributes": {"molmass": 28.01},
+        },
+        "aux": {"catalog": "independent"},
+        "user_meta": {"license": "test-only"},
+    }
+    path = tmp_path / "external_diffgrid.npz"
+    _write_npz_archive(path, arrays, metadata)
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path))
+
+    assert loaded.teacher_method == "external-producer"
+    assert loaded.molmass == pytest.approx(28.01)
+    assert loaded.aux == {"catalog": "independent"}
+    assert loaded.user_meta == {"license": "test-only"}
+    result = loaded.xsmatrix(
+        np.asarray([1500.0, 700.0], dtype=np.float32),
+        arrays["pressure_grid"],
+    )
+    assert result.shape == (2, 2)
+    assert np.all(np.isfinite(np.asarray(result)))
+
+
+def test_generic_saveopa_dispatches_diffgrid(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "generic_dispatch"
+
+    saveopa(opa, str(path), format="npz")
+
+    assert path.with_suffix(".npz").is_file()
+    assert _metadata_path(path.with_suffix(".npz")).is_file()
+
+
+@pytest.mark.parametrize(
+    "suffix,format",
+    [(".npz", "zarr"), (".zarr", "npz")],
+)
+def test_save_rejects_path_suffix_conflicting_with_format(
+    tmp_path, diffgrid_case, suffix, format
+):
+    opa, _, _ = diffgrid_case
+
+    with pytest.raises(ValueError, match="suffix.*conflicts"):
+        saveopa(opa, str(tmp_path / f"artifact{suffix}"), format=format)
+
+
+def test_save_rejects_metadata_it_cannot_reload(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    original_teacher_method = opa.teacher_method
+    try:
+        opa.teacher_method = 1
+        with pytest.raises(ValueError, match="teacher_method"):
+            saveopa(opa, str(tmp_path / "invalid_provenance"), format="npz")
+    finally:
+        opa.teacher_method = original_teacher_method
+
+
+def test_loaded_diffgrid_does_not_require_teacher(tmp_path):
+    teacher = _AnalyticTeacher()
+    opa = OpaDiffgrid(
+        teacher,
+        np.asarray([700.0, 1000.0, 1500.0], dtype=np.float32),
+        np.asarray([0.1, 1.0], dtype=np.float32),
+        min_cross_section=1.0e-30,
+    )
+    path = tmp_path / "teacher_independent"
+    saveopa(opa, str(path), format="npz")
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("the saved diffgrid must not call its teacher")
+
+    teacher.xsmatrix = fail_if_called
+    del opa
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    result = loaded.xsmatrix(jnp.asarray([800.0, 1200.0]))
+    assert result.shape == (2, 3)
+    assert np.all(np.isfinite(np.asarray(result)))
+    assert not hasattr(loaded, "base_opa")
+
+
+def test_optional_attribute_absence_is_preserved(tmp_path):
+    opa = OpaDiffgrid(
+        _MinimalAnalyticTeacher(),
+        np.asarray([700.0, 1000.0, 1500.0], dtype=np.float32),
+        np.asarray([0.1], dtype=np.float32),
+        min_cross_section=1.0e-30,
+    )
+    path = tmp_path / "minimal_attributes"
+    saveopa(opa, str(path), format="npz")
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    for attribute in ("wavelength_order", "wav", "resolution", "molmass"):
+        assert not hasattr(loaded, attribute)
+
+
+def test_loaded_xsmatrix_matches_at_nodes_and_interior(tmp_path, diffgrid_case):
+    opa, _, pressure_grid = diffgrid_case
+    path = tmp_path / "evaluation_roundtrip"
+    saveopa(opa, str(path), format="npz")
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    at_nodes = np.asarray([700.0, 1500.0], dtype=np.float32)
+    interior = np.asarray([800.0, 1200.0], dtype=np.float32)
+    for temperature in (at_nodes, interior):
+        np.testing.assert_allclose(
+            loaded.xsmatrix(temperature, pressure_grid),
+            opa.xsmatrix(temperature, pressure_grid),
+            rtol=2.0e-6,
+            atol=0.0,
+        )
+
+
+def test_loaded_diffgrid_supports_jax_transformations(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "jax_transformations"
+    saveopa(opa, str(path), format="npz")
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+    temperature = jnp.asarray([800.0, 1200.0])
+    tangent = jnp.asarray([0.5, -0.25])
+
+    compiled = jax.jit(loaded.xsmatrix)(temperature)
+    batched = jax.vmap(loaded.xsmatrix)(
+        jnp.stack([temperature, temperature + jnp.asarray([10.0, -10.0])])
+    )
+
+    def objective(value):
+        return jnp.sum(jnp.log(loaded.xsmatrix(value)))
+
+    gradient = jax.grad(objective)(temperature)
+    value, directional_derivative = jax.jvp(
+        objective, (temperature,), (tangent,)
+    )
+
+    assert compiled.shape == (2, 3)
+    assert batched.shape == (2, 2, 3)
+    for result in (compiled, batched, gradient, value, directional_derivative):
+        assert np.all(np.isfinite(np.asarray(result)))
+
+
+def test_loaded_diffgrid_preserves_pressure_validation(tmp_path, diffgrid_case):
+    opa, _, pressure_grid = diffgrid_case
+    path = tmp_path / "pressure_validation"
+    saveopa(opa, str(path), format="npz")
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    with pytest.raises(ValueError, match="rebuild the table"):
+        loaded.xsmatrix(np.asarray([800.0, 1200.0]), pressure_grid * 1.01)
+    with pytest.raises(ValueError, match="shape does not match"):
+        loaded.xsmatrix(np.asarray([800.0, 1200.0]), pressure_grid[:-1])
+
+
+@pytest.mark.parametrize(
+    "saved_pressure",
+    [
+        np.asarray([1.0, 0.1], dtype=np.float32),
+        np.asarray([1.0, 1.0], dtype=np.float32),
+    ],
+)
+def test_load_preserves_pressure_layer_order_without_uniqueness_requirement(
+    tmp_path, diffgrid_case, saved_pressure
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "pressure_layer_order")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["pressure_grid"] = saved_pressure
+    _refresh_array_metadata(metadata, "pressure_grid", saved_pressure)
+    _write_npz_archive(path, arrays, metadata)
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path))
+
+    np.testing.assert_array_equal(loaded.pressure_grid, saved_pressure)
+    result = loaded.xsmatrix(
+        np.asarray([800.0, 1200.0], dtype=np.float32), saved_pressure
+    )
+    assert np.all(np.isfinite(np.asarray(result)))
+
+
+def _saved_npz(tmp_path, opa, name="archive"):
+    path = tmp_path / name
+    saveopa(opa, str(path), format="npz")
+    return path.with_suffix(".npz")
+
+
+def test_load_rejects_missing_required_array(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "missing_array")
+    arrays, metadata = _read_npz_archive(path)
+    del arrays["log_cross_section_derivative_grid"]
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(KeyError, match="log_cross_section_derivative_grid"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_wrong_table_shape(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "wrong_shape")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["log_cross_section_derivative_grid"] = arrays[
+        "log_cross_section_derivative_grid"
+    ][..., :-1]
+    _refresh_array_metadata(
+        metadata,
+        "log_cross_section_derivative_grid",
+        arrays["log_cross_section_derivative_grid"],
+    )
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="shape"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_fractional_shape_metadata(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "fractional_shape")
+    arrays, metadata = _read_npz_archive(path)
+    metadata["array_shapes"]["pressure_grid"] = [2.9]
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="Invalid shape metadata"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_optional_array_declared_but_missing(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "missing_optional_array")
+    arrays, metadata = _read_npz_archive(path)
+    del arrays["wav"]
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="missing from the payload.*wav"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+@pytest.mark.parametrize(
+    "key,index",
+    [
+        ("pressure_grid", (0,)),
+        ("temperature_grid", (0,)),
+        ("inverse_temperature_grid", (0,)),
+        ("log_cross_section_grid", (0, 0, 0)),
+        ("log_cross_section_derivative_grid", (0, 0, 0)),
+    ],
+)
+def test_load_rejects_nonfinite_arrays(tmp_path, diffgrid_case, key, index):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, f"nonfinite_{key}")
+    arrays, metadata = _read_npz_archive(path)
+    arrays[key] = arrays[key].copy()
+    arrays[key][index] = np.nan
+    _refresh_array_metadata(metadata, key, arrays[key])
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="finite"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_inconsistent_temperature_coordinates(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "inconsistent_coordinates")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["temperature_grid"] = arrays["temperature_grid"].copy()
+    arrays["temperature_grid"][1] *= 1.1
+    _refresh_array_metadata(metadata, "temperature_grid", arrays["temperature_grid"])
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="temperature"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+@pytest.mark.parametrize("floor", [np.nan, np.inf])
+def test_load_rejects_invalid_floor(tmp_path, diffgrid_case, floor):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "invalid_floor")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["log_cross_section_floor"] = np.asarray(
+        floor, dtype=arrays["log_cross_section_floor"].dtype
+    )
+    _refresh_array_metadata(
+        metadata, "log_cross_section_floor", arrays["log_cross_section_floor"]
+    )
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="floor|finite"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_floor_below_active_normal_range(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "unrepresentable_floor")
+    arrays, metadata = _read_npz_archive(path)
+    dtype = arrays["log_cross_section_grid"].dtype
+    arrays["log_cross_section_floor"] = np.asarray(
+        np.log(np.finfo(dtype).tiny) - 1.0,
+        dtype=dtype,
+    )
+    _refresh_array_metadata(
+        metadata,
+        "log_cross_section_floor",
+        arrays["log_cross_section_floor"],
+    )
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="smallest normal"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_floor_above_active_finite_range(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "oversized_floor")
+    arrays, metadata = _read_npz_archive(path)
+    dtype = arrays["log_cross_section_grid"].dtype
+    arrays["log_cross_section_floor"] = np.asarray(
+        np.log(np.finfo(dtype).max) + 1.0,
+        dtype=dtype,
+    )
+    _refresh_array_metadata(
+        metadata,
+        "log_cross_section_floor",
+        arrays["log_cross_section_floor"],
+    )
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="largest finite"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+def test_load_rejects_digest_mismatch(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "digest_mismatch")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["pressure_grid"] = arrays["pressure_grid"].copy()
+    arrays["pressure_grid"][0] *= 1.01
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="[Dd]igest"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+
+@pytest.mark.parametrize(
+    "metadata_key,value,message",
+    [
+        ("opa_type", "OpaPremodit", "opa_type|OpaDiffgrid"),
+        (
+            "diffgrid_schema_version",
+            "diffgrid@999",
+            "Diffgrid schema|diffgrid.*schema",
+        ),
+    ],
+)
+def test_load_rejects_wrong_type_or_diffgrid_schema(
+    tmp_path, diffgrid_case, metadata_key, value, message
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, f"wrong_{metadata_key}")
+    arrays, metadata = _read_npz_archive(path)
+    metadata[metadata_key] = value
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match=message):
+        OpaDiffgrid.from_saved_opa(str(path))
+    if metadata_key == "diffgrid_schema_version":
+        with pytest.raises(ValueError, match=message):
+            OpaDiffgrid.from_saved_opa(str(path), allow_downgrade=True)
+
+
+def test_common_schema_allow_downgrade_policy(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "common_schema")
+    arrays, metadata = _read_npz_archive(path)
+    metadata["schema_version"] = "ioopa@0"
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="schema"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path), allow_downgrade=True)
+    assert loaded.ready is True
+
+
+def test_exojax_version_strictness(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "version_policy")
+    arrays, metadata = _read_npz_archive(path)
+    metadata["exojax_version"] = "0.0.external"
+    _write_npz_archive(path, arrays, metadata)
+
+    with pytest.raises(ValueError, match="strict=False"):
+        OpaDiffgrid.from_saved_opa(str(path))
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path), strict=False)
+    assert loaded.ready is True
+
+
+def test_dtype_conversion_requires_non_strict_load(tmp_path, diffgrid_case):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "float64_payload")
+    arrays, metadata = _read_npz_archive(path)
+    for key in ARRAY_KEYS:
+        arrays[key] = np.asarray(arrays[key], dtype=np.float64)
+    arrays["inverse_temperature_grid"] = (
+        np.asarray(1.0, dtype=np.float64) / arrays["temperature_grid"]
+    )
+    for key in ARRAY_KEYS:
+        _refresh_array_metadata(metadata, key, arrays[key])
+    _write_npz_archive(path, arrays, metadata)
+
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", False)
+        with pytest.raises(ValueError, match="dtype|64-bit|strict=False"):
+            OpaDiffgrid.from_saved_opa(str(path))
+
+        loaded = OpaDiffgrid.from_saved_opa(str(path), strict=False)
+        assert loaded.log_cross_section_grid.dtype == jnp.float32
+        assert np.all(
+            np.isfinite(np.asarray(loaded.xsmatrix(jnp.asarray([800.0, 1200.0]))))
+        )
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)
+
+
+def test_roundtrip_accepts_integer_temperature_nodes(tmp_path):
+    opa = OpaDiffgrid(
+        _MinimalAnalyticTeacher(),
+        np.asarray([700, 1000, 1500], dtype=np.int32),
+        np.asarray([0.1], dtype=np.float32),
+        min_cross_section=1.0e-30,
+    )
+    path = tmp_path / "integer_temperature_nodes"
+    saveopa(opa, str(path), format="npz")
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path) + ".npz")
+
+    np.testing.assert_array_equal(loaded.temperature_grid, opa.temperature_grid)
+    result = loaded.xsmatrix(np.asarray([1000.0], dtype=np.float32))
+    assert np.all(np.isfinite(np.asarray(result)))
+
+
+def test_non_strict_load_rejects_table_overflow_in_active_dtype(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "overflowing_table")
+    arrays, metadata = _read_npz_archive(path)
+    value_grid = np.asarray(
+        arrays["log_cross_section_grid"], dtype=np.float64
+    )
+    value_grid[0, 0, 0] = 2.0 * float(np.finfo(np.float32).max)
+    arrays["log_cross_section_grid"] = value_grid
+    _refresh_array_metadata(metadata, "log_cross_section_grid", value_grid)
+    _write_npz_archive(path, arrays, metadata)
+
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", False)
+        with pytest.raises(ValueError, match="finite.*active JAX dtype"):
+            OpaDiffgrid.from_saved_opa(str(path), strict=False)
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)
+
+
+def test_non_strict_load_rejects_temperature_nodes_collapsed_by_jax_dtype(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "collapsed_nodes")
+    arrays, metadata = _read_npz_archive(path)
+    temperature_grid = np.asarray(
+        [1500.0, 1000.00001, 1000.0], dtype=np.float64
+    )
+    arrays["temperature_grid"] = temperature_grid
+    arrays["inverse_temperature_grid"] = 1.0 / temperature_grid
+    for key in (
+        "temperature_grid",
+        "inverse_temperature_grid",
+        "log_cross_section_grid",
+        "log_cross_section_derivative_grid",
+        "log_cross_section_floor",
+        "pressure_grid",
+    ):
+        arrays[key] = np.asarray(arrays[key], dtype=np.float64)
+        _refresh_array_metadata(metadata, key, arrays[key])
+    _write_npz_archive(path, arrays, metadata)
+
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", False)
+        with pytest.raises(ValueError, match="active JAX dtype|unique|distinct"):
+            OpaDiffgrid.from_saved_opa(str(path), strict=False)
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)
+
+
+def test_load_rejects_wavenumber_nodes_collapsed_by_jax_dtype(
+    tmp_path, diffgrid_case
+):
+    opa, _, _ = diffgrid_case
+    path = _saved_npz(tmp_path, opa, "collapsed_wavenumbers")
+    arrays, metadata = _read_npz_archive(path)
+    arrays["nu_grid"] = np.asarray(
+        [1000.0, 1000.00001, 1002.0], dtype=np.float64
+    )
+    _refresh_array_metadata(metadata, "nu_grid", arrays["nu_grid"])
+    _write_npz_archive(path, arrays, metadata)
+
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", False)
+        with pytest.raises(ValueError, match="nu_grid.*distinct.*active JAX"):
+            OpaDiffgrid.from_saved_opa(str(path))
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)


### PR DESCRIPTION
## Summary

- add self-contained NPZ and Zarr persistence for `OpaDiffgrid`
- restore saved Diffgrid calculators without a teacher, MDB, or PreMODIT state
- integrate Diffgrid dispatch into the public `saveopa()` API
- validate schemas, units, shapes, dtypes, SHA-256 digests, active JAX dtypes, and pressure-layer contracts
- cover externally produced archives, metadata round trips, corruption cases, and JAX transformations

## Why

Precomputed Diffgrid cross sections need to be reusable across sessions and distributable independently of ExoJAX line databases and teacher calculators. The new `diffgrid@1` archive contract makes the table self-contained while preserving the existing layer-aligned pressure and differentiability behavior.

## User impact

Users can now write and restore Diffgrid tables with:

```python
saveopa(opa, "co_diffgrid.zarr", format="zarr")
loaded = OpaDiffgrid.from_saved_opa("co_diffgrid.zarr")
```

NPZ is also supported using the existing payload plus JSON sidecar convention.

## Validation

- Diffgrid test set: 51 tests passed across the non-Zarr suite and targeted Zarr/path cases
- Related regression suite: 68 passed
- `ruff check src/exojax/opacity/diffgrid src/exojax/opacity/io tests/unittests/opacity/diffgrid`
- `git diff --check`
