### PR TITLE
Fix trans2E3 limits and float32 stability

### DIFF
--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -61,7 +61,14 @@ def trans2E3(x):
     Returns:
         Transmission function T=2 E3(x)
     """
-    return (1.0 - x) * jnp.exp(-x) + x**2 * E1(x)
+    x = jnp.asarray(x)
+    float_dtype = jnp.result_type(x, 1.0)
+    # Keep x**2 and its reverse-mode cotangent below dtype overflow.
+    too_large = x >= jnp.sqrt(jnp.finfo(float_dtype).max)
+    x_eval = jnp.where(too_large, 1.0, x)
+    x_e1 = jnp.where(x_eval == 0.0, 1.0, x_eval)
+    value = (1.0 - x_eval) * jnp.exp(-x_eval) + x_eval**2 * E1(x_e1)
+    return jnp.where(too_large, 0.0, value)
 
 
 @jit
@@ -75,9 +82,9 @@ def rtrun_emis_pureabs_fbased2st(dtau, source_matrix):
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
     Nnus = jnp.shape(dtau)[1]
-    TransM = jnp.where(dtau == 0, 1.0, trans2E3(dtau))
+    TransM = trans2E3(dtau)
     Qv = jnp.vstack([(1 - TransM) * source_matrix, jnp.zeros(Nnus)])
-    return jnp.nansum(
+    return jnp.sum(
         Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), TransM]), axis=0), axis=0
     )
 
@@ -95,9 +102,9 @@ def rtrun_emis_pureabs_fbased2st_surface(dtau, source_matrix, source_surface):
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
     Nnus = jnp.shape(dtau)[1]
-    trans = jnp.where(dtau == 0, 1.0, trans2E3(dtau))
+    trans = trans2E3(dtau)
     Qv = jnp.vstack([(1 - trans) * source_matrix, source_surface])
-    return jnp.nansum(
+    return jnp.sum(
         Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), trans]), axis=0), axis=0
     )
 

--- a/src/exojax/special/expn.py
+++ b/src/exojax/special/expn.py
@@ -28,16 +28,26 @@ def E1(x):
     C3 = 21.0996530827
     C4 = 3.9584969228
 
-    x2 = x**2
-    x3 = x**3
-    x4 = x**4
-    x5 = x**5
-    ep1A = -jnp.log(x) + A0 + A1 * x + A2 * x2 + A3 * x3 + A4 * x4 + A5 * x5
+    # Branch-local inputs keep the inactive expression from contaminating autodiff.
+    use_small_x = x <= 1.0
+    x_small = jnp.where(use_small_x, x, 1.0)
+    x_large = jnp.where(use_small_x, 1.0, x)
+
+    x2 = x_small**2
+    x3 = x_small**3
+    x4 = x_small**4
+    x5 = x_small**5
+    ep1A = -jnp.log(x_small) + A0 + A1 * x_small + A2 * x2 + A3 * x3 + A4 * x4 + A5 * x5
+
+    z = 1.0 / x_large
+    z2 = z**2
+    z3 = z**3
+    z4 = z**4
     ep1B = (
-        jnp.exp(-x)
-        / x
-        * (x4 + B1 * x3 + B2 * x2 + B3 * x + B4)
-        / (x4 + C1 * x3 + C2 * x2 + C3 * x + C4)
+        jnp.exp(-x_large)
+        * z
+        * (1.0 + B1 * z + B2 * z2 + B3 * z3 + B4 * z4)
+        / (1.0 + C1 * z + C2 * z2 + C3 * z3 + C4 * z4)
     )
-    ep = jnp.where(x <= 1.0, ep1A, ep1B)
+    ep = jnp.where(use_small_x, ep1A, ep1B)
     return ep

--- a/tests/unittests/opacity/xs/expint_test.py
+++ b/tests/unittests/opacity/xs/expint_test.py
@@ -1,16 +1,69 @@
 import numpy as np
+import jax
+import jax.numpy as jnp
 from scipy.special import expn
 from exojax.rt import rtransfer as rt
-import jax.numpy as jnp
-import pytest
+from exojax.special.expn import E1
 
 
 def test_comparison_expint():
+    x = np.logspace(-4, 1.9, 1000).astype(np.float32)
+    dif = np.abs(2.0 * expn(3, x) - rt.trans2E3(x))
+    assert np.max(dif) < 2.0e-7
 
-    x = np.logspace(-4, 1.9, 1000)
-    dif = 2.0*expn(3, x)-rt.trans2E3(x)
-    assert np.max(dif) < 2.e-7
+
+def test_trans2E3_zero_limit_and_reverse_gradient():
+    x = jnp.float32(0.0)
+    np.testing.assert_allclose(rt.trans2E3(x), 1.0)
+    np.testing.assert_allclose(jax.grad(rt.trans2E3)(x), -2.0)
 
 
-if __name__ == '__main__':
+def test_trans2E3_reverse_gradient_near_zero():
+    gradient = jax.grad(rt.trans2E3)(jnp.float32(1.0e-20))
+    np.testing.assert_allclose(gradient, -2.0)
+
+
+def test_large_float32_optical_depth():
+    x = jnp.float32(1.0e10)
+    np.testing.assert_allclose(E1(x), 0.0)
+    np.testing.assert_allclose(jax.grad(E1)(x), 0.0)
+    np.testing.assert_allclose(rt.trans2E3(x), 0.0)
+
+    dtau = jnp.array([[0.1], [1.0e10]], dtype=jnp.float32)
+    source = jnp.array([[1.0], [2.0]], dtype=jnp.float32)
+    flux = rt.rtrun_emis_pureabs_fbased2st(dtau, source)
+    np.testing.assert_allclose(flux, [1.8325829], rtol=1.0e-6)
+
+    def objective(d, s):
+        return jnp.sum(rt.rtrun_emis_pureabs_fbased2st(d, s))
+
+    gradients = jax.grad(objective, argnums=(0, 1))(dtau, source)
+    assert all(jnp.all(jnp.isfinite(gradient)) for gradient in gradients)
+
+    x_overflow = jnp.float32(1.0e20)
+    np.testing.assert_allclose(rt.trans2E3(x_overflow), 0.0)
+    np.testing.assert_allclose(jax.grad(rt.trans2E3)(x_overflow), 0.0)
+
+
+def test_fbased2st_zero_optical_depth_reverse_gradient():
+    source = jnp.ones((1, 1), dtype=jnp.float32)
+
+    def flux(x):
+        return rt.rtrun_emis_pureabs_fbased2st(x.reshape(1, 1), source)[0]
+
+    gradient = jax.grad(flux)(jnp.float32(0.0))
+    np.testing.assert_allclose(gradient, 2.0)
+
+    source_surface = jnp.full(1, 3.0, dtype=jnp.float32)
+
+    def flux_with_surface(x):
+        return rt.rtrun_emis_pureabs_fbased2st_surface(
+            x.reshape(1, 1), source, source_surface
+        )[0]
+
+    gradient_with_surface = jax.grad(flux_with_surface)(jnp.float32(0.0))
+    np.testing.assert_allclose(gradient_with_surface, -4.0)
+
+
+if __name__ == "__main__":
     test_comparison_expint()

--- a/tests/unittests/opacity/xs/f64/expint_f64_test.py
+++ b/tests/unittests/opacity/xs/f64/expint_f64_test.py
@@ -4,11 +4,12 @@ from exojax.rt import rtransfer as rt
 
 
 def test_comparison_expint():
-    from jax import config  
+    from jax import config
+
     config.update("jax_enable_x64", True)
 
     x = np.logspace(-4, 1.9, 1000)
-    dif = 2.0 * expn(3, x) - rt.trans2E3(x)
+    dif = np.abs(2.0 * expn(3, x) - rt.trans2E3(x))
     assert np.max(dif) < 4.0e-8
 
 


### PR DESCRIPTION
## Summary

- make the Abramowitz-Stegun `E1` approximation safe in both `jnp.where` branches
- handle the removable singularity of `trans2E3` at zero with the correct reverse-mode derivative
- avoid float32 overflow for very large optical depths
- stop silently dropping non-finite radiative-transfer contributions
- add float32, limit, reverse-mode, surface, and radiative-transfer regression tests

## Root cause and numerical formulation

The two-stream transmission is evaluated through

$$
T(x) = 2E_3(x) = (1-x)e^{-x} + x^2 E_1(x).
$$

Although $E_1(0)=+\infty$, its contribution has the removable limit

$$
E_1(x) = -\gamma - \log x + O(x),
\qquad
\lim_{x\to0^+} x^2E_1(x)=0,
$$

so

$$
T(0)=1.
$$

Using $\frac{d}{dx}E_n(x)=-E_{n-1}(x)$ and $E_2(0)=1$ also gives

$$
T'(0)=2E_3'(0)=-2E_2(0)=-2.
$$

The previous expression formed `0 * E1(0)`, producing NaN. A caller-side `where` hid the forward value but allowed the non-finite VJP to contaminate reverse-mode differentiation. `trans2E3` now supplies a finite branch-local argument to `E1`, preserving both $T(0)=1$ and $T'(0)=-2$.

For $x>1$, the Abramowitz-Stegun rational approximation was previously evaluated as fourth-order polynomials in $x$. With $z=1/x$, it is now evaluated as

$$
E_1(x) \simeq e^{-x}z
\frac{1+B_1z+B_2z^2+B_3z^3+B_4z^4}
{1+C_1z+C_2z^2+C_3z^3+C_4z^4}.
$$

This is algebraically equivalent but avoids the float32 `x**4` overflow and the resulting `inf / inf`. `trans2E3` additionally guards the range where `x**2` or its reverse-mode cotangent would overflow; at that scale the $e^{-x}$ transmission is already below the representable range and the correct floating-point result is zero.

The higher-level zero-depth `where` expressions were removed so the physical zero-depth derivative is retained. The final reductions use `sum` instead of `nansum`, preventing future non-finite internal values from becoming plausible but incorrect spectra.

## Impact

- `trans2E3(0)` changes from NaN to `1`.
- `jax.grad(trans2E3)(0)` changes from NaN to `-2`.
- the audited float32 case changes from `0.16741711` to `1.8325829`.
- large-optical-depth forward values and reverse-mode gradients remain finite.
- `E1(0)` remains `+inf`, which is mathematically correct.

## Validation

- `JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu pytest -q tests/unittests/opacity/xs` — 24 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu pytest -q tests/unittests/rt` — 44 passed
- `git diff --check` — passed