### PR TITLE
Fix float32 lognormal Mie grid sampling

### DIFF
--- a/src/exojax/special/lognormal.py
+++ b/src/exojax/special/lognormal.py
@@ -67,15 +67,15 @@ def cubeweighted_mean(rg, sigmag):
 
 
 def cubeweighted_std(rg, sigmag):
-    """variance of the cube weighted lognormal distribution
+    """standard deviation of the cube weighted lognormal distribution
 
     Args:
         rg (float)): rg parameter
         sigmag (float): sigmag parameter must be > 1.
 
     Returns:
-        float: variance of the cube weighted lognormal distribution
+        float: standard deviation of the cube weighted lognormal distribution
     """
     mu = cubeweighted_mean(rg, sigmag)
-    var = moment(rg, sigmag, 5) / moment(rg, sigmag, 3)
-    return jnp.sqrt(var - mu**2)
+    log_variance = jnp.log(sigmag) ** 2
+    return mu * jnp.sqrt(jnp.expm1(log_variance))

--- a/tests/unittests/database/clouds/mie_test.py
+++ b/tests/unittests/database/clouds/mie_test.py
@@ -26,6 +26,15 @@ def test_autogrid():
         assert check
 
 
+def test_autogrid_narrow_distribution_float32():
+    rg_nm = np.float32(50.0)
+    sigmag = np.float32(1.0001)
+
+    rgrid = auto_rgrid(rg_nm, sigmag)
+
+    assert cubeweighted_integral_checker(rgrid, rg_nm, sigmag)
+
+
 def test_cubeweighted_integral_checker():
     rg_um = 0.05  # 0.1um = 100nm
     sigmag = 2.0


### PR DESCRIPTION
## Summary

- compute the cube-weighted lognormal standard deviation with a cancellation-free analytic expression
- add a float32 regression test for the narrow default distribution at `rg = 50 nm` and `sigmag = 1.0001`

## Root cause and impact

The previous implementation subtracted two nearly equal moments. In float32 this produced a negative rounded variance and therefore `NaN`. `auto_rgrid` then selected a coarse fallback grid that missed the narrow particle-size distribution completely, causing the sampled PDF and generated Mie coefficients to collapse to zero.

Using `expm1(log(sigmag) ** 2)` preserves the small variance without enabling x64. For the reported case, the sampled cube-weighted PDF integral changes from 0 to 0.99999422.

## Validation

- `JAX_ENABLE_X64=0 python -m pytest -q tests/unittests/database/clouds` (10 passed)
- `JAX_ENABLE_X64=1 python -m pytest -q tests/unittests/database/clouds/mie_test.py` (3 passed)
- `ruff check src/exojax/special/lognormal.py tests/unittests/database/clouds/mie_test.py`

The full unit suite could not be collected in the local environment because the existing RADIS `.egg` installation does not provide a Numba cache locator.