### PR TITLE
Fix layer-dependent cloud opacity factors

### DIFF
--- a/src/exojax/rt/layeropacity.py
+++ b/src/exojax/rt/layeropacity.py
@@ -321,14 +321,21 @@ def layer_optical_depth_clouds_lognormal(
         extinction coefficient (array): extinction coefficient  in cgs (cm-1) [N_layer, N_nus]
         condensate_substance_density (float): condensate substance density (g/cm3)
         mmr_condensate (array): Mass mixing ratio (array) of condensate [Nlayer]
-        rg (float): rg parameter in the lognormal distribution of condensate size, defined by (9) in AM01
-        sigmag (float):sigmag parameter (geometric standard deviation) in the lognormal distribution of condensate size, defined by (9) in AM01, must be sigmag > 1
-        gravity (float): gravity (cm/s2)
+        rg (float or array): rg parameter in the lognormal distribution of condensate size, defined by (9) in AM01 [N_layer]
+        sigmag (float or array): sigmag parameter (geometric standard deviation) in the lognormal distribution of condensate size, defined by (9) in AM01, must be sigmag > 1 [N_layer]
+        gravity (float or array): gravity (cm/s2) [N_layer]
         N0 (float, optional): the normalization of the lognormal distribution ($N_0$). Defaults to 1.0.
 
     Returns:
         2D array: optical depth matrix, dtau  [N_layer, N_nus]
     """
+    if jnp.ndim(rg) == 1:
+        rg = rg[:, None]
+    if jnp.ndim(sigmag) == 1:
+        sigmag = sigmag[:, None]
+    if jnp.ndim(gravity) == 1:
+        gravity = gravity[:, None]
+
     expfac = bar_cgs * sigmag ** (
         jnp.log(sigmag**-4.5)
     )  # bar_cgs * exp(-9/2 * (log sigmag)**2), see tests/manual_check/f32/lnmoment_amcloud.py

--- a/tests/unittests/opacity/xs/clouds_test.py
+++ b/tests/unittests/opacity/xs/clouds_test.py
@@ -62,6 +62,47 @@ def test_layer_optical_depth_clouds_lognormal():
     assert dtau.shape == (1, 1000)
     assert np.sum(dtau) == pytest.approx(ref_value)
 
+
+@pytest.mark.parametrize("nnu", [2, 3])
+def test_layer_optical_depth_clouds_lognormal_with_layer_profiles(nnu):
+    dpressure = jnp.array([1.0, 2.0])
+    extinction_coefficient = (
+        jnp.arange(1, 2 * nnu + 1, dtype=float).reshape(2, nnu) * 1.0e-11
+    )
+    condensate_substance_density = 3.0
+    mmr_condensate = jnp.array([1.0e-5, 3.0e-5])
+    rg = jnp.array([1.0e-5, 2.0e-5])
+    sigmag = jnp.array([1.5, 2.0])
+    gravity = jnp.array([1.0e3, 2.0e3])
+
+    dtau = layer_optical_depth_clouds_lognormal(
+        dpressure,
+        extinction_coefficient,
+        condensate_substance_density,
+        mmr_condensate,
+        rg,
+        sigmag,
+        gravity,
+    )
+    expected = jnp.stack(
+        [
+            single_layer_optical_depth_clouds_lognormal(
+                dpressure[i],
+                extinction_coefficient[i],
+                condensate_substance_density,
+                mmr_condensate[i],
+                rg[i],
+                sigmag[i],
+                gravity[i],
+            )
+            for i in range(2)
+        ]
+    )
+
+    assert dtau.shape == (2, nnu)
+    np.testing.assert_allclose(dtau, expected, rtol=1.0e-6)
+
+
 def test_single_layer_optical_depth_clouds_lognormal():
 
     (


### PR DESCRIPTION
## Summary

- Promote one-dimensional `rg`, `sigmag`, and `gravity` cloud profiles to column vectors before combining them with spectral extinction.
- Add regression coverage for both equal and unequal layer/wavenumber dimensions.

## Root cause

PR #750 made cloud radii correctly layer-dependent, but `layer_optical_depth_clouds_lognormal` still multiplied `(Nlayer,)` factors directly into `(Nlayer, Nnu)` extinction. Trailing-axis broadcasting therefore either failed when the dimensions differed or applied layer factors along the wavelength axis when they matched.

## Impact

Layer-dependent cloud radii from #750 can now flow through the standard lognormal cloud-opacity path. Scalar and existing `(Nlayer, 1)` inputs remain supported.

## Validation

- `python -m pytest tests/unittests/opacity/xs/clouds_test.py tests/unittests/atm/am01_test.py -q` — 12 passed
- `ruff check --ignore F401 src/exojax/rt/layeropacity.py tests/unittests/opacity/xs/clouds_test.py` — passed
- `git diff --check` — passed
