### PR TITLE
atm: fix Ackerman-Marley density conversion

### DIFF
--- a/src/exojax/atm/atmphys.py
+++ b/src/exojax/atm/atmphys.py
@@ -9,10 +9,11 @@ from exojax.atm.amclouds import get_value_at_smooth_index
 from exojax.atm.amclouds import mixing_ratio_cloud_profile
 from exojax.atm.atmprof import pressure_scale_height
 from exojax.atm.atmconvert import mmr_to_vmr
+from exojax.atm.idealgas import number_density
 from exojax.atm.vterm import terminal_velocity
 from exojax.atm.viscosity import calc_vfactor
 from exojax.atm.viscosity import eta_Rosner
-from exojax.utils.constants import kB, m_u
+from exojax.utils.constants import m_u
 import warnings
 from jax import vmap
 import jax.numpy as jnp
@@ -141,9 +142,10 @@ class AmpAmcloud(AmpCloud):
             rw (array): Parameter in the lognormal distribution of condensate size, defined by (9) in AM01
             MMR_condensate (array): Mass Mixing Ratio (MMR) of condensates
         """
-        # density difference
-        rho = mean_molecular_weight * m_u * pressures / (kB * temperatures)
-        drho = self.pdb.condensate_substance_density - rho
+        # atmospheric density
+        rho_atm = mean_molecular_weight * m_u * number_density(
+            pressures, temperatures
+        )
 
         # saturation pressure
         psat = self.pdb.saturation_pressure(temperatures)
@@ -164,8 +166,14 @@ class AmpAmcloud(AmpCloud):
         eta_dvisc = self.dynamic_viscosity(temperatures)
 
         # terminal velocity
-        vf_vmap = vmap(terminal_velocity, (None, None, 0, 0, 0))
-        vterminal = vf_vmap(self.rcond_arr, gravity, eta_dvisc, drho, rho)
+        vf_vmap = vmap(terminal_velocity, (None, None, 0, None, 0))
+        vterminal = vf_vmap(
+            self.rcond_arr,
+            gravity,
+            eta_dvisc,
+            self.pdb.condensate_substance_density,
+            rho_atm,
+        )
 
         # condensate size
         vfind_rw = vmap(find_rw, (None, 0, None), 0)

--- a/src/exojax/atm/vterm.py
+++ b/src/exojax/atm/vterm.py
@@ -103,12 +103,12 @@ def terminal_velocity(r, gravity, dynamic_viscosity, rho_cloud, rho_atm, Nkn=0.0
 
         >>> #terminal velocity at T=300K, for Earth atmosphere/gravity.
         >>> g=980.
-        >>> drho=1.0
+        >>> rho_cloud=1.0
         >>> rho=1.29*1.e-3 #g/cm3
         >>> vfactor,Tr=vc.calc_vfactor(atm="Air")
         >>> eta=vc.eta_Rosner(300.0,vfactor)
         >>> r=jnp.logspace(-5,0,70)
-        >>> terminal_velocity(r,g,eta,drho,rho) #terminal velocity (cm/s)
+        >>> terminal_velocity(r,g,eta,rho_cloud,rho) #terminal velocity (cm/s)
     """
     drho = rho_cloud - rho_atm
     ND = Ndavies(r, gravity, dynamic_viscosity, drho, rho_atm)

--- a/tests/unittests/atm/am01_test.py
+++ b/tests/unittests/atm/am01_test.py
@@ -1,11 +1,22 @@
+import jax.numpy as jnp
+import pytest
+
 from exojax.atm import viscosity
 from exojax.atm import atmprof
 from exojax.atm import vterm
-import jax.numpy as jnp
-import pytest
+from exojax.atm.atmphys import AmpAmcloud
 from exojax.atm.amclouds import sigmag_from_effective_radius
 from exojax.atm.amclouds import effective_radius
 from exojax.atm.amclouds import get_rg
+from exojax.utils.constants import bar_cgs, kB, m_u
+
+
+class _DummyPdb:
+    condensate_substance_density = 0.84
+
+    def saturation_pressure(self, temperatures):
+        return jnp.array([10.0, 1.0e4])
+
 
 def test_viscosity():
     T = 1000.0  # K
@@ -23,13 +34,60 @@ def test_pressure_scale_height_for_Earth():
 
 def test_terminal_velocity():
     g = 980.0
-    drho = 1.0
+    rho_cloud = 1.0
     rho = 1.29 * 1.0e-3  # g/cm3
     vfactor, Tr = viscosity.calc_vfactor(atm="Air")
     eta = viscosity.eta_Rosner(300.0, vfactor)
     r = jnp.logspace(-5, 0, 70)
-    vfall = vterm.terminal_velocity(r, g, eta, drho, rho)
+    vfall = vterm.terminal_velocity(r, g, eta, rho_cloud, rho)
     assert jnp.mean(vfall) == pytest.approx(328.12296)
+
+
+def test_calc_ammodel_rw_uses_cgs_density_once():
+    # The deep layer separates a missing bar conversion from double subtraction.
+    pressures = jnp.array([100.0, 1000.0])
+    temperatures = jnp.full_like(pressures, 300.0)
+    mean_molecular_weight = 2.22
+    gravity = 2478.6
+    target_velocity = 1.0e-2
+    scale_height = atmprof.pressure_scale_height(
+        gravity, temperatures[0], mean_molecular_weight
+    )
+    amp = AmpAmcloud(
+        _DummyPdb(),
+        bkgatm="H2",
+        size_min=1.0e-7,
+        size_max=1.0e-3,
+        nsize=4000,
+    )
+
+    rw, _ = amp.calc_ammodel_rw(
+        pressures,
+        temperatures,
+        mean_molecular_weight=mean_molecular_weight,
+        molecular_mass_condensate=mean_molecular_weight,
+        gravity=gravity,
+        fsed=1.0,
+        Kzz=target_velocity * scale_height,
+        MMR_base=1.0,
+    )
+
+    rho_atm = (
+        mean_molecular_weight
+        * m_u
+        * pressures[1]
+        * bar_cgs
+        / (kB * temperatures[1])
+    )
+    dynamic_viscosity = amp.dynamic_viscosity(temperatures)[1]
+    expected_rw = jnp.sqrt(
+        9.0
+        * dynamic_viscosity
+        * target_velocity
+        / (2.0 * gravity * (_DummyPdb.condensate_substance_density - rho_atm))
+    )
+
+    assert rw[1] == pytest.approx(expected_rw, rel=5.0e-3)
 
 
 def _am01_test_param_set():


### PR DESCRIPTION
## Summary

- compute atmospheric density from bar pressure with the existing cgs-aware `number_density` helper
- pass the absolute condensate density to `terminal_velocity` and map it as a layer-independent scalar
- clarify the terminal-velocity example and add an offline regression test for both density errors

## Root cause

`AmpAmcloud.calc_ammodel_rw` passed pressure in bar directly to a cgs ideal-gas expression, making atmospheric density `1e6` too small. It also passed `rho_cloud - rho_atm` to an API that expects absolute `rho_cloud`, so `terminal_velocity` subtracted atmospheric density a second time.

## Impact

The incorrect atmospheric density changed the Davies number and drag-regime selection, which could substantially bias inferred Ackerman-Marley particle radii. The fix restores the audit case from about 63 microns to 812 microns while leaving the condensate mixing-ratio profile unchanged.

## Validation

- `JAX_PLATFORMS=cpu pytest -q -p no:cacheprovider tests/unittests/atm` — 23 passed, 3 existing warnings
- `git diff --check`
- audit reproducer — 812.354 microns at 100 bar