### PR TITLE
Fix layer-dependent Kzz cloud radii

### DIFF
--- a/src/exojax/atm/atmphys.py
+++ b/src/exojax/atm/atmphys.py
@@ -176,8 +176,9 @@ class AmpAmcloud(AmpCloud):
         )
 
         # condensate size
-        vfind_rw = vmap(find_rw, (None, 0, None), 0)
-        rw = vfind_rw(self.rcond_arr, vterminal, Kzz / L_cloud)
+        Kzz_over_L = jnp.broadcast_to(Kzz / L_cloud, pressures.shape)
+        vfind_rw = vmap(find_rw, (None, 0, 0), 0)
+        rw = vfind_rw(self.rcond_arr, vterminal, Kzz_over_L)
         # MMR of condensates
         MMR_condensate = mixing_ratio_cloud_profile(
             pressures, pressure_base, fsed, MMR_base

--- a/tests/unittests/atm/am01_test.py
+++ b/tests/unittests/atm/am01_test.py
@@ -90,6 +90,44 @@ def test_calc_ammodel_rw_uses_cgs_density_once():
     assert rw[1] == pytest.approx(expected_rw, rel=5.0e-3)
 
 
+def test_calc_ammodel_rw_with_layer_dependent_kzz():
+    pressures = jnp.array([100.0, 1000.0])
+    temperatures = jnp.full_like(pressures, 300.0)
+    mean_molecular_weight = 2.22
+    gravity = 2478.6
+    scale_height = atmprof.pressure_scale_height(
+        gravity, temperatures[0], mean_molecular_weight
+    )
+    amp = AmpAmcloud(
+        _DummyPdb(),
+        bkgatm="H2",
+        size_min=1.0e-7,
+        size_max=1.0e-3,
+        nsize=4000,
+    )
+
+    def calculate_rw(Kzz):
+        return amp.calc_ammodel_rw(
+            pressures,
+            temperatures,
+            mean_molecular_weight=mean_molecular_weight,
+            molecular_mass_condensate=mean_molecular_weight,
+            gravity=gravity,
+            fsed=1.0,
+            Kzz=Kzz,
+            MMR_base=1.0,
+        )[0]
+
+    Kzz = jnp.array([1.0e-3, 1.0e-2]) * scale_height
+    rw = calculate_rw(Kzz)
+    expected_rw = jnp.array(
+        [calculate_rw(layer_Kzz)[i] for i, layer_Kzz in enumerate(Kzz)]
+    )
+
+    assert rw.shape == pressures.shape
+    assert jnp.array_equal(rw, expected_rw)
+
+
 def _am01_test_param_set():
     rw = 1.0e-4
     fsed = 2.0


### PR DESCRIPTION
## Summary

- Broadcast scalar or profile `Kzz / L` to the atmospheric layer shape.
- Map one `Kzz` value to each layer when solving for the condensate radius.
- Add regression coverage for layer-dependent `Kzz` while preserving scalar compatibility.

## Root cause

`vmap(find_rw, (None, 0, None))` treated `Kzz / L` as an unmapped argument. For a layer-dependent profile, every layer therefore received the complete `Kzz` vector, and `find_rw` returned an extra layer dimension.

## Impact

Layer-dependent `Kzz` now produces `rw` and `rg` with shape `(Nlayer,)` instead of `(Nlayer, Nlayer)`. Existing scalar `Kzz` usage remains supported.

## Validation

- `python -m pytest tests/unittests/atm/am01_test.py -q` — 8 passed
- `python -m pytest tests/unittests/atm -q` — 24 passed, 4 existing warnings
- `git diff --check origin/develop...HEAD`
