### PR TITLE
Fix CKD opacity for empty bands

### DIFF
--- a/src/exojax/opacity/ckd/api.py
+++ b/src/exojax/opacity/ckd/api.py
@@ -18,6 +18,7 @@ from exojax.opacity.ckd.contracts import CKDTableInfo
 from exojax.opacity.ckd.core import gauss_legendre_grid
 from exojax.opacity.ckd.core import compute_ckd_tables
 from exojax.opacity.ckd.core import interpolate_log_k_2d
+from exojax.opacity.ckd.core import safe_log_k
 from exojax.opacity.ckd.io import _hash_json
 from exojax.opacity.ckd.io import _base_fingerprint
 from exojax.opacity.ckd.io import _ckd_save_as_npz
@@ -230,7 +231,12 @@ class OpaCKD(OpaCalc):
 
         # Initialize storage for all bands
         nnu_bands = len(self.nu_bands)
-        log_kggrid = jnp.zeros((nT, nP, self.Ng, nnu_bands))
+        empty_log_k = safe_log_k(jnp.zeros((), dtype=xsmatrix_full.dtype))
+        log_kggrid = jnp.full(
+            (nT, nP, self.Ng, nnu_bands),
+            empty_log_k,
+            dtype=xsmatrix_full.dtype,
+        )
 
         # Process each spectral band using precise edges
         print(f"Processing {nnu_bands} spectral bands...")

--- a/tests/unittests/opacity/ckd/ckd_api_test.py
+++ b/tests/unittests/opacity/ckd/ckd_api_test.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 import jax.numpy as jnp
 from exojax.opacity.ckd.api import OpaCKD
+from exojax.opacity.ckd.core import safe_log_k
 
 
 class MockBaseOpa:
@@ -23,6 +24,16 @@ class PairedMockBaseOpa:
         return jnp.broadcast_to(
             cross_section[:, None], (cross_section.size, self.nu_grid.size)
         )
+
+
+class SparseMockBaseOpa:
+    """Base opacity mock with an uncovered spectral band."""
+
+    def __init__(self):
+        self.nu_grid = jnp.array([1000.0, 1003.0])
+
+    def xsmatrix(self, T_array, P_array):
+        return jnp.full((T_array.size, self.nu_grid.size), 2.0e-20)
 
 
 def test_opa_ckd_init():
@@ -70,6 +81,18 @@ def test_precompute_tables_uses_cartesian_temperature_pressure_grid():
     expected = T_grid[:, None] + 10.0 * P_grid[None, :]
     actual = jnp.exp(opa_ckd.ckd_info.log_kggrid[:, :, :, 0])
     assert jnp.allclose(actual, expected[:, :, None])
+
+
+def test_precompute_tables_uses_opacity_floor_for_empty_band():
+    opa_ckd = OpaCKD(
+        SparseMockBaseOpa(), Ng=2, band_width=1.0, band_spacing="linear"
+    )
+
+    opa_ckd.precompute_tables(jnp.array([1000.0]), jnp.array([1.0]))
+
+    actual = opa_ckd.xsarray_ckd(1000.0, 1.0)[:, 1]
+    expected = jnp.exp(safe_log_k(jnp.zeros_like(actual)))
+    assert jnp.allclose(actual, expected, rtol=1.0e-6, atol=0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- initialize uncovered CKD bands with the existing finite zero-opacity floor
- preserve the base cross-section dtype when allocating the CKD table
- add a sparse-grid regression test for an empty spectral band

## Root cause

Uncovered bands were skipped after `log_kggrid` had been initialized to zero. The later exponentiation converted the untouched `log(k) = 0` entries into cross sections of `1 cm²`, making empty bands artificially opaque.

## Impact

Empty bands now use the same precision-aware floor as zero cross sections (`1e-30 cm²` for float32 or `1e-100 cm²` for float64), so sparse wavenumber grids remain effectively transparent without introducing non-finite log values.

## Validation

- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu python -m pytest -q tests/unittests/opacity/ckd/ckd_api_test.py tests/unittests/opacity/ckd/ckd_core_test.py tests/unittests/opacity/ckd/ckd_io_test.py tests/unittests/opacity/ckd/test_precompute_tables.py`
- 44 passed