### PR TITLE
Make empty CKD bands transparent in float32

### DIFF
--- a/src/exojax/opacity/ckd/core.py
+++ b/src/exojax/opacity/ckd/core.py
@@ -91,17 +91,14 @@ def safe_log_k(k_values: jnp.ndarray, min_value: float = None) -> jnp.ndarray:
     
     Args:
         k_values: K-values (cross-sections), shape (nnu,)
-        min_value: Minimum value to avoid log(0). If None, uses precision-aware default:
-                  1e-100 for float64, 1e-30 for float32
+        min_value: Minimum value to avoid log(0). If None, uses the smallest
+            positive normal value for the input dtype.
         
     Returns:
         log_k: Safe logarithm of k-values, shape (nnu,)
     """
     if min_value is None:
-        if k_values.dtype == jnp.float64:
-            min_value = 1e-100  # Much smaller for float64
-        else:
-            min_value = 1e-30   # Current default for float32
+        min_value = jnp.finfo(k_values.dtype).tiny
     return jnp.log(jnp.maximum(k_values, min_value))
 
 
@@ -291,4 +288,3 @@ def interpolate_log_k_2d(
     log_k_interp = log_k_flat.reshape(Ng, nnu_bands)
     
     return log_k_interp
-

--- a/tests/unittests/opacity/ckd/ckd_api_test.py
+++ b/tests/unittests/opacity/ckd/ckd_api_test.py
@@ -4,7 +4,8 @@ import pytest
 import numpy as np
 import jax.numpy as jnp
 from exojax.opacity.ckd.api import OpaCKD
-from exojax.opacity.ckd.core import safe_log_k
+from exojax.rt import ArtAbsPure
+from exojax.rt.layeropacity import layer_optical_depth_ckd
 
 
 class MockBaseOpa:
@@ -33,7 +34,9 @@ class SparseMockBaseOpa:
         self.nu_grid = jnp.array([1000.0, 1003.0])
 
     def xsmatrix(self, T_array, P_array):
-        return jnp.full((T_array.size, self.nu_grid.size), 2.0e-20)
+        return jnp.full(
+            (T_array.size, self.nu_grid.size), 2.0e-20, dtype=jnp.float32
+        )
 
 
 def test_opa_ckd_init():
@@ -91,8 +94,38 @@ def test_precompute_tables_uses_opacity_floor_for_empty_band():
     opa_ckd.precompute_tables(jnp.array([1000.0]), jnp.array([1.0]))
 
     actual = opa_ckd.xsarray_ckd(1000.0, 1.0)[:, 1]
-    expected = jnp.exp(safe_log_k(jnp.zeros_like(actual)))
-    assert jnp.allclose(actual, expected, rtol=1.0e-6, atol=0.0)
+    assert jnp.all(actual < 1.0e-37)
+
+
+@pytest.mark.parametrize("gravity", [1000.0, 100.0])
+def test_empty_band_is_transparent_in_radiative_transfer(gravity):
+    opa_ckd = OpaCKD(
+        SparseMockBaseOpa(), Ng=2, band_width=1.0, band_spacing="linear"
+    )
+    opa_ckd.precompute_tables(jnp.array([1000.0]), jnp.array([1.0]))
+    xs_ckd = opa_ckd.xstensor_ckd(
+        jnp.array([1000.0, 1000.0]), jnp.array([1.0, 1.0])
+    )
+    art = ArtAbsPure(
+        pressure_top=1.0e-8,
+        pressure_btm=100.0,
+        nlayer=2,
+        nu_grid=opa_ckd.nu_bands,
+    )
+
+    dtau_ckd = layer_optical_depth_ckd(
+        jnp.array([50.0, 50.0]), xs_ckd, jnp.ones(2), 2.3, gravity
+    )
+    transmission = art.run_ckd(
+        dtau_ckd,
+        art.pressure_boundary[-1],
+        jnp.ones_like(opa_ckd.nu_bands),
+        1.0,
+        None,
+        opa_ckd.ckd_info.weights,
+    )
+
+    assert transmission[1] > 1.0 - 1.0e-7
 
 
 if __name__ == "__main__":

--- a/tests/unittests/opacity/ckd/ckd_core_test.py
+++ b/tests/unittests/opacity/ckd/ckd_core_test.py
@@ -106,13 +106,14 @@ def test_safe_log_k():
     k_values_f32 = jnp.array([1.0, 0.0, 2.0], dtype=jnp.float32)
     k_values_f64 = jnp.array([1.0, 0.0, 2.0], dtype=jnp.float64)
     
-    log_k_f32 = safe_log_k(k_values_f32)  # Should use 1e-30
-    log_k_f64 = safe_log_k(k_values_f64)  # Should use 1e-100
+    log_k_f32 = safe_log_k(k_values_f32)
+    log_k_f64 = safe_log_k(k_values_f64)
     
-    # Both should be finite but f64 should allow smaller values
+    # Both should use the smallest finite normal value for their dtype
     assert jnp.isfinite(log_k_f32[1])
     assert jnp.isfinite(log_k_f64[1])
-    assert log_k_f64[1] < log_k_f32[1]  # 1e-100 gives smaller log than 1e-30
+    assert jnp.isclose(log_k_f32[1], jnp.log(jnp.finfo(jnp.float32).tiny))
+    assert jnp.isclose(log_k_f64[1], jnp.log(jnp.finfo(jnp.float64).tiny))
 
 
 def test_interpolate_log_k_to_g_grid():


### PR DESCRIPTION
## Summary

- use the dtype's smallest positive normal value as the default CKD log floor
- verify empty float32 bands at both the cross-section and radiative-transfer levels
- cover the reported `dP=100 bar`, `VMR=1`, `mass=2.3`, and `g=1000/100 cm s^-2` cases

## Root cause

PR #752 replaced uncovered bands with the existing finite `safe_log_k` floor. For float32, that floor was `1e-30 cm^2`. Although small as a cross section, the atmospheric column factor amplified it to optical depths of about 0.026 and 0.262, producing transmissions of about 0.974 and 0.770.

The default now uses `jnp.finfo(dtype).tiny`, which keeps stored log values finite while making the resulting opacity negligible.

## Impact

Empty CKD bands remain transparent in float32, including high-column and low-gravity cases. Explicit `min_value` arguments are unchanged.

CKD tables generated with the old floor must be regenerated because the saved sentinel is indistinguishable from a physical `1e-30 cm^2` value.

## Validation

- `NUMBA_DISABLE_JIT=1 CUDA_VISIBLE_DEVICES='' JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu python -m pytest -q tests/unittests/opacity/ckd`
- 102 passed
