### PR TITLE
Fix linsap coefficients at small optical depth

### DIFF
--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -238,9 +238,19 @@ def coeffs_linsap(dtau_per_mu, trans):
     Returns:
         _type_: beta coefficient, gamma coefficient
     """
-    fac = (1.0 - trans) / dtau_per_mu
-    beta = 1.0 - fac
-    gamma = -trans + fac
+    # Use the series near zero; safe_dtau also keeps the inactive branch AD-safe.
+    small = jnp.abs(dtau_per_mu) < 1.0e-3
+    safe_dtau = jnp.where(small, 1.0, dtau_per_mu)
+    fac = -jnp.expm1(-dtau_per_mu) / safe_dtau
+
+    beta_small = dtau_per_mu * (
+        0.5 + dtau_per_mu * (-1.0 / 6.0 + dtau_per_mu / 24.0)
+    )
+    gamma_small = dtau_per_mu * (
+        0.5 + dtau_per_mu * (-1.0 / 3.0 + dtau_per_mu / 8.0)
+    )
+    beta = jnp.where(small, beta_small, 1.0 - fac)
+    gamma = jnp.where(small, gamma_small, -trans + fac)
     return beta, gamma
 
 

--- a/tests/unittests/rt/atmrt/emispure_intensity_test.py
+++ b/tests/unittests/rt/atmrt/emispure_intensity_test.py
@@ -1,13 +1,30 @@
 import jax.numpy as jnp
 import pytest
+from jax import jacfwd, jit
 
 from exojax.rt import ArtEmisPure
 from exojax.rt.planck import piBarr
 from exojax.rt.rtransfer import (
+    coeffs_linsap,
     rtrun_emis_pureabs_ibased,
     rtrun_emis_pureabs_ibased_flux_from_intensity,
     rtrun_emis_pureabs_ibased_intensity,
 )
+
+
+def test_linsap_coefficients_at_small_optical_depth():
+    x = jnp.array([0.0, 1.0e-8], dtype=jnp.float32)
+    expected = jnp.array([0.0, 5.0e-9], dtype=jnp.float32)
+
+    beta, gamma = jit(coeffs_linsap)(x, jnp.exp(-x))
+
+    assert beta == pytest.approx(expected, rel=1.0e-6, abs=0.0)
+    assert gamma == pytest.approx(expected, rel=1.0e-6, abs=0.0)
+
+    derivatives = jacfwd(
+        lambda value: jnp.stack(coeffs_linsap(value, jnp.exp(-value)))
+    )(jnp.float32(0.0))
+    assert derivatives == pytest.approx(jnp.full(2, 0.5), rel=1.0e-6)
 
 
 def test_ibased_intensity_reconstructs_flux():


### PR DESCRIPTION
## Summary

- evaluate the linsap coefficients with Taylor series at zero and small optical depth
- use `expm1` and an AD-safe denominator outside the small-value branch
- add float32 regression coverage for coefficient values and zero-point derivatives

## Root cause

The original `(1 - exp(-x)) / x` evaluation becomes `0 / 0` at `x = 0`. For tiny float32 values such as `x = 1e-8`, `exp(-x)` rounds to one, causing catastrophic cancellation and producing `beta ≈ 1` and `gamma ≈ -1` instead of values near `x / 2`.

## Numerical formulation

Let $x = \Delta\tau / \mu$ be the optical depth of a layer along a ray and $T = e^{-x}$ its transmission. If the source function varies linearly between the upper and lower layer boundaries,

$$
S(t) = S_n + \frac{t}{x}\left(S_{n+1} - S_n\right),
$$

the layer contribution to the outgoing intensity is

$$
\Delta I = \int_0^x S(t)e^{-t}\,dt = \beta S_n + \gamma S_{n+1}.
$$

Defining

$$
f(x) = \frac{1-e^{-x}}{x},
$$

gives the exact coefficients

$$
\beta = 1-f(x), \qquad \gamma = f(x)-e^{-x}.
$$

They satisfy $\beta + \gamma = 1-e^{-x}$, so a constant source recovers the usual isothermal-layer emission. Near zero,

$$
\beta = \frac{x}{2} - \frac{x^2}{6} + \frac{x^3}{24} + O(x^4),
$$

$$
\gamma = \frac{x}{2} - \frac{x^2}{3} + \frac{x^3}{8} + O(x^4).
$$

Therefore both coefficients approach zero with derivative $1/2$, and an optically thin layer contributes the trapezoidal limit $\Delta I \approx x(S_n + S_{n+1})/2$. The implementation evaluates these series directly for $|x| < 10^{-3}$, uses `expm1` for the regular branch, and substitutes a safe inactive-branch denominator so automatic differentiation remains finite at $x=0$.

## Impact

The linsap emission solver now returns finite, accurate coefficients for transparent and nearly transparent layers while preserving finite automatic derivatives at zero optical depth.

## Validation

- `JAX_PLATFORMS=cpu NUMBA_DISABLE_JIT=1 pytest -q tests/unittests/rt` — 45 passed
- `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 pytest -q tests/unittests/rt/atmrt/emispure_intensity_test.py` — 6 passed
- `ruff check src/exojax/rt/rtransfer.py tests/unittests/rt/atmrt/emispure_intensity_test.py`
- `git diff --check`