### PR TITLE
Fix PreMODIT single broadening index

### DIFF
--- a/src/exojax/opacity/premodit/premodit.py
+++ b/src/exojax/opacity/premodit/premodit.py
@@ -1405,7 +1405,7 @@ def _check_single_broadening(ngamma_ref_grid, n_Texp_grid):
             "Single broadening parameter: ngamma_ref=",
             ngamma_ref_grid[0],
             "n_Texp=",
-            n_Texp_grid[1],
+            n_Texp_grid[0],
         )
         single_broadening = True
     else:

--- a/tests/unittests/opacity/premodit/premodit_single_broadening_test.py
+++ b/tests/unittests/opacity/premodit/premodit_single_broadening_test.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+from exojax.opacity.premodit.premodit import _check_single_broadening
+
+
+def test_check_single_broadening_with_single_value():
+    assert _check_single_broadening(np.array([1.0]), np.array([0.5])) is True


### PR DESCRIPTION
## Summary

- Use the sole `n_Texp_grid` element when reporting single-broadening parameters.
- Add a focused regression test with one-element NumPy grids.

## Root cause

`_check_single_broadening` verified that `n_Texp_grid` had length one, then accessed index 1 while printing the selected parameter. This raised `IndexError` before single-broadening mode could be returned.

## Impact

PreMODIT single-broadening initialization no longer fails for one-element NumPy broadening grids.

## Validation

- `JAX_PLATFORMS=cpu python -m pytest tests/unittests/opacity/premodit/premodit_single_broadening_test.py -q` (1 passed)
- `JAX_PLATFORMS=cpu NUMBA_DISABLE_JIT=1 python -m pytest tests/unittests/opacity/premodit/opa_xsvector_test.py::test_xsection_premodit_for_single_broadening -q` (2 passed)