### PR TITLE
Fix variable Gaussian response velocity coordinate

### DIFF
--- a/src/exojax/postproc/response.py
+++ b/src/exojax/postproc/response.py
@@ -175,7 +175,7 @@ def ipgauss_variable_sampling(nusd, nus, spectrum, beta_variable, RV):
     def convolve_ipgauss_scan(carry, arr):
         nusd_each = arr[0]
         beta_each = arr[1]
-        dvgrid = c * (jnp.log1p(1.0 - nus / nusd_each))
+        dvgrid = c * jnp.log(nusd_each / nus)
         kernel = jnp.exp(-((dvgrid + RV) ** 2) / (2.0 * beta_each**2))
         kernel = kernel / jnp.sum(kernel)
         return carry, kernel @ spectrum

--- a/tests/unittests/postproc/response/response_test.py
+++ b/tests/unittests/postproc/response/response_test.py
@@ -239,6 +239,23 @@ def test_ipgauss_variable_sampling_using_constant_beta_array(fig=False):
         plt.show()
 
 
+def test_ipgauss_variable_sampling_handles_wide_wavenumber_range():
+    nus = np.geomspace(1.0, 4.0, 5)
+    nusd = np.array([1.0])
+    spectrum = np.arange(1.0, 6.0)
+    beta_variable = np.array([c])
+
+    result = ipgauss_variable_sampling(
+        nusd, nus, spectrum, beta_variable, RV=0.0
+    )
+
+    dvgrid = c * np.log(nusd[0] / nus)
+    kernel = np.exp(-(dvgrid**2) / (2.0 * beta_variable[0] ** 2))
+    expected = np.array([kernel @ spectrum / np.sum(kernel)])
+    assert np.all(np.isfinite(result))
+    np.testing.assert_allclose(result, expected, rtol=1.0e-6)
+
+
 def test_SopInstProfile_ola(fig=False):
     from exojax.postproc.specop import SopInstProfile
     


### PR DESCRIPTION
## Summary

- Replace the variable-sampling Gaussian response velocity coordinate with `c * log(nusd / nus)`.
- Add a regression test on a wide log-spaced wavenumber grid that includes `nus / nusd > 2`.

## Root cause

The previous `log1p(1 - nus / nusd)` expression evaluates `log(2 - nus / nusd)`. It only approximates the intended logarithmic coordinate near unity and becomes undefined when `nus / nusd > 2`, contaminating the normalized kernel with NaNs.

## Impact

The response now remains finite across positive wavenumber ratios and is consistent with ExoJAX's existing logarithmic wavenumber coordinate. The function signature, output shape, JIT behavior, and radial-velocity convention are unchanged.

## Validation

- `pytest -q tests/unittests/postproc/response/response_test.py` (10 passed)
- `ruff check --ignore F841 src/exojax/postproc/response.py tests/unittests/postproc/response/response_test.py` (passed; the ignored F841 is pre-existing)
- `git diff --check`