### PR TITLE
Fix direct Mie wavelength units

### DIFF
--- a/src/exojax/opacity/opacont.py
+++ b/src/exojax/opacity/opacont.py
@@ -377,6 +377,9 @@ class OpaMie(OpaCont):
         refraction_index_wavenumber_restricted = self.pdb.refraction_index_wavenumber[
             imin:imax
         ]
+        refraction_index_wavelength_nm_restricted = (
+            self.pdb.refraction_index_wavelength_nm[imin:imax]
+        )
         nind = len(refraction_index_wavenumber_restricted)
         refraction_index_restricted = self.pdb.refraction_index[imin:imax]
 
@@ -395,7 +398,7 @@ class OpaMie(OpaCont):
         for ind_m, m in enumerate(tqdm(refraction_index_restricted)):
             coeff = mie_lognormal_pymiescatt(
                 m,
-                refraction_index_wavenumber_restricted[ind_m],
+                refraction_index_wavelength_nm_restricted[ind_m],
                 sigmag,
                 rg_nm,
                 self.pdb.N0,

--- a/tests/unittests/database/clouds/opamie_test.py
+++ b/tests/unittests/database/clouds/opamie_test.py
@@ -1,5 +1,7 @@
 """opacity for mie test
 """
+from types import SimpleNamespace
+
 from exojax.test.emulate_pdb import mock_PdbPlouds
 from exojax.opacity import OpaMie
 from exojax.utils.grids import wavenumber_grid
@@ -24,6 +26,34 @@ def test_mieparams_vector():
     rg = 1.0e-5
     sigmag = 2.0
     dtau, w, g = opa.mieparams_vector(rg, sigmag)
+
+
+def test_mieparams_vector_direct_uses_wavelength_nm(monkeypatch):
+    wavenumber = np.array([5000.0, 10000.0, 15000.0])
+    wavelength_nm = 1.0e7 / wavenumber
+    pdb = SimpleNamespace(
+        refraction_index_wavenumber=wavenumber,
+        refraction_index_wavelength_nm=wavelength_nm,
+        refraction_index=np.ones(3, dtype=complex),
+        N0=1.0,
+    )
+    opa = OpaMie(pdb, wavenumber)
+    passed_wavelengths = []
+
+    def mock_mie_lognormal(m, wavelength, sigmag, rg, N0, rgrid):
+        passed_wavelengths.append(wavelength)
+        return np.zeros(7)
+
+    monkeypatch.setattr(
+        "exojax.opacity.opacont.mie_lognormal_pymiescatt", mock_mie_lognormal
+    )
+    monkeypatch.setattr(
+        "exojax.database.mie.auto_rgrid", lambda rg, sigmag: np.ones(1)
+    )
+
+    opa.mieparams_vector_direct_from_pymiescatt(rg=1.0e-5, sigmag=2.0)
+
+    np.testing.assert_allclose(passed_wavelengths, wavelength_nm)
 
 
 def test_mieparams_matrix():


### PR DESCRIPTION
## Summary

- pass the refractive-index wavelength table in nm to direct PyMieScatt calculations
- add a regression test for the conversion of 5000, 10000, and 15000 cm^-1 to 2000, 1000, and 666.7 nm

## Root cause

The direct Mie path passed refractive-index wavenumbers in cm^-1 to PyMieScatt's wavelength argument while particle radii were converted to nm. This silently corrupted the Mie size parameter.

## Impact

Direct Mie calculations now use consistent nm units for particle sizes and wavelengths. Precomputed Mie-grid behavior is unchanged.

## Validation

- `JAX_PLATFORMS=cpu python -m pytest tests/unittests/database/clouds/opamie_test.py tests/unittests/database/clouds/pbd_test.py tests/unittests/database/clouds/mie_test.py -q` (11 passed)
- `git diff --check`