### PR TITLE
Fix Opart flux-adding source and layer order

### DIFF
--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -591,9 +591,10 @@ class OpartEmisScat(ArtCommon):
         source_vector = piB(temparature, self.nu_grid)
         # -------------------------------------------------
         dtau, single_scattering_albedo, asymmetric_parameter = self.opalayer(params)
-        trans_coeff_i, scat_coeff_i, pihatB_i, _, _, _ = setrt_toonhm(
+        trans_coeff_i, scat_coeff_i, reduced_piB_i, _, _, _ = setrt_toonhm(
             dtau, single_scattering_albedo, asymmetric_parameter, source_vector
         )
+        pihatB_i = (1.0 - trans_coeff_i - scat_coeff_i) * reduced_piB_i
         denom = 1.0 - scat_coeff_i * Rphat_prev
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom
@@ -621,7 +622,7 @@ class OpartEmisScat(ArtCommon):
         # no source term at the bottom
         source_bottom = jnp.zeros_like(self.nu_grid)
         rs_bottom = [reflectivity_bottom, source_bottom]
-        rs, _ = scan(layer_update_function, rs_bottom, layer_params)
+        rs, _ = scan(layer_update_function, rs_bottom, layer_params, reverse=True)
         return rs[1]
 
     def run(self, opalayer, layer_params, flbl):

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -451,7 +451,7 @@ class OpartReflectPure(ArtCommon):
         # rs_bottom = (refectivity_bottom, source_bottom)
         source_bottom = jnp.zeros_like(self.nu_grid)
         rs_bottom = [reflectivity_bottom, source_bottom]
-        rs, _ = scan(layer_update_function, rs_bottom, layer_params)
+        rs, _ = scan(layer_update_function, rs_bottom, layer_params, reverse=True)
         return rs[0] * incoming_flux + rs[1]
 
     def run(self, opalayer, layer_params, flbl):
@@ -496,9 +496,10 @@ class OpartReflectEmis(ArtCommon):
         source_vector = piB(temparature, self.nu_grid)
         # -------------------------------------------------
         dtau, single_scattering_albedo, asymmetric_parameter = self.opalayer(params)
-        trans_coeff_i, scat_coeff_i, pihatB_i, _, _, _ = setrt_toonhm(
+        trans_coeff_i, scat_coeff_i, reduced_piB_i, _, _, _ = setrt_toonhm(
             dtau, single_scattering_albedo, asymmetric_parameter, source_vector
         )
+        pihatB_i = (1.0 - trans_coeff_i - scat_coeff_i) * reduced_piB_i
         denom = 1.0 - scat_coeff_i * Rphat_prev
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom
@@ -528,7 +529,7 @@ class OpartReflectEmis(ArtCommon):
             array: flux [Nnus]
         """
         rs_bottom = [reflectivity_bottom, source_bottom]
-        rs, _ = scan(layer_update_function, rs_bottom, layer_params)
+        rs, _ = scan(layer_update_function, rs_bottom, layer_params, reverse=True)
         return rs[0] * incoming_flux + rs[1]
 
     def run(self, opalayer, layer_params, flbl):

--- a/tests/unittests/multi/opart/opart_emis_scat_test.py
+++ b/tests/unittests/multi/opart/opart_emis_scat_test.py
@@ -50,7 +50,7 @@ def test_forward_emis_scat_opart():
     layer_params = [temperature, opart.pressure, opart.dParr, mixing_ratio]
     flux = opart(layer_params, layer_update_function)
     print(np.mean(flux))
-    ref = 515245.12625256577  # 1/28 2025
+    ref = 3722.9015136863964  # 8/16 2026
     assert np.mean(flux) == pytest.approx(ref)
     plot = False
     if plot:

--- a/tests/unittests/multi/opart/opart_reflection_emis_test.py
+++ b/tests/unittests/multi/opart/opart_reflection_emis_test.py
@@ -60,7 +60,7 @@ def test_forward_reflection_emis_opart():
     flux = opart(
         layer_params, layer_update_function, source_bottom, reflectivity_surface, incoming_flux
     )
-    ref = 1764352.3124300546 #2021 1/28
+    ref = 768779.7391443906  # 8/16 2026
     print(np.mean(flux))
     assert np.mean(flux) == pytest.approx(ref)
     plot = False

--- a/tests/unittests/rt/atmrt/opart_fluxadding_test.py
+++ b/tests/unittests/rt/atmrt/opart_fluxadding_test.py
@@ -1,0 +1,124 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.rt import OpartEmisScat, OpartReflectEmis, OpartReflectPure
+from exojax.rt.planck import piB, piBarr
+from exojax.rt.rtransfer import (
+    rtrun_emis_scat_fluxadding_toonhm,
+    rtrun_reflect_fluxadding_toonhm,
+)
+
+
+class MockOpaLayer:
+    def __init__(self):
+        self.nu_grid = jnp.array([1000.0])
+
+    def __call__(self, params):
+        _, dtau, single_scattering_albedo, asymmetric_parameter = params
+        return dtau, single_scattering_albedo, asymmetric_parameter
+
+
+def layer_update_function(opart):
+    def update(carry, params):
+        return opart.update_layer(carry, params), None
+
+    return update
+
+
+def layer_params_top_to_bottom():
+    temperature = jnp.array([500.0, 1000.0])
+    dtau = jnp.array([0.2, 2.0])
+    single_scattering_albedo = jnp.array([0.3, 0.7])
+    asymmetric_parameter = jnp.array([0.0, 0.2])
+    return [temperature, dtau, single_scattering_albedo, asymmetric_parameter]
+
+
+@pytest.mark.parametrize("opart_class", [OpartEmisScat, OpartReflectEmis])
+def test_opart_layer_uses_full_thermal_source(opart_class):
+    opalayer = MockOpaLayer()
+    opart = opart_class(opalayer, nlayer=2)
+    temperature = 1000.0
+    dtau = jnp.array([1.0e-3])
+    params = [temperature, dtau, jnp.zeros(1), jnp.zeros(1)]
+    initial_carry = [jnp.zeros(1), jnp.zeros(1)]
+
+    _, actual_source = opart.update_layer(initial_carry, params)
+
+    expected_source = (1.0 - jnp.exp(-2.0 * dtau)) * piB(
+        temperature, opalayer.nu_grid
+    )
+    np.testing.assert_allclose(actual_source, expected_source, rtol=1.0e-5)
+
+
+def test_opart_emis_scat_matches_batch_for_top_to_bottom_layers():
+    opalayer = MockOpaLayer()
+    opart = OpartEmisScat(opalayer, nlayer=2)
+    layer_params = layer_params_top_to_bottom()
+
+    actual = opart(layer_params, layer_update_function(opart))
+    temperature, dtau, single_scattering_albedo, asymmetric_parameter = layer_params
+    expected = rtrun_emis_scat_fluxadding_toonhm(
+        dtau[:, None],
+        single_scattering_albedo[:, None],
+        asymmetric_parameter[:, None],
+        piBarr(temperature, opalayer.nu_grid),
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+
+
+def test_opart_reflect_pure_matches_batch_for_top_to_bottom_layers():
+    opalayer = MockOpaLayer()
+    opart = OpartReflectPure(opalayer, nlayer=2)
+    layer_params = layer_params_top_to_bottom()
+    reflectivity_bottom = jnp.array([0.4])
+    incoming_flux = jnp.ones(1)
+
+    actual = opart(
+        layer_params,
+        layer_update_function(opart),
+        reflectivity_bottom,
+        incoming_flux,
+    )
+    _, dtau, single_scattering_albedo, asymmetric_parameter = layer_params
+    expected = rtrun_reflect_fluxadding_toonhm(
+        dtau[:, None],
+        single_scattering_albedo[:, None],
+        asymmetric_parameter[:, None],
+        jnp.zeros((2, 1)),
+        jnp.zeros(1),
+        reflectivity_bottom,
+        incoming_flux,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+
+
+def test_opart_reflect_emis_matches_batch_for_top_to_bottom_layers():
+    opalayer = MockOpaLayer()
+    opart = OpartReflectEmis(opalayer, nlayer=2)
+    layer_params = layer_params_top_to_bottom()
+    source_bottom = jnp.array([0.1])
+    reflectivity_bottom = jnp.array([0.4])
+    incoming_flux = jnp.ones(1)
+
+    actual = opart(
+        layer_params,
+        layer_update_function(opart),
+        source_bottom,
+        reflectivity_bottom,
+        incoming_flux,
+    )
+    temperature, dtau, single_scattering_albedo, asymmetric_parameter = layer_params
+    expected = rtrun_reflect_fluxadding_toonhm(
+        dtau[:, None],
+        single_scattering_albedo[:, None],
+        asymmetric_parameter[:, None],
+        piBarr(temperature, opalayer.nu_grid),
+        source_bottom,
+        reflectivity_bottom,
+        incoming_flux,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)


### PR DESCRIPTION
## Summary

- convert the reduced Toon thermal source to the full layer source before the Opart flux-adding recurrence
- scan top-to-bottom atmospheric inputs in reverse so flux adding proceeds from bottom to top
- apply the layer-order fix to OpartEmisScat, OpartReflectPure, and OpartReflectEmis
- add lightweight Opart-to-batch parity regressions and update affected emission golden values

## Root cause

`setrt_toonhm` returns the reduced source function as its third value, while the flux-adding recurrence requires `(1 - T - S) * reduced_source`. Opart passed the reduced value directly. Opart also scanned the normal top-to-bottom layer arrays in forward order even though the recurrence starts at the bottom boundary.

The source error overestimated a pure-absorption layer with `tau = 1e-3` by about 500.5 times. Heterogeneous multilayer cases also disagreed with the batch solver because of the reversed integration direction.

## Impact

Opart emission and reflection-with-emission now use the same source convention and layer ordering as the canonical batch flux-adding solver. Reflection-only Opart uses the corrected bottom-to-top ordering as well.

## Validation

- `JAX_PLATFORMS=cpu python -m pytest -q tests/unittests/rt/twostream tests/unittests/rt/atmrt/opart_fluxadding_test.py` — 12 passed
- Opart regression and existing golden tests — 8 passed
- `python -m py_compile` for the modified source and new test
- `git diff --check`
