### PR TITLE
Fix atomic VALD opacity paths

### DIFF
--- a/src/exojax/database/core_atom/line_strength.py
+++ b/src/exojax/database/core_atom/line_strength.py
@@ -1,6 +1,6 @@
 import numpy as np
 import jax.numpy as jnp
-from exojax.database.core_atom import io
+from exojax.database.core_atom.pf import partfn_Fe
 from exojax.utils.constants import Tref_original
 from exojax.utils.constants import ccgs
 from exojax.utils.constants import hcperk
@@ -29,7 +29,7 @@ def line_strength_atom(A, gupper, nu_lines, elower, QTref_284, QTmask, Irwin=Fal
 
     # Use Irwin_1981 for Fe I (mask==76)  #test211013Tako
     if Irwin == True:
-        QTref[jnp.where(QTmask == 76)[0]] = core_atom.io.partfn_Fe(Tref_original)
+        QTref[jnp.where(QTmask == 76)[0]] = partfn_Fe(Tref_original)
 
     S0 = (
         -A

--- a/src/exojax/database/core_atom/misc.py
+++ b/src/exojax/database/core_atom/misc.py
@@ -35,7 +35,7 @@ def ielemion_to_FastChemSymbol(ielem, iion):
     Returns:
         SpeciesSymbol in FastChem (str) (cf. https://github.com/exoclime/FastChem/blob/master/input/logK_ext.dat)
     """
-    return (core_atom.io.PeriodicTable[ielem] + "1" + "+" * (iion - 1)).rstrip("1")
+    return (io.PeriodicTable[ielem] + "1" + "+" * (iion - 1)).rstrip("1")
 
 
 def get_VMR_uspecies(
@@ -73,8 +73,8 @@ def get_VMR_uspecies(
 
     mods_ID_uspecies = scan(f_miu, (0, mods_ID_uspecies), uspecies)[0][1]
 
-    ipccd = core_atom.io.load_atomicdata()
-    ItIoI = core_atom.io.ielem_to_index_of_ipccd
+    ipccd = io.load_atomicdata()
+    ItIoI = io.ielem_to_index_of_ipccd
     Narr = jnp.array(10 ** (ipccd["solarA"]))  # number density in the Sun
 
     def f_vmr(i, sp):
@@ -152,7 +152,7 @@ def uspecies_info(
         atomicmass_uspecies_list: jnp.array of atomic mass [amu] of each species in "uspecies"
         mods_uspecies_list: jnp.array of abundance deviation from the Sun [dex] for each species in "uspecies"
     """
-    ipccd = core_atom.io.load_atomicdata()
+    ipccd = io.load_atomicdata()
     Narr = jnp.array(10 ** (ipccd["solarA"]))  # number density
     # mass of each neutral atom per particle [amu]
     massarr = jnp.array(ipccd["mass"])

--- a/src/exojax/database/vald/api.py
+++ b/src/exojax/database/vald/api.py
@@ -390,6 +390,7 @@ class AdbSepVald:
         gQT_284species (jnp array): partition function grid of 284 species
         T_gQT (jnp array): temperatures in the partition function grid
         QTref_284 (jnp array): partition function at the reference temperature Q(Tref), for 284 species
+        Tref (float): reference temperature
     """
 
     def __init__(self, adb):
@@ -422,3 +423,4 @@ class AdbSepVald:
         self.gQT_284species = adb.gQT_284species
         self.T_gQT = adb.T_gQT
         self.QTref_284 = adb.QTref_284
+        self.Tref = adb.Tref

--- a/src/exojax/opacity/modit/modit.py
+++ b/src/exojax/opacity/modit/modit.py
@@ -618,7 +618,7 @@ def vald_all(asdb, Tarr, PH, PHe, PHH, R):
                 None,
                 None,
                 0,
-                0,
+                None,
                 0,
                 0,
                 0,

--- a/tests/unittests/database/atom/core_atom_test.py
+++ b/tests/unittests/database/atom/core_atom_test.py
@@ -1,0 +1,31 @@
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.database.core_atom.line_strength import line_strength_atom
+from exojax.database.core_atom.misc import get_VMR_uspecies
+from exojax.database.core_atom.misc import ielemion_to_FastChemSymbol
+from exojax.database.core_atom.pf import partfn_Fe
+from exojax.utils.constants import Tref_original
+
+
+def test_atomic_species_helpers():
+    assert ielemion_to_FastChemSymbol(26, 1) == "Fe"
+
+    vmr = get_VMR_uspecies(jnp.array([[26, 1], [26, 2]]))
+    np.testing.assert_allclose(vmr[1] / vmr[0], 1.0e-10)
+
+
+def test_line_strength_atom_irwin_partition_function():
+    inputs = (
+        np.ones(1),
+        np.ones(1),
+        np.full(1, 1000.0),
+        np.zeros(1),
+        np.ones(77),
+        np.array([76]),
+    )
+
+    barklem = line_strength_atom(*inputs)
+    irwin = line_strength_atom(*inputs, Irwin=True)
+
+    np.testing.assert_allclose(irwin, barklem / partfn_Fe(Tref_original))

--- a/tests/unittests/opacity/modit/vald_all_test.py
+++ b/tests/unittests/opacity/modit/vald_all_test.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.database.vald.api import AdbSepVald
+from exojax.opacity.modit.modit import vald_all
+
+
+def test_vald_all_uses_shared_partition_function_reference():
+    number_of_species = 2
+    number_of_lines = 1
+    adb = SimpleNamespace(
+        nu_lines=jnp.array([1000.0, 1001.0]),
+        gQT_284species=jnp.ones((284, 2)),
+        T_gQT=jnp.array([100.0, 2000.0]),
+        QTmask=jnp.array([0, 1]),
+        QTref_284=jnp.ones(284),
+        ielem=jnp.array([26, 1]),
+        iion=jnp.ones(number_of_species, dtype=int),
+        atomicmass=jnp.array([56.0, 1.0]),
+        ionE=jnp.array([7.9, 13.6]),
+        dev_nu_lines=jnp.array([1000.0, 1001.0]),
+        logsij0=jnp.log(jnp.full(number_of_species, 1.0e-20)),
+        elower=jnp.zeros(number_of_species),
+        eupper=jnp.ones(number_of_species),
+        gamRad=jnp.zeros(number_of_species),
+        gamSta=jnp.zeros(number_of_species),
+        vdWdamp=jnp.full(number_of_species, -7.0),
+        Tref=296.0,
+    )
+    asdb = AdbSepVald(adb)
+    temperatures = jnp.array([1000.0, 1200.0])
+    partial_pressure = jnp.full_like(temperatures, 1.0e-3)
+
+    results = vald_all(
+        asdb,
+        temperatures,
+        partial_pressure,
+        partial_pressure,
+        partial_pressure,
+        1.0e5,
+    )
+
+    for result in results:
+        assert result.shape == (number_of_species, len(temperatures), number_of_lines)
+        assert np.all(np.isfinite(result))


### PR DESCRIPTION
## Summary

- Keep the 284-entry VALD reference partition function shared across species in `vald_all`.
- Fix stale atomic I/O references and import the Irwin Fe partition function from its current module.
- Preserve the reference temperature when constructing `AdbSepVald`.
- Add lightweight regression tests for the two-species VALD path and atomic helpers.

## Root cause

PR #751 repaired the downstream `xsmatrix_vald` dispatch, but the upstream atomic path still had three independent blockers:

1. `vald_all` mapped the shared `QTref_284.shape == (284,)` over the species axis, conflicting with `Nspecies`.
2. The atomic database reorganization updated imports without updating the remaining `core_atom.io` references; `partfn_Fe` had also moved to `core_atom.pf`.
3. `AdbSepVald` did not copy `Tref`, although the VALD MODIT helpers consume it.

## Scope

MODIT is planned for removal, so this change only repairs the existing legacy path. It does not refactor or extend the MODIT API. The shared atomic helpers remain relevant outside MODIT and are fixed directly.

## Validation

- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu pytest -q tests/unittests/database/atom tests/unittests/opacity/modit` (17 passed)
- `ruff check src/exojax/database/core_atom/misc.py src/exojax/database/core_atom/line_strength.py src/exojax/database/vald/api.py src/exojax/opacity/modit/modit.py --select F821`
- `ruff check tests/unittests/database/atom/core_atom_test.py tests/unittests/opacity/modit/vald_all_test.py`
- `git diff origin/develop...HEAD --check`
