### PR TITLE
Fix float32 Planck forward values and gradients

### DIFF
--- a/src/exojax/rt/planck.py
+++ b/src/exojax/rt/planck.py
@@ -26,8 +26,12 @@ def piBarr(Tarr, nu_grid):
     Note:
        hcperk = hc/k in cgs, fac = 2*h*c*c*pi in cgs
     """
-    
-    return (fac_planck*nu_grid**3)/(jnp.exp(hcperk*nu_grid/Tarr[:, None])-1.0)
+    exponent = (hcperk / Tarr[:, None]) * nu_grid
+    log_numerator = (
+        jnp.log(fac_planck * nu_grid) + 2.0 * jnp.log(nu_grid) - exponent
+    )
+    return jnp.exp(log_numerator) / (-jnp.expm1(-exponent))
+
 
 def piB(T, nu_grid):
     """pi B_nu (Planck Function)
@@ -42,4 +46,8 @@ def piB(T, nu_grid):
     Note:
         hcperk = hc/k in cgs, fac = 2*h*c*c*pi in cgs
     """
-    return (fac_planck * nu_grid**3) / (jnp.exp(hcperk * nu_grid / T) - 1.0)
+    exponent = (hcperk / T) * nu_grid
+    log_numerator = (
+        jnp.log(fac_planck * nu_grid) + 2.0 * jnp.log(nu_grid) - exponent
+    )
+    return jnp.exp(log_numerator) / (-jnp.expm1(-exponent))

--- a/tests/unittests/rt/planck_test.py
+++ b/tests/unittests/rt/planck_test.py
@@ -1,0 +1,61 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.rt.planck import fac_planck, piB, piBarr
+from exojax.utils.constants import hcperk
+
+
+@pytest.mark.parametrize(
+    "planck_function",
+    [
+        lambda temperature, nu_grid: piB(temperature, nu_grid),
+        lambda temperature, nu_grid: piBarr(
+            jnp.atleast_1d(temperature), nu_grid
+        )[0],
+    ],
+    ids=["piB", "piBarr"],
+)
+def test_float32_forward_and_gradients(planck_function):
+    temperature = jnp.float32(100.0)
+    nu_grid = jnp.array(
+        [44.0 * float(temperature) / hcperk, 6200.0], dtype=jnp.float32
+    )
+
+    exponent = hcperk * np.asarray(nu_grid, dtype=np.float64) / float(temperature)
+    expected = fac_planck * np.asarray(nu_grid, dtype=np.float64) ** 3 / np.expm1(
+        exponent
+    )
+    expected_temperature_gradient = (
+        expected
+        * exponent
+        / float(temperature)
+        / (-np.expm1(-exponent))
+    )
+    expected_wavenumber_gradient = expected * (
+        3.0 / np.asarray(nu_grid, dtype=np.float64)
+        - (hcperk / float(temperature)) / (-np.expm1(-exponent))
+    )
+
+    actual = planck_function(temperature, nu_grid)
+    actual_temperature_gradient = jax.jacrev(
+        lambda value: planck_function(value, nu_grid)
+    )(temperature)
+    actual_wavenumber_gradient = jnp.diag(
+        jax.jacrev(lambda value: planck_function(temperature, value))(nu_grid)
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-5, atol=0.0)
+    np.testing.assert_allclose(
+        actual_temperature_gradient,
+        expected_temperature_gradient,
+        rtol=1.0e-5,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        actual_wavenumber_gradient,
+        expected_wavenumber_gradient,
+        rtol=1.0e-5,
+        atol=0.0,
+    )


### PR DESCRIPTION
## Summary

- evaluate the Planck numerator in the log domain and use a negative-exponent `expm1` denominator
- preserve representable float32 forward values and autodiff gradients at large exponents
- add regression coverage for `piB` and `piBarr`, including temperature and wavenumber gradients

## Root cause

The direct `exp(x) - 1` denominator overflows near the reported `x = 89.2` case. Its reverse-mode evaluation loses gradients much earlier, around `x = 44`. Computing `exp(-x)` directly is also insufficient because XLA flushes the intermediate subnormal value before the Planck prefactor can rescale it.

## Impact

Cold, high-wavenumber Planck values that are representable in float32 remain positive, and their gradients remain finite and nonzero.

## Validation

- `JAX_PLATFORMS=cpu python -m pytest tests/unittests/rt/planck_test.py -q` — 2 passed
- `JAX_PLATFORMS=cpu python -m pytest tests/unittests/rt/atmrt/opart_fluxadding_test.py -q` — 6 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu python -m pytest tests/unittests/rt -q` — 49 passed

The broader RT run used `NUMBA_DISABLE_JIT=1` to bypass a local RADIS/Numba cache-locator collection error.