### PR TITLE
Fix inverse-square gravity scaling in hydrostatic calculation

### DIFF
--- a/src/exojax/opacity/diffgrid/api.py
+++ b/src/exojax/opacity/diffgrid/api.py
@@ -345,10 +345,19 @@ class OpaDiffgrid(OpaCalc):
                 f"range [{temperature_min}, {temperature_max}] K."
             )
         inverse_temperature = 1.0 / temperature
+        coordinate_tolerance = (
+            8.0 * np.finfo(self._inverse_temperature_grid_host.dtype).eps
+        )
+        inverse_temperature_min = self._inverse_temperature_grid_host[0]
+        inverse_temperature_max = self._inverse_temperature_grid_host[-1]
         if (
-            np.any(inverse_temperature < self._inverse_temperature_grid_host[0])
+            np.any(
+                inverse_temperature
+                < inverse_temperature_min * (1.0 - coordinate_tolerance)
+            )
             or np.any(
-                inverse_temperature > self._inverse_temperature_grid_host[-1]
+                inverse_temperature
+                > inverse_temperature_max * (1.0 + coordinate_tolerance)
             )
         ):
             raise ValueError(

--- a/src/exojax/opacity/diffgrid/core.py
+++ b/src/exojax/opacity/diffgrid/core.py
@@ -127,10 +127,17 @@ def cross_section_matrix(
     xsmatrix = jnp.exp(log_cross_section)
 
     inverse_temperature = 1.0 / temperature
+    coordinate_tolerance = 8.0 * jnp.finfo(inverse_temperature_grid.dtype).eps
     valid = (
         jnp.isfinite(temperature)
         & (temperature > 0.0)
-        & (inverse_temperature >= inverse_temperature_grid[0])
-        & (inverse_temperature <= inverse_temperature_grid[-1])
+        & (
+            inverse_temperature
+            >= inverse_temperature_grid[0] * (1.0 - coordinate_tolerance)
+        )
+        & (
+            inverse_temperature
+            <= inverse_temperature_grid[-1] * (1.0 + coordinate_tolerance)
+        )
     )
     return jnp.where(valid[:, None], xsmatrix, jnp.nan)

--- a/src/exojax/rt/common.py
+++ b/src/exojax/rt/common.py
@@ -113,8 +113,10 @@ class ArtCommon:
         normalized_height, normalized_radius_lower = self.atmosphere_height(
             temperature, mean_molecular_weight, radius_btm, gravity_btm
         )
+#        normalized_radius_layer = normalized_radius_lower + 0.5 * normalized_height
+#        return jnp.array([gravity_btm / normalized_radius_layer]).T
         normalized_radius_layer = normalized_radius_lower + 0.5 * normalized_height
-        return jnp.array([gravity_btm / normalized_radius_layer]).T
+        return jnp.array([gravity_btm / normalized_radius_layer**2]).T
 
     def constant_profile(self, value):
         return value * np.ones_like(self.pressure)

--- a/src/exojax/rt/common.py
+++ b/src/exojax/rt/common.py
@@ -66,7 +66,8 @@ class ArtCommon:
                 mean molecular weight profile (float/Nlayer)
             radius_btm (float):
                 the bottom radius of the atmospheric layer
-            gravity_btm (float): the bottom gravity cm2/s at radius_btm, i.e. G M_p/radius_btm
+            gravity_btm (float): the bottom gravity in cm/s2 at radius_btm,
+                i.e. G M_p/radius_btm**2
 
         Returns:
             1D array: height normalized by radius_btm (Nlayer)
@@ -104,17 +105,16 @@ class ArtCommon:
                 mean molecular weight profile (float/Nlayer)
             radius_btm (float): the bottom radius of the atmospheric layer
             gravity_btm (float):
-                the bottom gravity cm2/s at radius_btm, i.e. G M_p/radius_btm
+                the bottom gravity in cm/s2 at radius_btm,
+                i.e. G M_p/radius_btm**2
 
         Returns:
             2D array:
-                gravity in cm2/s (Nlayer, 1), suitable for the input of opacity_profile_lines
+                gravity in cm/s2 (Nlayer, 1), suitable for the input of opacity_profile_lines
         """
         normalized_height, normalized_radius_lower = self.atmosphere_height(
             temperature, mean_molecular_weight, radius_btm, gravity_btm
         )
-#        normalized_radius_layer = normalized_radius_lower + 0.5 * normalized_height
-#        return jnp.array([gravity_btm / normalized_radius_layer]).T
         normalized_radius_layer = normalized_radius_lower + 0.5 * normalized_height
         return jnp.array([gravity_btm / normalized_radius_layer**2]).T
 

--- a/tests/unittests/opacity/diffgrid/diffgrid_api_test.py
+++ b/tests/unittests/opacity/diffgrid/diffgrid_api_test.py
@@ -126,6 +126,27 @@ def test_diffgrid_matches_premodit_at_temperature_nodes(diffgrid_setup):
     np.testing.assert_allclose(actual, expected, rtol=3.0e-5, atol=0.0)
 
 
+def test_diffgrid_accepts_range_boundaries_across_dtypes():
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", True)
+        pressure = np.asarray([1.0, 2.0])
+        opa = OpaDiffgrid(
+            _AnalyticTeacher(),
+            np.asarray([25.0, 30.0], dtype=np.float32),
+            pressure,
+        )
+
+        temperature = np.asarray([25.0, 30.0])
+        actual = opa.xsmatrix(temperature, pressure)
+        compiled = jax.jit(opa.xsmatrix)(temperature)
+
+        assert np.all(np.isfinite(np.asarray(actual)))
+        assert np.all(np.isfinite(np.asarray(compiled)))
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)
+
+
 def test_diffgrid_improves_on_linear_log_interpolation(diffgrid_setup):
     opa, teacher, pressure, _ = diffgrid_setup
     temperature = np.asarray([720.0, 1000.0, 1700.0])

--- a/tests/unittests/opacity/dit/lpffilter_test.py
+++ b/tests/unittests/opacity/dit/lpffilter_test.py
@@ -174,8 +174,8 @@ def test_lpffilter_aliasing_area(i, figure=False):
     elif i==-1:
         diff = noaliase_area[-filter_length_oneside-1:] - shapefilter[0:filter_length_oneside+1]
     res = jnp.max(jnp.abs(diff))
-    #print("max diff",res)
-    assert res < 1.e-16 #2.7755575615628914e-17, 5.55111512e-17
+    tolerance = jnp.finfo(shapefilter.dtype).eps
+    assert res < tolerance
 
     if figure:
         import matplotlib.pyplot as plt

--- a/tests/unittests/rt/atmrt/common_test.py
+++ b/tests/unittests/rt/atmrt/common_test.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from exojax.rt.common import ArtCommon
+
+
+def test_gravity_profile_obeys_inverse_square_law(monkeypatch):
+    art = ArtCommon(
+        pressure_top=1.0e-2,
+        pressure_btm=1.0,
+        nlayer=2,
+        warn_no_nu_grid=False,
+    )
+    normalized_height = np.array([0.8, 0.2])
+    normalized_radius_lower = np.array([1.2, 1.0])
+    monkeypatch.setattr(
+        art,
+        "atmosphere_height",
+        lambda *_: (normalized_height, normalized_radius_lower),
+    )
+
+    gravity_btm = 100.0
+    gravity = art.gravity_profile(
+        temperature=np.ones(2),
+        mean_molecular_weight=np.ones(2),
+        radius_btm=1.0,
+        gravity_btm=gravity_btm,
+    )
+
+    normalized_radius_layer = normalized_radius_lower + 0.5 * normalized_height
+    expected = gravity_btm / normalized_radius_layer**2
+    assert gravity.shape == (2, 1)
+    np.testing.assert_allclose(np.asarray(gravity[:, 0]), expected)


### PR DESCRIPTION
## Summary

  - Fix `ArtCommon.gravity_profile` to follow the inverse-square law.
  - Add a regression test for the gravity profile and its output shape.
  - Allow Diffgrid boundary temperatures to tolerate dtype-level rounding in both eager and JIT paths.
  - Make the LPF aliasing test tolerance consistent with the generated filter dtype.

  ## Root cause

  `gravity_profile` divided the bottom gravity by the normalized radius instead of its square. Since the normalized
  radius is `r / R_btm`, the previous implementation scaled as `1/r`, while Newtonian gravity requires `1/r**2`.

  ## Influence
  less influence on emission/reflection spectra, but it might affect transmission spectrum at high latitude 
  


  ## Validation

  - Opacity unit tests: 246 passed
  - Gravity and atmospheric-layer tests: 6 passed
  - Diffgrid boundary tests verified in eager and JIT modes
  - `git diff --check`: passed