### PR TITLE
Fix atomic MODIT VALD matrix dispatch

### DIFF
--- a/src/exojax/opacity/modit/modit.py
+++ b/src/exojax/opacity/modit/modit.py
@@ -901,7 +901,7 @@ def xsmatrix_vald(
     Return:
         xsmS: cross section matrix [N_species x N_layer x N_wav]
     """
-    xsmS = jit(vmap(xsmatrix, (0, 0, None, None, 0, 0, 0, None, 0)))(
+    xsmS = jit(vmap(xsmatrix_zeroscan, (0, 0, None, None, 0, 0, 0, None, 0)))(
         cnuS, indexnuS, R, pmarray, nsigmaDlS, ngammaLMS, SijMS, nu_grid, dgm_ngammaLS
     )
     xsmS = jnp.abs(xsmS)

--- a/tests/unittests/opacity/modit/xsmatrix_vald_test.py
+++ b/tests/unittests/opacity/modit/xsmatrix_vald_test.py
@@ -1,0 +1,42 @@
+import jax.numpy as jnp
+
+from exojax.opacity.modit.modit import xsmatrix_zeroscan
+from exojax.opacity.modit.modit import xsmatrix_vald
+
+
+def test_xsmatrix_vald_zeroscan():
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0, 1003.0])
+    cnuS = jnp.array([[0.5]])
+    indexnuS = jnp.array([[1]])
+    R = 1000.0
+    pmarray = jnp.array([1.0, -1.0, 1.0, -1.0, 1.0])
+    nsigmaDlS = jnp.array([[[0.1]]])
+    ngammaLMS = jnp.array([[[0.2]]])
+    SijMS = jnp.array([[[1.0e-20]]])
+    dgm_ngammaLS = jnp.array([[[0.1, 1.0]]])
+
+    actual = xsmatrix_vald(
+        cnuS,
+        indexnuS,
+        R,
+        pmarray,
+        nsigmaDlS,
+        ngammaLMS,
+        SijMS,
+        nu_grid,
+        dgm_ngammaLS,
+    )
+    expected = xsmatrix_zeroscan(
+        cnuS[0],
+        indexnuS[0],
+        R,
+        pmarray,
+        nsigmaDlS[0],
+        ngammaLMS[0],
+        SijMS[0],
+        nu_grid,
+        dgm_ngammaLS[0],
+    )
+
+    assert actual.shape == (1, 1, 4)
+    assert jnp.array_equal(actual[0], jnp.abs(expected))


### PR DESCRIPTION
## Summary

- Dispatch `xsmatrix_vald` through the defined `xsmatrix_zeroscan` implementation.
- Add a lightweight synthetic regression test for the atomic VALD wrapper.

## Root cause

The legacy `xsmatrix` helper was removed when the zeroscan implementation became the supported path, but `xsmatrix_vald` retained the stale reference. Calling the public wrapper therefore raised `NameError` during JAX tracing.

## Impact

Atomic MODIT callers can invoke `xsmatrix_vald` without hitting an undefined name, while behavior remains aligned with the existing zeroscan implementation.

## Validation

- `pytest -q tests/unittests/opacity/modit/xsmatrix_vald_test.py`
- `NUMBA_DISABLE_JIT=1 pytest -q tests/unittests/opacity/modit/zeroscan_test.py tests/unittests/opacity/modit/xsmatrix_vald_test.py`
- `ruff check src/exojax/opacity/modit/modit.py --select F821`
- `ruff check tests/unittests/opacity/modit/xsmatrix_vald_test.py`
- `git diff --check`