### PR TITLE
Fix HITRAN all-isotope opacity calculations

### DIFF
--- a/src/exojax/opacity/lpf/api.py
+++ b/src/exojax/opacity/lpf/api.py
@@ -101,7 +101,7 @@ class OpaDirect(OpaCalc):
         self._vmap_doppler_sigma = jit(vmap(doppler_sigma, (None, 0, None)))
 
         if self.dbtype == "hitran":
-            self._vmap_qt = vmap(self.mdb.qr_interp, (None, 0, None))
+            self._vmap_qt = vmap(self.mdb.qr_interp_lines, (0, None))
             self._vmap_gamma = jit(vmap(gamma_hitran, (0, 0, 0, None, None, None)))
         elif self.dbtype == "exomol":
             self._vmap_qt = vmap(self.mdb.qr_interp, (0, None))
@@ -134,7 +134,7 @@ class OpaDirect(OpaCalc):
         dbtype = self.mdb.dbtype
 
         if dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
+            qt = self.mdb.qr_interp_lines(T, Tref_original)
             gammaL = gamma_hitran(
                 P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
             ) + gamma_natural(self.mdb.A)
@@ -189,7 +189,7 @@ class OpaDirect(OpaCalc):
         dbtype = self.mdb.dbtype
 
         if dbtype == "hitran":
-            qt = self._vmap_qt(self.mdb.isotope, Tarr, Tref_original)
+            qt = self._vmap_qt(Tarr, Tref_original)
             gammaLM = self._vmap_gamma(
                 Parr,
                 Tarr,

--- a/src/exojax/opacity/modit/api.py
+++ b/src/exojax/opacity/modit/api.py
@@ -153,7 +153,7 @@ class OpaModit(OpaCalc):
 
         # Compute broadening and line strength based on database type
         if dbtype == "hitran":
-            qt = self.mdb.qr_interp(self.mdb.isotope, T, Tref_original)
+            qt = self.mdb.qr_interp_lines(T, Tref_original)
             gammaL = gamma_hitran(
                 P, T, Pself, self.mdb.n_air, self.mdb.gamma_air, self.mdb.gamma_self
             ) + gamma_natural(self.mdb.A)

--- a/tests/unittests/opacity/opa/opadirect_call_test.py
+++ b/tests/unittests/opacity/opa/opadirect_call_test.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from exojax.test.emulate_mdb import mock_mdbHitemp, mock_mdbExomol
 from exojax.utils.grids import wavenumber_grid
 from exojax.opacity import OpaDirect
@@ -6,8 +8,14 @@ def test_opadirect_hitemp_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")
     mdb = mock_mdbHitemp(multi_isotope=True)
     opa = OpaDirect(mdb, nu_grid=nus)
+    xsv = opa.xsvector(1000.0, 1.0)
+    xsm = opa.xsmatrix(np.array([1000.0, 1200.0]), np.array([1.0, 0.1]))
 
     assert isinstance(opa, OpaDirect)
+    assert xsv.shape == nus.shape
+    assert xsm.shape == (2, len(nus))
+    assert np.all(np.isfinite(xsv))
+    assert np.all(np.isfinite(xsm))
 
 def test_opadirect_exomol_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")

--- a/tests/unittests/opacity/opa/opamodit_call_test.py
+++ b/tests/unittests/opacity/opa/opamodit_call_test.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from exojax.test.emulate_mdb import mock_mdbHitemp, mock_mdbExomol
 from exojax.utils.grids import wavenumber_grid
 from exojax.opacity import OpaModit
@@ -6,8 +8,11 @@ def test_opamodit_hitemp_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")
     mdb = mock_mdbHitemp(multi_isotope=True)
     opa = OpaModit(mdb, nu_grid=nus, allow_32bit=True)
+    xsv = opa.xsvector(1000.0, 1.0)
 
     assert isinstance(opa, OpaModit)
+    assert xsv.shape == nus.shape
+    assert np.all(np.isfinite(xsv))
 
 def test_opamodit_exomol_call():
     nus, wav, res = wavenumber_grid(22920.0, 23100.0, 20000, unit="AA", xsmode="premodit")


### PR DESCRIPTION
## Summary

- use line-specific partition-function ratios for HITRAN/HITEMP opacity calculations
- support all-isotope databases in Direct `xsvector`/`xsmatrix` and MODIT `xsvector`
- add regression coverage for finite vector and matrix outputs with `isotope=0`

## Root cause

`MdbHitran` defaults to `isotope=0`, which means all isotopes, but the affected opacity paths passed that sentinel to the single-isotope `qr_interp` API. Since HITRAN isotope numbers start at 1, this attempted to look up isotope 0 and raised `IndexError`.

The affected paths now use the existing `qr_interp_lines` API, which selects the correct partition-function ratio for each spectral line.

## Impact

Default HITRAN all-isotope databases can now be used by Direct and MODIT opacity calculations without an isotope lookup failure. Explicit single-isotope calculations remain numerically consistent with the existing reference tests.

## Validation

- `pytest -q tests/unittests/opacity/opa/opadirect_call_test.py tests/unittests/opacity/opa/opamodit_call_test.py` — 4 passed
- `pytest -q tests/unittests/opacity/modit/modit_xsection_test.py tests/integration/unittests_long/lpf/lpf_test.py::test_xsection` — 4 passed
- `pytest -q 'tests/integration/unittests_long/lpf/lpf_test.py::test_spectrum[hitemp]'` — 1 passed
- `git diff --check`
