### PR TITLE
Fix Toon conservative scattering limit

### DIFF
--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -34,7 +34,6 @@ from jax.scipy.integrate import trapezoid
 from exojax.signal.integrate import simpson
 from exojax.rt.toon import (
     params_hemispheric_mean,
-    reduced_source_function_isothermal_layer,
     zetalambda_coeffs,
 )
 from exojax.rt.twostream import (
@@ -537,13 +536,9 @@ def setrt_toonhm(dtau, single_scattering_albedo, asymmetric_parameter, source_ma
         single_scattering_albedo, asymmetric_parameter
     )
     zeta_plus, zeta_minus, lambdan = zetalambda_coeffs(gamma_1, gamma_2)
-    trans_coeff, scat_coeff = set_scat_trans_coeffs(
-        zeta_plus, zeta_minus, lambdan, dtau
-    )
+    trans_coeff, scat_coeff = set_scat_trans_coeffs(gamma_1, gamma_2, dtau)
 
-    reduced_piB = reduced_source_function_isothermal_layer(
-        single_scattering_albedo, gamma_1, gamma_2, source_matrix
-    )
+    reduced_piB = source_matrix
 
     return trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan
 
@@ -554,15 +549,8 @@ def settridiag_toohm(
     diagonal_top = 1.0 * jnp.ones_like(trans_coeff[0, :])  # setting b0=1
     upper_diagonal_top = trans_coeff[0, :]
 
-    zeta_plus0 = zeta_plus[0, :]
-    zeta_minus0 = zeta_minus[0, :]
-
     # emission (no reflection)
-    trans_func0 = jnp.exp(-lambdan[0, :] * dtau[0, :])
-    denom = zeta_plus0**2 - (zeta_minus0 * trans_func0) ** 2
-    omtrans = 1.0 - trans_func0
-    fac = zeta_plus0 * omtrans - zeta_minus0 * trans_func0 * omtrans
-    vector_top = (zeta_plus0**2 - zeta_minus0**2) / denom * fac * reduced_piB[0, :]
+    vector_top = (1.0 - trans_coeff[0, :] - scat_coeff[0, :]) * reduced_piB[0, :]
 
     # tridiagonal elements
     (

--- a/src/exojax/rt/toon.py
+++ b/src/exojax/rt/toon.py
@@ -19,10 +19,19 @@ def zetalambda_coeffs(gamma_1, gamma_2):
     Returns:
         _type_: coupling zeta (+), coupling zeta (-), lambda coefficients
     """
-    delta = jnp.sqrt((gamma_1 - gamma_2) / (gamma_1 + gamma_2))
+    gamma_plus = gamma_1 + gamma_2
+    gamma_minus = gamma_1 - gamma_2
+    zero_gamma = gamma_plus == 0.0
+    safe_gamma_plus = jnp.where(zero_gamma, 1.0, gamma_plus)
+    delta_squared = jnp.where(zero_gamma, 1.0, gamma_minus / safe_gamma_plus)
+    delta = jnp.where(zero_gamma, 0.0, jnp.sqrt(delta_squared))
     zeta_plus = 0.5 * (1.0 + delta)
     zeta_minus = 0.5 * (1.0 - delta)
-    lambdan = jnp.sqrt(gamma_1**2 - gamma_2**2)
+    lambda_squared = gamma_minus * gamma_plus
+    zero_lambda = lambda_squared == 0.0
+    lambdan = jnp.where(
+        zero_lambda, 0.0, jnp.sqrt(jnp.where(zero_lambda, 1.0, lambda_squared))
+    )
     return zeta_plus, zeta_minus, lambdan
 
 
@@ -123,7 +132,9 @@ def params_hemispheric_mean(single_scattering_albedo, asymmetric_parameter):
     Returns:
         _type_: gamma_1, gamma_2, mu1
     """
-    gamma_1 = 2.0 - single_scattering_albedo * (1.0 + asymmetric_parameter)
-    gamma_2 = single_scattering_albedo * (1.0 - asymmetric_parameter)
+    absorption = 1.0 - single_scattering_albedo
+    transport = 1.0 - single_scattering_albedo * asymmetric_parameter
+    gamma_1 = transport + absorption
+    gamma_2 = transport - absorption
     mu1 = 0.5
     return gamma_1, gamma_2, mu1

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -265,24 +265,43 @@ def contribution_function_lart(cumT, Q):
     return cumT * Q
 
 
-def set_scat_trans_coeffs(zeta_plus, zeta_minus, lambdan, dtau):
-    """sets scattering and transmission coefficients from zeta and lambda coefficient and dtau
+def set_scat_trans_coeffs(gamma_1, gamma_2, dtau):
+    """sets scattering and transmission coefficients from gamma coefficients and dtau
 
     Args:
-        zeta_plus (_type_): coupling zeta (+) coefficient (e.g. Heng 2017)
-        zeta_minus (_type_): coupling zeta (-) coefficient (e.g. Heng 2017)
-        lambdan (_type_): lambda coefficient
+        gamma_1 (_type_): Toon+89 gamma_1 coefficient
+        gamma_2 (_type_): Toon+89 gamma_2 coefficient
         dtau (_type_): optical depth interval of the layers
 
     Returns:
         _type_: transmission coefficient, scattering coeffcient
     """
-    trans_func = jnp.exp(-lambdan * dtau)  # transmission function (Heng 2017, 3.58)
-    denom = zeta_plus**2 - (zeta_minus * trans_func) ** 2
-    trans_coeff = trans_func * (zeta_plus**2 - zeta_minus**2) / denom
-    scat_coeff = (1.0 - trans_func**2) * zeta_plus * zeta_minus / denom
+    lambda_dtau_squared = jnp.asarray(
+        (gamma_1 - gamma_2) * (gamma_1 + gamma_2) * dtau**2
+    )
+    use_taylor = jnp.abs(lambda_dtau_squared) < jnp.sqrt(
+        jnp.finfo(lambda_dtau_squared.dtype).eps
+    )
 
-    return trans_coeff, scat_coeff
+    safe_squared = jnp.where(use_taylor, 1.0, lambda_dtau_squared)
+    lambda_dtau = jnp.sqrt(safe_squared)
+    trans_func = jnp.exp(-lambda_dtau)
+    phi = -jnp.expm1(-2.0 * lambda_dtau) / (2.0 * lambda_dtau)
+    denom = 1.0 + trans_func**2 + 2.0 * gamma_1 * dtau * phi
+    trans_coeff = 2.0 * trans_func / denom
+    scat_coeff = 2.0 * gamma_2 * dtau * phi / denom
+
+    squared2 = lambda_dtau_squared**2
+    cosh_taylor = 1.0 + lambda_dtau_squared / 2.0 + squared2 / 24.0
+    sinhc_taylor = 1.0 + lambda_dtau_squared / 6.0 + squared2 / 120.0
+    denom_taylor = cosh_taylor + gamma_1 * dtau * sinhc_taylor
+    trans_taylor = 1.0 / denom_taylor
+    scat_taylor = gamma_2 * dtau * sinhc_taylor / denom_taylor
+
+    return (
+        jnp.where(use_taylor, trans_taylor, trans_coeff),
+        jnp.where(use_taylor, scat_taylor, scat_coeff),
+    )
 
 
 def compute_tridiag_diagonals_and_vector(

--- a/tests/unittests/rt/atmrt/opart_fluxadding_test.py
+++ b/tests/unittests/rt/atmrt/opart_fluxadding_test.py
@@ -122,3 +122,19 @@ def test_opart_reflect_emis_matches_batch_for_top_to_bottom_layers():
     )
 
     np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+
+
+def test_reflect_fluxadding_toonhm_conservative_scattering_limit():
+    asymmetric_parameter = jnp.array([[0.0, 0.5, 1.0]])
+    reflected_flux = rtrun_reflect_fluxadding_toonhm(
+        jnp.ones((1, 3)),
+        jnp.ones((1, 3)),
+        asymmetric_parameter,
+        jnp.zeros((1, 3)),
+        jnp.zeros(3),
+        jnp.zeros(3),
+        jnp.ones(3),
+    )
+
+    expected = (1.0 - asymmetric_parameter[0]) / (2.0 - asymmetric_parameter[0])
+    np.testing.assert_allclose(reflected_flux, expected, rtol=1.0e-6)

--- a/tests/unittests/rt/twostream/toon_test.py
+++ b/tests/unittests/rt/twostream/toon_test.py
@@ -20,6 +20,14 @@ def test_zetalambda_coeffs():
     assert jnp.isclose(lambdan, lambdan_ref), f"Expected {jnp.sqrt(3.0)}, got {lambdan}"
 
 
+def test_zetalambda_coeffs_zero_gamma():
+    zeta_plus, zeta_minus, lambdan = zetalambda_coeffs(0.0, 0.0)
+
+    assert jnp.isclose(zeta_plus, 0.5)
+    assert jnp.isclose(zeta_minus, 0.5)
+    assert jnp.isclose(lambdan, 0.0)
+
+
 def test_reduced_source_function_isothermal_layer():
     single_scattering_albedo = 0.5
     gamma_1 = 2.0


### PR DESCRIPTION
## Summary

- evaluate Toon layer transmission and scattering from `gamma_1` and `gamma_2`, retaining the transport scale at the conservative-scattering endpoint
- use a Taylor expansion near zero eigenvalue to keep the forward result and JAX derivatives finite
- remove equivalent `0/0` forms from the hemispheric-mean reduced source and LART top boundary
- add regression coverage for zero gamma and one-layer conservative reflection

## Root cause

At `omega = 1`, the Toon eigenvalue is zero and `zeta_plus = zeta_minus = 0.5`. The previous coefficient formulas therefore evaluated both transmission and scattering as `0/0`. The zeta/eigenvalue representation also loses the finite transport scale needed to recover the endpoint for general asymmetry.

## Impact

A one-layer atmosphere with `tau = 1`, `omega = 1`, and `g = 0` now returns the physical limiting transmission and reflection coefficients `T = S = 0.5` instead of NaN. The LART surface path and forward/reverse JAX derivatives are finite at the same endpoint.

## Validation

- `JAX_PLATFORMS=cpu pytest -q tests/unittests/rt/atmrt/opart_fluxadding_test.py tests/unittests/rt/twostream` — 14 passed
- `JAX_PLATFORMS=cpu NUMBA_DISABLE_JIT=1 pytest -q tests/unittests/rt` — 46 passed
- compared non-endpoint coefficients against the previous formulas over an x64 grid spanning albedo, asymmetry, and optical depth