### PR TITLE
Fix float32 thin-layer thermal emission

### DIFF
--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -10,7 +10,7 @@ from exojax.rt.rtransfer import (
     rtrun_emis_scat_lart_toonhm,
     rtrun_emis_scat_sfm2st_toonhm,
     initialize_gaussian_quadrature,
-    setrt_toonhm,
+    setrt_toonhm_with_absorption,
 )
 from exojax.rt.rtlayer import fluxsum_scan
 from exojax.rt.common import ArtCommon
@@ -591,10 +591,14 @@ class OpartEmisScat(ArtCommon):
         source_vector = piB(temparature, self.nu_grid)
         # -------------------------------------------------
         dtau, single_scattering_albedo, asymmetric_parameter = self.opalayer(params)
-        trans_coeff_i, scat_coeff_i, reduced_piB_i, _, _, _ = setrt_toonhm(
-            dtau, single_scattering_albedo, asymmetric_parameter, source_vector
+        toon_coeffs = setrt_toonhm_with_absorption(
+            dtau,
+            single_scattering_albedo,
+            asymmetric_parameter,
+            source_vector,
         )
-        pihatB_i = (1.0 - trans_coeff_i - scat_coeff_i) * reduced_piB_i
+        trans_coeff_i, scat_coeff_i, absorption_coeff_i, reduced_piB_i = toon_coeffs[:4]
+        pihatB_i = absorption_coeff_i * reduced_piB_i
         denom = 1.0 - scat_coeff_i * Rphat_prev
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -1,7 +1,11 @@
 import jax.numpy as jnp
 from exojax.rt.common import ArtCommon
 from exojax.rt.planck import piB, piBarr
-from exojax.rt.rtransfer import rtrun_reflect_fluxadding_toonhm, setrt_toonhm
+from exojax.rt.rtransfer import (
+    rtrun_reflect_fluxadding_toonhm,
+    setrt_toonhm,
+    setrt_toonhm_with_absorption,
+)
 from exojax.rt.common import ArtCommon
 
 import jax.numpy as jnp
@@ -492,10 +496,14 @@ class OpartReflectEmis(ArtCommon):
         source_vector = piB(temparature, self.nu_grid)
         # -------------------------------------------------
         dtau, single_scattering_albedo, asymmetric_parameter = self.opalayer(params)
-        trans_coeff_i, scat_coeff_i, reduced_piB_i, _, _, _ = setrt_toonhm(
-            dtau, single_scattering_albedo, asymmetric_parameter, source_vector
+        toon_coeffs = setrt_toonhm_with_absorption(
+            dtau,
+            single_scattering_albedo,
+            asymmetric_parameter,
+            source_vector,
         )
-        pihatB_i = (1.0 - trans_coeff_i - scat_coeff_i) * reduced_piB_i
+        trans_coeff_i, scat_coeff_i, absorption_coeff_i, reduced_piB_i = toon_coeffs[:4]
+        pihatB_i = absorption_coeff_i * reduced_piB_i
         denom = 1.0 - scat_coeff_i * Rphat_prev
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -38,12 +38,33 @@ from exojax.rt.toon import (
 )
 from exojax.rt.twostream import (
     compute_tridiag_diagonals_and_vector,
-    set_scat_trans_coeffs,
+    set_scat_trans_absorption_coeffs,
+    set_scat_trans_coeffs,  # re-exported for backward compatibility
     solve_fluxadding_twostream,
     solve_fluxadding_twostream_fluxes,
     solve_lart_twostream,
 )
 from exojax.special.expn import E1
+
+
+def _trans2E3_coefficients(x):
+    """Returns transmission and absorption coefficients for pure absorption."""
+    x = jnp.asarray(x)
+    float_dtype = jnp.result_type(x, 1.0)
+    # Keep x**2 and its reverse-mode cotangent below dtype overflow.
+    too_large = x >= jnp.sqrt(jnp.finfo(float_dtype).max)
+    x_eval = jnp.where(too_large, 1.0, x)
+    x_e1 = jnp.where(x_eval == 0.0, 1.0, x_eval)
+    exp_negative_x = jnp.exp(-x_eval)
+    e1_term = x_eval**2 * E1(x_e1)
+    transmission = (1.0 - x_eval) * exp_negative_x + e1_term
+    absorption = (
+        -jnp.expm1(-x_eval) + x_eval * exp_negative_x - e1_term
+    )
+    return (
+        jnp.where(too_large, 0.0, transmission),
+        jnp.where(too_large, 1.0, absorption),
+    )
 
 
 @jit
@@ -60,14 +81,8 @@ def trans2E3(x):
     Returns:
         Transmission function T=2 E3(x)
     """
-    x = jnp.asarray(x)
-    float_dtype = jnp.result_type(x, 1.0)
-    # Keep x**2 and its reverse-mode cotangent below dtype overflow.
-    too_large = x >= jnp.sqrt(jnp.finfo(float_dtype).max)
-    x_eval = jnp.where(too_large, 1.0, x)
-    x_e1 = jnp.where(x_eval == 0.0, 1.0, x_eval)
-    value = (1.0 - x_eval) * jnp.exp(-x_eval) + x_eval**2 * E1(x_e1)
-    return jnp.where(too_large, 0.0, value)
+    transmission, _ = _trans2E3_coefficients(x)
+    return transmission
 
 
 @jit
@@ -81,8 +96,8 @@ def rtrun_emis_pureabs_fbased2st(dtau, source_matrix):
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
     Nnus = jnp.shape(dtau)[1]
-    TransM = trans2E3(dtau)
-    Qv = jnp.vstack([(1 - TransM) * source_matrix, jnp.zeros(Nnus)])
+    TransM, absorption = _trans2E3_coefficients(dtau)
+    Qv = jnp.vstack([absorption * source_matrix, jnp.zeros(Nnus)])
     return jnp.sum(
         Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), TransM]), axis=0), axis=0
     )
@@ -101,8 +116,8 @@ def rtrun_emis_pureabs_fbased2st_surface(dtau, source_matrix, source_surface):
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
     Nnus = jnp.shape(dtau)[1]
-    trans = trans2E3(dtau)
-    Qv = jnp.vstack([(1 - trans) * source_matrix, source_surface])
+    trans, absorption = _trans2E3_coefficients(dtau)
+    Qv = jnp.vstack([absorption * source_matrix, source_surface])
     return jnp.sum(
         Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), trans]), axis=0), axis=0
     )
@@ -353,9 +368,11 @@ def rtrun_emis_scat_lart_toonhm(
             - scat_coeff (2D array): Scattering coefficients.
             - reduced_piB (2D array): Reduced source function.
     """
-    trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
+    toon_coeffs = setrt_toonhm_with_absorption(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
     )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
+    zeta_plus, zeta_minus, lambdan = toon_coeffs[4:]
 
     # avoids zero
     epsilon = 1.0e-8
@@ -363,7 +380,14 @@ def rtrun_emis_scat_lart_toonhm(
     trans_coeff = trans_coeff + epsilon
 
     diagonal, lower_diagonal, upper_diagonal, vector = settridiag_toohm(
-        dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coeff, reduced_piB
+        dtau,
+        zeta_plus,
+        zeta_minus,
+        lambdan,
+        trans_coeff,
+        scat_coeff,
+        reduced_piB,
+        absorption_coeff,
     )
     nlayer, Nnus = diagonal.shape
     cumTtilde, Qtilde, spectrum = solve_lart_twostream(
@@ -395,11 +419,20 @@ def rtrun_emis_scat_lart_toonhm_surface(
             - scat_coeff (2D array): Scattering coefficients.
             - piB (2D array): Reduced source function.
     """
-    trans_coeff, scat_coeff, piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
+    toon_coeffs = setrt_toonhm_with_absorption(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
     )
+    trans_coeff, scat_coeff, absorption_coeff, piB = toon_coeffs[:4]
+    zeta_plus, zeta_minus, lambdan = toon_coeffs[4:]
     diagonal, lower_diagonal, upper_diagonal, vector = settridiag_toohm(
-        dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coeff, piB
+        dtau,
+        zeta_plus,
+        zeta_minus,
+        lambdan,
+        trans_coeff,
+        scat_coeff,
+        piB,
+        absorption_coeff,
     )
 
     cumTtilde, Qtilde, spectrum = solve_lart_twostream(
@@ -432,12 +465,18 @@ def rtrun_reflect_fluxadding_toonhm(
     Returns:
         1D array: Reflected spectrum in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
-    trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
+    toon_coeffs = setrt_toonhm_with_absorption(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
     )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
     
     Rphat, Sphat = solve_fluxadding_twostream(
-        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface
+        trans_coeff,
+        scat_coeff,
+        reduced_piB,
+        reflectivity_surface,
+        source_surface,
+        absorption_coeff,
     )
     
     return Rphat * incoming_flux + Sphat
@@ -462,12 +501,18 @@ def rtrun_emis_scat_fluxadding_toonhm(
     source_surface = jnp.zeros(Nnus)
     reflectivity_surface = jnp.zeros(Nnus)
 
-    trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan = setrt_toonhm(
+    toon_coeffs = setrt_toonhm_with_absorption(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
     )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
 
     _, spectrum = solve_fluxadding_twostream(
-        trans_coeff, scat_coeff, reduced_piB, reflectivity_surface, source_surface
+        trans_coeff,
+        scat_coeff,
+        reduced_piB,
+        reflectivity_surface,
+        source_surface,
+        absorption_coeff,
     )
 
     return spectrum
@@ -504,9 +549,10 @@ def rtrun_emis_scat_sfm2st_toonhm(
     source_surface = jnp.zeros(Nnus)
     reflectivity_surface = jnp.zeros(Nnus)
 
-    trans_coeff, scat_coeff, reduced_piB, _, _, _ = setrt_toonhm(
+    toon_coeffs = setrt_toonhm_with_absorption(
         dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
     )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
 
     flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
         trans_coeff,
@@ -514,6 +560,7 @@ def rtrun_emis_scat_sfm2st_toonhm(
         reduced_piB,
         reflectivity_surface,
         source_surface,
+        absorption_coeff=absorption_coeff,
     )
 
     flux_plus_layer = 0.5 * (flux_plus[:-1] + flux_plus[1:])
@@ -531,7 +578,12 @@ def rtrun_emis_scat_sfm2st_toonhm(
     return rtrun_emis_pureabs_ibased(dtau, source_sfm, mus, weights)
 
 
-def setrt_toonhm(dtau, single_scattering_albedo, asymmetric_parameter, source_matrix):
+def setrt_toonhm(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+):
     """Sets some coefficients for radiative transfer assuming Toon Hemispheric Mean.
 
     Args:
@@ -541,33 +593,62 @@ def setrt_toonhm(dtau, single_scattering_albedo, asymmetric_parameter, source_ma
         source_matrix (2D array): Source matrix (N_layer, N_nus)
 
     Returns:
-        trans_coeff (2D array): Transmission coefficients.
-        scat_coeff (2D array): Scattering coefficients.
-        reduced_piB (2D array): Reduced source function.
-        zeta_plus (2D array): Zeta plus coefficients.
-        zeta_minus (2D array): Zeta minus coefficients.
-        lambdan (2D array): Lambda coefficients.
+        tuple: Transmission, scattering, source, zeta, and lambda coefficients.
     """
-    
+    toon_coeffs = setrt_toonhm_with_absorption(
+        dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
+    )
+    trans_coeff, scat_coeff, _, reduced_piB = toon_coeffs[:4]
+    zeta_plus, zeta_minus, lambdan = toon_coeffs[4:]
+    return trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan
+
+
+def setrt_toonhm_with_absorption(
+    dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
+):
+    """Sets Toon hemispheric-mean coefficients including absorption.
+
+    The absorption coefficient is evaluated directly and returned after the
+    scattering coefficient so that thin-layer thermal sources remain accurate.
+    """
     gamma_1, gamma_2, mu1 = params_hemispheric_mean(
         single_scattering_albedo, asymmetric_parameter
     )
     zeta_plus, zeta_minus, lambdan = zetalambda_coeffs(gamma_1, gamma_2)
-    trans_coeff, scat_coeff = set_scat_trans_coeffs(gamma_1, gamma_2, dtau)
+    trans_coeff, scat_coeff, absorption_coeff = set_scat_trans_absorption_coeffs(
+        gamma_1, gamma_2, dtau
+    )
 
     reduced_piB = source_matrix
 
-    return trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan
+    return (
+        trans_coeff,
+        scat_coeff,
+        absorption_coeff,
+        reduced_piB,
+        zeta_plus,
+        zeta_minus,
+        lambdan,
+    )
 
 
 def settridiag_toohm(
-    dtau, zeta_plus, zeta_minus, lambdan, trans_coeff, scat_coeff, reduced_piB
+    dtau,
+    zeta_plus,
+    zeta_minus,
+    lambdan,
+    trans_coeff,
+    scat_coeff,
+    reduced_piB,
+    absorption_coeff=None,
 ):
     diagonal_top = 1.0 * jnp.ones_like(trans_coeff[0, :])  # setting b0=1
     upper_diagonal_top = trans_coeff[0, :]
 
     # emission (no reflection)
-    vector_top = (1.0 - trans_coeff[0, :] - scat_coeff[0, :]) * reduced_piB[0, :]
+    if absorption_coeff is None:
+        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+    vector_top = absorption_coeff[0, :] * reduced_piB[0, :]
 
     # tridiagonal elements
     (
@@ -582,6 +663,7 @@ def settridiag_toohm(
         upper_diagonal_top,
         diagonal_top,
         vector_top,
+        absorption_coeff,
     )
 
     return diagonal, lower_diagonal, upper_diagonal, vector

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -47,6 +47,9 @@ from exojax.rt.twostream import (
 from exojax.special.expn import E1
 
 
+_TRANS2E3_COMPLEMENT_SWITCH = 0.4190354
+
+
 def _trans2E3_coefficients(x):
     """Returns transmission and absorption coefficients for pure absorption."""
     x = jnp.asarray(x)
@@ -65,6 +68,61 @@ def _trans2E3_coefficients(x):
         jnp.where(too_large, 0.0, transmission),
         jnp.where(too_large, 1.0, absorption),
     )
+
+
+def _trans2E3_stable_coefficient(x):
+    """Returns the smaller coefficient and its complementary-form selector."""
+    trans_coeff, absorption_coeff = _trans2E3_coefficients(x)
+    # 2 E3(x) = 0.5 at x = 0.419..., where both complementary forms
+    # are equally well conditioned.
+    use_absorption = jnp.asarray(x) <= _TRANS2E3_COMPLEMENT_SWITCH
+    stable_coeff = jnp.where(
+        use_absorption,
+        absorption_coeff,
+        trans_coeff,
+    )
+    return stable_coeff, use_absorption
+
+
+def _solve_pure_absorption_emission(
+    stable_coeff, use_absorption, source_matrix, source_surface
+):
+    """Integrates pure-absorption emission using stable complementary forms."""
+    calculation_dtype = jnp.result_type(
+        stable_coeff, source_matrix, source_surface
+    )
+    stable_coeff = jnp.asarray(stable_coeff, dtype=calculation_dtype)
+    source_matrix = jnp.asarray(source_matrix, dtype=calculation_dtype)
+    source_surface = jnp.asarray(source_surface, dtype=calculation_dtype)
+    source_surface = jnp.broadcast_to(source_surface, source_matrix.shape[1:])
+
+    def integrate_layer(carry, layer):
+        flux, correction = carry
+        coeff_layer, use_absorption_layer, source_layer = layer
+        source_difference = (source_layer - flux) - correction
+        absorption_increment = correction + coeff_layer * source_difference
+        transmission_increment = -coeff_layer * source_difference
+        base = jnp.where(use_absorption_layer, flux, source_layer)
+        # Use the smaller complementary coefficient to avoid cancellation in
+        # both optically thin and optically thick layers.
+        increment = jnp.where(
+            use_absorption_layer,
+            absorption_increment,
+            transmission_increment,
+        )
+
+        updated_flux = base + increment
+        # Carry the rounded-off part of the update into the next layer.
+        correction = increment - (updated_flux - base)
+        return (updated_flux, correction), None
+
+    (flux, correction), _ = scan(
+        integrate_layer,
+        (source_surface, jnp.zeros_like(source_surface)),
+        (stable_coeff, use_absorption, source_matrix),
+        reverse=True,
+    )
+    return flux + correction
 
 
 @jit
@@ -95,11 +153,12 @@ def rtrun_emis_pureabs_fbased2st(dtau, source_matrix):
     Returns:
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
-    Nnus = jnp.shape(dtau)[1]
-    TransM, absorption = _trans2E3_coefficients(dtau)
-    Qv = jnp.vstack([absorption * source_matrix, jnp.zeros(Nnus)])
-    return jnp.sum(
-        Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), TransM]), axis=0), axis=0
+    stable_coeff, use_absorption = _trans2E3_stable_coefficient(dtau)
+    return _solve_pure_absorption_emission(
+        stable_coeff,
+        use_absorption,
+        source_matrix,
+        jnp.zeros_like(source_matrix[0]),
     )
 
 
@@ -115,11 +174,9 @@ def rtrun_emis_pureabs_fbased2st_surface(dtau, source_matrix, source_surface):
     Returns:
         flux in the unit of [erg/cm2/s/cm-1] if using piBarr as a source function.
     """
-    Nnus = jnp.shape(dtau)[1]
-    trans, absorption = _trans2E3_coefficients(dtau)
-    Qv = jnp.vstack([absorption * source_matrix, source_surface])
-    return jnp.sum(
-        Qv * jnp.cumprod(jnp.vstack([jnp.ones(Nnus), trans]), axis=0), axis=0
+    stable_coeff, use_absorption = _trans2E3_stable_coefficient(dtau)
+    return _solve_pure_absorption_emission(
+        stable_coeff, use_absorption, source_matrix, source_surface
     )
 
 
@@ -595,12 +652,20 @@ def setrt_toonhm(
     Returns:
         tuple: Transmission, scattering, source, zeta, and lambda coefficients.
     """
-    toon_coeffs = setrt_toonhm_with_absorption(
-        dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
+    gamma_1, gamma_2, _ = params_hemispheric_mean(
+        single_scattering_albedo, asymmetric_parameter
     )
-    trans_coeff, scat_coeff, _, reduced_piB = toon_coeffs[:4]
-    zeta_plus, zeta_minus, lambdan = toon_coeffs[4:]
-    return trans_coeff, scat_coeff, reduced_piB, zeta_plus, zeta_minus, lambdan
+    zeta_plus, zeta_minus, lambdan = zetalambda_coeffs(gamma_1, gamma_2)
+    trans_coeff, scat_coeff = set_scat_trans_coeffs(gamma_1, gamma_2, dtau)
+
+    return (
+        trans_coeff,
+        scat_coeff,
+        source_matrix,
+        zeta_plus,
+        zeta_minus,
+        lambdan,
+    )
 
 
 def setrt_toonhm_with_absorption(

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -309,10 +309,9 @@ def set_scat_trans_coeffs(gamma_1, gamma_2, dtau):
     Returns:
         _type_: transmission coefficient, scattering coeffcient
     """
-    trans_coeff, scat_coeff, _ = set_scat_trans_absorption_coeffs(
-        gamma_1, gamma_2, dtau
+    return _set_scat_trans_coefficients(
+        gamma_1, gamma_2, dtau, return_absorption=False
     )
-    return trans_coeff, scat_coeff
 
 
 def set_scat_trans_absorption_coeffs(gamma_1, gamma_2, dtau):
@@ -330,6 +329,14 @@ def set_scat_trans_absorption_coeffs(gamma_1, gamma_2, dtau):
     Returns:
         _type_: transmission, scattering, and absorption coefficients
     """
+    return _set_scat_trans_coefficients(
+        gamma_1, gamma_2, dtau, return_absorption=True
+    )
+
+
+def _set_scat_trans_coefficients(
+    gamma_1, gamma_2, dtau, return_absorption
+):
     lambda_dtau_squared = jnp.asarray(
         (gamma_1 - gamma_2) * (gamma_1 + gamma_2) * dtau**2
     )
@@ -342,29 +349,39 @@ def set_scat_trans_absorption_coeffs(gamma_1, gamma_2, dtau):
     trans_func = jnp.exp(-lambda_dtau)
     phi = -jnp.expm1(-2.0 * lambda_dtau) / (2.0 * lambda_dtau)
     denom = 1.0 + trans_func**2 + 2.0 * gamma_1 * dtau * phi
-    trans_coeff = 2.0 * trans_func / denom
-    scat_coeff = 2.0 * gamma_2 * dtau * phi / denom
-    one_minus_trans_func = -jnp.expm1(-lambda_dtau)
-    absorption_coeff = (
-        one_minus_trans_func**2 + 2.0 * (gamma_1 - gamma_2) * dtau * phi
-    ) / denom
+    trans_numerator = 2.0 * trans_func
+    scat_numerator = 2.0 * gamma_2 * dtau * phi
 
     squared2 = lambda_dtau_squared**2
-    coshm1_taylor = lambda_dtau_squared / 2.0 + squared2 / 24.0
     cosh_taylor = 1.0 + lambda_dtau_squared / 2.0 + squared2 / 24.0
     sinhc_taylor = 1.0 + lambda_dtau_squared / 6.0 + squared2 / 120.0
     denom_taylor = cosh_taylor + gamma_1 * dtau * sinhc_taylor
-    trans_taylor = 1.0 / denom_taylor
-    scat_taylor = gamma_2 * dtau * sinhc_taylor / denom_taylor
-    absorption_taylor = (
-        coshm1_taylor + (gamma_1 - gamma_2) * dtau * sinhc_taylor
-    ) / denom_taylor
+    trans_numerator_taylor = jnp.ones_like(lambda_dtau_squared)
+    scat_numerator_taylor = gamma_2 * dtau * sinhc_taylor
 
-    return (
-        jnp.where(use_taylor, trans_taylor, trans_coeff),
-        jnp.where(use_taylor, scat_taylor, scat_coeff),
-        jnp.where(use_taylor, absorption_taylor, absorption_coeff),
+    selected_denom = jnp.where(use_taylor, denom_taylor, denom)
+    trans_coeff = jnp.where(
+        use_taylor, trans_numerator_taylor, trans_numerator
+    ) / selected_denom
+    scat_coeff = jnp.where(
+        use_taylor, scat_numerator_taylor, scat_numerator
+    ) / selected_denom
+    if not return_absorption:
+        return trans_coeff, scat_coeff
+
+    one_minus_trans_func = -jnp.expm1(-lambda_dtau)
+    absorption_numerator = (
+        one_minus_trans_func**2 + 2.0 * (gamma_1 - gamma_2) * dtau * phi
     )
+    coshm1_taylor = lambda_dtau_squared / 2.0 + squared2 / 24.0
+    absorption_numerator_taylor = (
+        coshm1_taylor + (gamma_1 - gamma_2) * dtau * sinhc_taylor
+    )
+    absorption_coeff = jnp.where(
+        use_taylor, absorption_numerator_taylor, absorption_numerator
+    ) / selected_denom
+
+    return trans_coeff, scat_coeff, absorption_coeff
 
 
 def compute_tridiag_diagonals_and_vector(

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -12,7 +12,12 @@ from jax.lax import scan
 
 
 def solve_fluxadding_twostream(
-    trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom
+    trans_coeff,
+    scat_coeff,
+    reduced_source_function,
+    reflectivity_bottom,
+    source_bottom,
+    absorption_coeff=None,
 ):
     """Two-stream RT solver using flux adding
 
@@ -22,6 +27,8 @@ def solve_fluxadding_twostream(
         reduced_source_function :  pi \mathcal{B} (Nlayer, Nnus)
         reflectivity_bottom (_type_): R^+_N (Nnus)
         source_bottom (_type_): S^+_N (Nnus)
+        absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
+            it is reconstructed from the transmission and scattering coefficients.
 
     Returns:
         Effective reflectivity (hat(R^plus)), Effective source (hat(S^plus))
@@ -33,12 +40,18 @@ def solve_fluxadding_twostream(
         reduced_source_function,
         reflectivity_bottom,
         source_bottom,
+        absorption_coeff,
     )
     return Rplus[0], Splus[0]
 
 
 def compute_fluxadding_coeffs(
-    trans_coeff, scat_coeff, reduced_source_function, reflectivity_bottom, source_bottom
+    trans_coeff,
+    scat_coeff,
+    reduced_source_function,
+    reflectivity_bottom,
+    source_bottom,
+    absorption_coeff=None,
 ):
     """Computes upward effective reflection/source at all interfaces.
 
@@ -48,12 +61,16 @@ def compute_fluxadding_coeffs(
         reduced_source_function: Reduced source function (Nlayer, Nnus).
         reflectivity_bottom: Bottom boundary reflectivity (Nnus).
         source_bottom: Bottom boundary source (Nnus).
+        absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
+            it is reconstructed from the transmission and scattering coefficients.
 
     Returns:
         tuple: Rplus, Splus, each with shape (Nlayer + 1, Nnus).
     """
 
-    pihatB = (1.0 - trans_coeff - scat_coeff) * reduced_source_function
+    if absorption_coeff is None:
+        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+    pihatB = absorption_coeff * reduced_source_function
 
     # bottom reflection
     Rplus_bottom = reflectivity_bottom
@@ -85,7 +102,11 @@ def compute_fluxadding_coeffs(
 
 
 def compute_fluxadding_downward_coeffs(
-    trans_coeff, scat_coeff, reduced_source_function, source_top=None
+    trans_coeff,
+    scat_coeff,
+    reduced_source_function,
+    source_top=None,
+    absorption_coeff=None,
 ):
     """Computes downward effective reflection/source at all interfaces.
 
@@ -97,6 +118,8 @@ def compute_fluxadding_downward_coeffs(
         scat_coeff: Scattering coefficient (Nlayer, Nnus).
         reduced_source_function: Reduced source function (Nlayer, Nnus).
         source_top: Top boundary incoming flux (Nnus). Defaults to zero.
+        absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
+            it is reconstructed from the transmission and scattering coefficients.
 
     Returns:
         tuple: Rminus, Sminus, each with shape (Nlayer + 1, Nnus).
@@ -106,7 +129,9 @@ def compute_fluxadding_downward_coeffs(
     if source_top is None:
         source_top = jnp.zeros(Nnus)
 
-    pihatB = (1.0 - trans_coeff - scat_coeff) * reduced_source_function
+    if absorption_coeff is None:
+        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+    pihatB = absorption_coeff * reduced_source_function
     Rminus_top = jnp.zeros(Nnus)
     Sminus_top = source_top
 
@@ -137,6 +162,7 @@ def solve_fluxadding_twostream_fluxes(
     reflectivity_bottom,
     source_bottom,
     source_top=None,
+    absorption_coeff=None,
 ):
     """Computes two-stream upward and downward fluxes at all interfaces.
 
@@ -147,6 +173,8 @@ def solve_fluxadding_twostream_fluxes(
         reflectivity_bottom: Bottom boundary reflectivity (Nnus).
         source_bottom: Bottom boundary source (Nnus).
         source_top: Top boundary incoming flux (Nnus). Defaults to zero.
+        absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
+            it is reconstructed from the transmission and scattering coefficients.
 
     Returns:
         tuple: flux_plus, flux_minus, each with shape (Nlayer + 1, Nnus).
@@ -158,9 +186,14 @@ def solve_fluxadding_twostream_fluxes(
         reduced_source_function,
         reflectivity_bottom,
         source_bottom,
+        absorption_coeff,
     )
     Rminus, Sminus = compute_fluxadding_downward_coeffs(
-        trans_coeff, scat_coeff, reduced_source_function, source_top
+        trans_coeff,
+        scat_coeff,
+        reduced_source_function,
+        source_top,
+        absorption_coeff,
     )
 
     denom = 1.0 - Rplus * Rminus
@@ -276,6 +309,27 @@ def set_scat_trans_coeffs(gamma_1, gamma_2, dtau):
     Returns:
         _type_: transmission coefficient, scattering coeffcient
     """
+    trans_coeff, scat_coeff, _ = set_scat_trans_absorption_coeffs(
+        gamma_1, gamma_2, dtau
+    )
+    return trans_coeff, scat_coeff
+
+
+def set_scat_trans_absorption_coeffs(gamma_1, gamma_2, dtau):
+    """Sets scattering, transmission, and absorption coefficients.
+
+    The absorption coefficient is evaluated directly rather than reconstructed
+    as ``1 - transmission - scattering`` so that it remains accurate for thin
+    layers in float32.
+
+    Args:
+        gamma_1 (_type_): Toon+89 gamma_1 coefficient
+        gamma_2 (_type_): Toon+89 gamma_2 coefficient
+        dtau (_type_): optical depth interval of the layers
+
+    Returns:
+        _type_: transmission, scattering, and absorption coefficients
+    """
     lambda_dtau_squared = jnp.asarray(
         (gamma_1 - gamma_2) * (gamma_1 + gamma_2) * dtau**2
     )
@@ -290,22 +344,37 @@ def set_scat_trans_coeffs(gamma_1, gamma_2, dtau):
     denom = 1.0 + trans_func**2 + 2.0 * gamma_1 * dtau * phi
     trans_coeff = 2.0 * trans_func / denom
     scat_coeff = 2.0 * gamma_2 * dtau * phi / denom
+    one_minus_trans_func = -jnp.expm1(-lambda_dtau)
+    absorption_coeff = (
+        one_minus_trans_func**2 + 2.0 * (gamma_1 - gamma_2) * dtau * phi
+    ) / denom
 
     squared2 = lambda_dtau_squared**2
+    coshm1_taylor = lambda_dtau_squared / 2.0 + squared2 / 24.0
     cosh_taylor = 1.0 + lambda_dtau_squared / 2.0 + squared2 / 24.0
     sinhc_taylor = 1.0 + lambda_dtau_squared / 6.0 + squared2 / 120.0
     denom_taylor = cosh_taylor + gamma_1 * dtau * sinhc_taylor
     trans_taylor = 1.0 / denom_taylor
     scat_taylor = gamma_2 * dtau * sinhc_taylor / denom_taylor
+    absorption_taylor = (
+        coshm1_taylor + (gamma_1 - gamma_2) * dtau * sinhc_taylor
+    ) / denom_taylor
 
     return (
         jnp.where(use_taylor, trans_taylor, trans_coeff),
         jnp.where(use_taylor, scat_taylor, scat_coeff),
+        jnp.where(use_taylor, absorption_taylor, absorption_coeff),
     )
 
 
 def compute_tridiag_diagonals_and_vector(
-    scat_coeff, trans_coeff, piB, upper_diagonal_top, diagonal_top, vector_top
+    scat_coeff,
+    trans_coeff,
+    piB,
+    upper_diagonal_top,
+    diagonal_top,
+    vector_top,
+    absorption_coeff=None,
 ):
     """computes the diagonals and right-handside vector from scattering and transmission coefficients for the tridiagonal system
 
@@ -316,6 +385,8 @@ def compute_tridiag_diagonals_and_vector(
         upper_diagonal_top (_type_): a[0] upper diagonal top boundary
         diagonal_top (_type_): b[0] diagonal top boundary
         vector_top (_type_): vector top boundary
+        absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
+            it is reconstructed from the transmission and scattering coefficients.
 
     Notes:
         In ExoJAX 2 paper, we assume the tridiagonal form as -an F_{n+1}^+ + b_n F_n^+ - cn F_{n-1}^+ = dn
@@ -340,7 +411,9 @@ def compute_tridiag_diagonals_and_vector(
     diagonal = diagonal.at[0].set(diagonal_top)
 
     # vector
-    hatpiB = (1.0 - trans_coeff - scat_coeff) * piB
+    if absorption_coeff is None:
+        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+    hatpiB = absorption_coeff * piB
     hatpiB_minus_one = jnp.roll(hatpiB, 1, axis=0)
     vector = rn_minus * hatpiB - rn * (Tn_minus_one - Sn_minus_one) * hatpiB_minus_one
 

--- a/tests/unittests/opacity/xs/expint_test.py
+++ b/tests/unittests/opacity/xs/expint_test.py
@@ -12,6 +12,30 @@ def test_comparison_expint():
     assert np.max(dif) < 2.0e-7
 
 
+def test_fbased2st_thin_float32_layers():
+    dtau = jnp.full((100, 1), 1.0e-8, dtype=jnp.float32)
+    source = jnp.ones_like(dtau)
+    source_surface = jnp.zeros(1, dtype=jnp.float32)
+
+    transmission = 2.0 * expn(3, 1.0e-8)
+    expected = -np.expm1(100.0 * np.log(transmission))
+
+    np.testing.assert_allclose(
+        rt.rtrun_emis_pureabs_fbased2st(dtau, source),
+        expected,
+        rtol=2.0e-6,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        rt.rtrun_emis_pureabs_fbased2st_surface(
+            dtau, source, source_surface
+        ),
+        expected,
+        rtol=2.0e-6,
+        atol=0.0,
+    )
+
+
 def test_trans2E3_zero_limit_and_reverse_gradient():
     x = jnp.float32(0.0)
     np.testing.assert_allclose(rt.trans2E3(x), 1.0)

--- a/tests/unittests/opacity/xs/expint_test.py
+++ b/tests/unittests/opacity/xs/expint_test.py
@@ -15,24 +15,87 @@ def test_comparison_expint():
 def test_fbased2st_thin_float32_layers():
     dtau = jnp.full((100, 1), 1.0e-8, dtype=jnp.float32)
     source = jnp.ones_like(dtau)
-    source_surface = jnp.zeros(1, dtype=jnp.float32)
+    half_source_surface = jnp.full(1, 0.5, dtype=jnp.float32)
 
     transmission = 2.0 * expn(3, 1.0e-8)
     expected = -np.expm1(100.0 * np.log(transmission))
+    expected_with_surface = expected + 0.5 * transmission**100
 
+    actual = rt.rtrun_emis_pureabs_fbased2st(dtau, source)
     np.testing.assert_allclose(
-        rt.rtrun_emis_pureabs_fbased2st(dtau, source),
-        expected,
-        rtol=2.0e-6,
-        atol=0.0,
+        actual, expected, rtol=2.0e-6, atol=0.0
+    )
+    np.testing.assert_array_equal(
+        rt.rtrun_emis_pureabs_fbased2st_surface(dtau, source, 0.0), actual
     )
     np.testing.assert_allclose(
         rt.rtrun_emis_pureabs_fbased2st_surface(
-            dtau, source, source_surface
+            dtau, source, half_source_surface
         ),
-        expected,
-        rtol=2.0e-6,
+        expected_with_surface,
+        rtol=1.0e-7,
         atol=0.0,
+    )
+    np.testing.assert_array_equal(
+        rt.rtrun_emis_pureabs_fbased2st_surface(
+            dtau, source, jnp.ones(1, dtype=jnp.float32)
+        ),
+        jnp.ones(1, dtype=jnp.float32),
+    )
+
+
+def test_fbased2st_thin_float32_layers_attenuate_deep_emission():
+    thin_dtau = 1.0e-8
+    bottom_dtau = 10.0
+    dtau = jnp.full((101, 1), thin_dtau, dtype=jnp.float32)
+    dtau = dtau.at[-1, 0].set(bottom_dtau)
+    source = jnp.zeros_like(dtau).at[-1, 0].set(1.0)
+
+    transmission_thin = 2.0 * expn(3, thin_dtau)
+    absorption_bottom = 1.0 - 2.0 * expn(3, bottom_dtau)
+    expected = transmission_thin**100 * absorption_bottom
+
+    actual = rt.rtrun_emis_pureabs_fbased2st(dtau, source)
+    np.testing.assert_allclose(
+        actual, expected, rtol=1.0e-7, atol=0.0
+    )
+    np.testing.assert_array_equal(
+        rt.rtrun_emis_pureabs_fbased2st_surface(dtau, source, 0.0), actual
+    )
+
+
+def test_fbased2st_thick_float32_layer_with_high_source_contrast():
+    source = jnp.ones((1, 1), dtype=jnp.float32)
+    source_surface = jnp.full(1, 1.0e12, dtype=jnp.float32)
+
+    for depth in (10.0, 15.0, 20.0):
+        transmission = 2.0 * expn(3, depth)
+        expected = transmission * 1.0e12 + (1.0 - transmission)
+        actual = rt.rtrun_emis_pureabs_fbased2st_surface(
+            jnp.full((1, 1), depth, dtype=jnp.float32),
+            source,
+            source_surface,
+        )
+        np.testing.assert_allclose(actual, expected, rtol=3.0e-5)
+
+
+def test_fbased2st_complementary_form_boundary_value_and_gradient():
+    source = jnp.full((1, 1), 3.0, dtype=jnp.float32)
+    source_surface = jnp.full(1, 7.0, dtype=jnp.float32)
+
+    def flux(depth):
+        return rt.rtrun_emis_pureabs_fbased2st_surface(
+            depth.reshape(1, 1), source, source_surface
+        )[0]
+
+    depth = jnp.float32(0.4190354)
+    transmission = 2.0 * expn(3, float(depth))
+    expected = transmission * 7.0 + (1.0 - transmission) * 3.0
+    expected_gradient = -2.0 * expn(2, float(depth)) * (7.0 - 3.0)
+
+    np.testing.assert_allclose(flux(depth), expected, rtol=1.0e-6)
+    np.testing.assert_allclose(
+        jax.grad(flux)(depth), expected_gradient, rtol=1.0e-6
     )
 
 

--- a/tests/unittests/rt/atmrt/opart_fluxadding_test.py
+++ b/tests/unittests/rt/atmrt/opart_fluxadding_test.py
@@ -5,9 +5,13 @@ import pytest
 from exojax.rt import OpartEmisScat, OpartReflectEmis, OpartReflectPure
 from exojax.rt.planck import piB, piBarr
 from exojax.rt.rtransfer import (
+    rtrun_emis_scat_lart_toonhm,
+    rtrun_emis_scat_lart_toonhm_surface,
     rtrun_emis_scat_fluxadding_toonhm,
     rtrun_reflect_fluxadding_toonhm,
+    setrt_toonhm_with_absorption,
 )
+from exojax.rt.twostream import solve_fluxadding_twostream_fluxes
 
 
 class MockOpaLayer:
@@ -34,18 +38,29 @@ def layer_params_top_to_bottom():
     return [temperature, dtau, single_scattering_albedo, asymmetric_parameter]
 
 
+def thin_toon_inputs(single_scattering_albedo, dtau_value):
+    shape = (100, 1)
+    dtau = jnp.full(shape, dtau_value, dtype=jnp.float32)
+    albedo = jnp.full(shape, single_scattering_albedo, dtype=jnp.float32)
+    asymmetry = jnp.zeros(shape, dtype=jnp.float32)
+    source = jnp.ones(shape, dtype=jnp.float32)
+    boundary = jnp.zeros(1, dtype=jnp.float32)
+    return dtau, albedo, asymmetry, source, boundary
+
+
 @pytest.mark.parametrize("opart_class", [OpartEmisScat, OpartReflectEmis])
 def test_opart_layer_uses_full_thermal_source(opart_class):
     opalayer = MockOpaLayer()
     opart = opart_class(opalayer, nlayer=2)
     temperature = 1000.0
-    dtau = jnp.array([1.0e-3])
-    params = [temperature, dtau, jnp.zeros(1), jnp.zeros(1)]
-    initial_carry = [jnp.zeros(1), jnp.zeros(1)]
+    dtau = jnp.array([1.0e-8], dtype=jnp.float32)
+    zeros = jnp.zeros(1, dtype=jnp.float32)
+    params = [temperature, dtau, zeros, zeros]
+    initial_carry = [zeros, zeros]
 
     _, actual_source = opart.update_layer(initial_carry, params)
 
-    expected_source = (1.0 - jnp.exp(-2.0 * dtau)) * piB(
+    expected_source = -jnp.expm1(-2.0 * dtau) * piB(
         temperature, opalayer.nu_grid
     )
     np.testing.assert_allclose(actual_source, expected_source, rtol=1.0e-5)
@@ -138,3 +153,76 @@ def test_reflect_fluxadding_toonhm_conservative_scattering_limit():
 
     expected = (1.0 - asymmetric_parameter[0]) / (2.0 - asymmetric_parameter[0])
     np.testing.assert_allclose(reflected_flux, expected, rtol=1.0e-6)
+
+
+@pytest.mark.parametrize(
+    "single_scattering_albedo, dtau_value, expected",
+    [
+        (0.5, 1.0e-8, 9.9999948118e-7),
+        (0.99, 1.0e-6, 1.9999980088e-6),
+    ],
+)
+def test_fluxadding_toonhm_thin_float32_layers(
+    single_scattering_albedo, dtau_value, expected
+):
+    dtau, albedo, asymmetry, source, boundary = thin_toon_inputs(
+        single_scattering_albedo, dtau_value
+    )
+
+    actual = rtrun_emis_scat_fluxadding_toonhm(
+        dtau, albedo, asymmetry, source
+    )
+    reflected_emission = rtrun_reflect_fluxadding_toonhm(
+        dtau,
+        albedo,
+        asymmetry,
+        source,
+        boundary,
+        boundary,
+        boundary,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=5.0e-6, atol=0.0)
+    np.testing.assert_allclose(
+        reflected_emission, expected, rtol=5.0e-6, atol=0.0
+    )
+
+
+def test_fluxadding_toonhm_thin_float32_layers_both_directions():
+    dtau, albedo, asymmetry, source, boundary = thin_toon_inputs(0.5, 1.0e-8)
+    toon_coeffs = setrt_toonhm_with_absorption(
+        dtau, albedo, asymmetry, source
+    )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_source = toon_coeffs[:4]
+
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        trans_coeff,
+        scat_coeff,
+        reduced_source,
+        boundary,
+        boundary,
+        absorption_coeff=absorption_coeff,
+    )
+
+    expected = 9.9999948118e-7
+    np.testing.assert_allclose(flux_plus[0], expected, rtol=5.0e-6, atol=0.0)
+    np.testing.assert_allclose(flux_minus[-1], expected, rtol=5.0e-6, atol=0.0)
+
+
+def test_lart_toonhm_thin_float32_layers():
+    dtau, albedo, asymmetry, source, source_surface = thin_toon_inputs(
+        0.5, 1.0e-8
+    )
+
+    spectrum = rtrun_emis_scat_lart_toonhm(
+        dtau, albedo, asymmetry, source
+    )[0]
+    spectrum_surface = rtrun_emis_scat_lart_toonhm_surface(
+        dtau, albedo, asymmetry, source, source_surface
+    )[0]
+
+    expected = 9.9999948118e-7
+    np.testing.assert_allclose(spectrum, expected, rtol=2.0e-6, atol=0.0)
+    np.testing.assert_allclose(
+        spectrum_surface, expected, rtol=2.0e-6, atol=0.0
+    )

--- a/tests/unittests/rt/twostream/toon_test.py
+++ b/tests/unittests/rt/twostream/toon_test.py
@@ -1,11 +1,13 @@
+import jax
+import jax.numpy as jnp
+
 from exojax.rt.toon import zetalambda_coeffs
 from exojax.rt.toon import reduced_source_function_isothermal_layer
 from exojax.rt.toon import reduced_source_function
 from exojax.rt.toon import params_eddington
 from exojax.rt.toon import params_quadrature
 from exojax.rt.toon import params_hemispheric_mean
-
-import jax.numpy as jnp
+from exojax.rt.twostream import set_scat_trans_absorption_coeffs
 
 
 def test_zetalambda_coeffs():
@@ -26,6 +28,15 @@ def test_zetalambda_coeffs_zero_gamma():
     assert jnp.isclose(zeta_plus, 0.5)
     assert jnp.isclose(zeta_minus, 0.5)
     assert jnp.isclose(lambdan, 0.0)
+
+
+def test_absorption_coeff_zero_depth_value_and_gradient():
+    def absorption(dtau):
+        return set_scat_trans_absorption_coeffs(1.5, 0.5, dtau)[2]
+
+    dtau = jnp.float32(0.0)
+    assert jnp.isclose(absorption(dtau), 0.0)
+    assert jnp.isclose(jax.grad(absorption)(dtau), 1.0)
 
 
 def test_reduced_source_function_isothermal_layer():

--- a/tests/unittests/rt/twostream/toon_test.py
+++ b/tests/unittests/rt/twostream/toon_test.py
@@ -7,7 +7,10 @@ from exojax.rt.toon import reduced_source_function
 from exojax.rt.toon import params_eddington
 from exojax.rt.toon import params_quadrature
 from exojax.rt.toon import params_hemispheric_mean
-from exojax.rt.twostream import set_scat_trans_absorption_coeffs
+from exojax.rt.twostream import (
+    set_scat_trans_absorption_coeffs,
+    set_scat_trans_coeffs,
+)
 
 
 def test_zetalambda_coeffs():
@@ -37,6 +40,28 @@ def test_absorption_coeff_zero_depth_value_and_gradient():
     dtau = jnp.float32(0.0)
     assert jnp.isclose(absorption(dtau), 0.0)
     assert jnp.isclose(jax.grad(absorption)(dtau), 1.0)
+
+
+def test_legacy_scat_trans_coeff_api_matches_full_coefficients():
+    gamma_1 = jnp.full(2, 1.5, dtype=jnp.float32)
+    gamma_2 = jnp.full(2, 0.5, dtype=jnp.float32)
+    dtau = jnp.array([1.0e-8, 0.1], dtype=jnp.float32)
+
+    legacy_coeffs = set_scat_trans_coeffs(gamma_1, gamma_2, dtau)
+    full_coeffs = set_scat_trans_absorption_coeffs(
+        gamma_1, gamma_2, dtau
+    )
+    jitted_legacy_coeffs = jax.jit(set_scat_trans_coeffs)(
+        gamma_1, gamma_2, dtau
+    )
+
+    assert len(legacy_coeffs) == 2
+    assert len(full_coeffs) == 3
+    for legacy, full, jitted in zip(
+        legacy_coeffs, full_coeffs[:2], jitted_legacy_coeffs
+    ):
+        assert jnp.array_equal(legacy, full)
+        assert jnp.array_equal(jitted, full)
 
 
 def test_reduced_source_function_isothermal_layer():


### PR DESCRIPTION
## Summary

- compute pure-absorption emissivity directly with `expm1` instead of subtracting a rounded transmission from one
- integrate pure absorption with compensated complementary updates, using absorption in thin layers and transmission in thick layers
- compute and retain the Toon absorption coefficient through flux-adding, LART, SFM, and Opart thermal-source paths
- preserve legacy coefficient APIs without computing and discarding absorption
- select Toon general/Taylor numerators before division to avoid materializing both branches
- add float32 regressions for thin accumulation, surface equilibrium, deep-source attenuation, thick high-contrast layers, gradients, and legacy API compatibility

## Root cause

PRs #745 and #747 stabilized the transmission and scattering coefficients themselves, but thermal emission was still reconstructed as `1 - T` or `1 - T - S`. For optically thin float32 layers, `T` rounds to one or its rounding error exceeds the physical absorption coefficient. This made positive thermal sources vanish or become negative.

The fix evaluates and retains absorption before that information is lost:

- pure absorption uses an `expm1` expression equivalent to `1 - 2 E3`
- Toon uses direct general and Taylor absorption formulas consistent with its transmission and scattering expressions
- pure transfer uses the smaller of complementary `A` and `T` forms with a carried rounding residual, avoiding cancellation in both thin and thick layers

## Impact

For 100 float32 layers with unit source:

- pure absorption, `dtau=1e-8`: `0` -> `1.9999998e-6`
- Toon, `ssa=0.5`, `dtau=1e-8`: `-5.0000023e-7` -> `1.0000005e-6`
- Toon, `ssa=0.99`, `dtau=1e-6`: `-3.6324825e-6` -> `2.0000032e-6`

The pure solver also preserves isothermal atmosphere/surface equilibrium and cumulative attenuation of deep emission by thin upper layers.

On CPU with float32 arrays of shape `(100, 10000)`, the final implementation was faster than the pre-PR `develop` implementation for pure absorption and remained at or below the prior LART memory/runtime envelope. Legacy eager coefficient helpers returned to their pre-PR operation count. LART temporary memory decreased from 36 MB in the initial fix to 24 MB.

## Validation

- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu pytest -q tests/unittests/rt` — 55 passed
- `JAX_PLATFORMS=cpu pytest -q tests/unittests/opacity/xs` — 28 passed
- focused thin/thick float32, API, and gradient regressions — 28 passed
- broad Toon value/gradient sweep — bitwise identical before and after the performance refactor; all gradients finite
- `git diff --check` — passed

GPU benchmarking was not available in the local environment.
