### PR TITLE
Fix surface optical depth integration

### DIFF
--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -2,11 +2,23 @@ import jax.numpy as jnp
 from exojax.rt.common import ArtCommon
 from exojax.rt.planck import piB, piBarr
 from exojax.rt.rtransfer import rtrun_reflect_fluxadding_toonhm, setrt_toonhm
-from exojax.utils.indexing import get_smooth_index
 from exojax.rt.common import ArtCommon
 
 import jax.numpy as jnp
 from jax.lax import scan
+
+
+def _surface_optical_depth(dtau, pressure_boundary, pressure_surface):
+    """Integrate layer optical depths down to a surface pressure."""
+    log_pressure_boundary = jnp.log10(pressure_boundary)
+    log_pressure_surface = jnp.log10(pressure_surface)
+    layer_fraction = jnp.clip(
+        (log_pressure_surface - log_pressure_boundary[:-1])
+        / jnp.diff(log_pressure_boundary),
+        0.0,
+        1.0,
+    )
+    return jnp.sum(dtau * layer_fraction[:, jnp.newaxis], axis=0)
 
 
 class ArtAbsPure(ArtCommon):
@@ -50,15 +62,8 @@ class ArtAbsPure(ArtCommon):
         if mu_out is not None:
             factor = factor + 1.0 / mu_out
 
-        logk = jnp.log10(self.pressure_decrease_rate)
-        logp_btm = jnp.log10(self.pressure) + (self.reference_point - 1.0) * logk
-        logp_surface = jnp.log10(pressure_surface)
-        smooth_index = get_smooth_index(logp_btm, logp_surface)
-        ind = smooth_index.astype(int)
-        res = smooth_index - jnp.floor(smooth_index)
-        stepfunc = jnp.heaviside(logp_surface - logp_btm, 0.5)
-        tau_opaque = (
-            jnp.sum(dtau * stepfunc[:, jnp.newaxis], axis=0) + dtau[ind, :] * res
+        tau_opaque = _surface_optical_depth(
+            dtau, self.pressure_boundary, pressure_surface
         )
         trans = jnp.exp(-factor * tau_opaque)
 
@@ -93,17 +98,8 @@ class ArtAbsPure(ArtCommon):
         # Reshape dtau_ckd to 2D for calculations
         dtau_2d = dtau_ckd.reshape((nlayer, Ng * Nbands))
         
-        # Compute absorption using same logic as standard run method
-        logk = jnp.log10(self.pressure_decrease_rate)
-        logp_btm = jnp.log10(self.pressure) + (self.reference_point - 1.0) * logk
-        logp_surface = jnp.log10(pressure_surface)
-        smooth_index = get_smooth_index(logp_btm, logp_surface)
-        ind = smooth_index.astype(int)
-        res = smooth_index - jnp.floor(smooth_index)
-        stepfunc = jnp.heaviside(logp_surface - logp_btm, 0.5)
-        
-        tau_opaque = (
-            jnp.sum(dtau_2d * stepfunc[:, jnp.newaxis], axis=0) + dtau_2d[ind, :] * res
+        tau_opaque = _surface_optical_depth(
+            dtau_2d, self.pressure_boundary, pressure_surface
         )
         trans_2d = jnp.exp(-factor * tau_opaque)
         spectrum_2d = trans_2d * incoming_flux_2d

--- a/tests/unittests/rt/atmrt/artabs_test.py
+++ b/tests/unittests/rt/atmrt/artabs_test.py
@@ -4,6 +4,18 @@ from exojax.utils.grids import wavenumber_grid
 import jax.numpy as jnp
 
 
+def _toy_artabs_case():
+    art = ArtAbsPure(
+        pressure_top=1.0e-3,
+        pressure_btm=1.0e1,
+        nlayer=5,
+        nu_grid=jnp.array([1.0]),
+    )
+    dtau = jnp.array([[1.0], [2.0], [4.0], [8.0], [16.0]])
+    incoming_flux = jnp.ones(1)
+    return art, dtau, incoming_flux
+
+
 def test_artabs_run_at_toa():
     """Test the run method of ArtAbsPure at TOA
     Note:
@@ -36,6 +48,46 @@ def test_artabs_run_at_ground():
     f = art.run(dtau, pressure_surface=ps, incoming_flux=incf, mu_in=1.0, mu_out=None)
 
     assert f[0] == pytest.approx(jnp.exp(-(3.5 + deltalogp)))
+
+
+@pytest.mark.parametrize(
+    ("pressure_surface", "expected_tau"),
+    [
+        (1.0, 11.0),
+        (10**-0.5, 7.0),
+        (1.0e-3, 0.5),
+    ],
+)
+def test_artabs_run_partial_layer(pressure_surface, expected_tau):
+    art, dtau, incoming_flux = _toy_artabs_case()
+
+    spectrum = art.run(
+        dtau,
+        pressure_surface=pressure_surface,
+        incoming_flux=incoming_flux,
+        mu_in=1.0,
+        mu_out=None,
+    )
+
+    assert spectrum[0] == pytest.approx(jnp.exp(-expected_tau))
+
+
+def test_artabs_run_ckd_partial_layer():
+    art, dtau, incoming_flux = _toy_artabs_case()
+    dtau_ckd = jnp.stack([dtau, 2.0 * dtau], axis=1)
+    weights = jnp.array([0.25, 0.75])
+
+    spectrum = art.run_ckd(
+        dtau_ckd,
+        pressure_surface=1.0,
+        incoming_flux=incoming_flux,
+        mu_in=1.0,
+        mu_out=None,
+        weights=weights,
+    )
+
+    expected = 0.25 * jnp.exp(-11.0) + 0.75 * jnp.exp(-22.0)
+    assert spectrum[0] == pytest.approx(expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- integrate `ArtAbsPure` optical depth using all pressure boundaries
- share the corrected integration between the line-by-line and CKD paths
- add lightweight regression tests for partial layers, exact boundaries, the top layer, and CKD quadrature

## Root cause

The previous implementation located the surface using layer-bottom boundaries, but applied the fractional contribution to `dtau[ind]`. That layer was already included in the full-layer sum; the surface was inside `dtau[ind + 1]`. Exact boundary matches also counted half a layer through `heaviside(..., 0.5)`.

## Impact

For the regression case, the previous optical depth was 9 instead of 11, overestimating transmission by `exp(2)`. The same indexing logic was present in `run_ckd`.

The new boundary-fraction formulation preserves log-pressure interpolation while handling interior surfaces, exact boundaries, the top layer, and out-of-range pressures consistently.

## Validation

- `JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/rt/atmrt/artabs_test.py` — 6 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/rt/atmrt` — 32 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/opacity/ckd/abspure_ckd_test.py` — 2 passed
- JIT evaluation returned `tau = 11`; the surface-pressure gradient matched the expected layer slope
- `git diff --check` passed