### PR TITLE
Fix ArtAbsPure partial-layer integration

### DIFF
--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -9,12 +9,9 @@ from jax.lax import scan
 
 
 def _surface_optical_depth(dtau, pressure_boundary, pressure_surface):
-    """Integrate layer optical depths down to a surface pressure."""
-    log_pressure_boundary = jnp.log10(pressure_boundary)
-    log_pressure_surface = jnp.log10(pressure_surface)
+    """Integrate layer optical depths using linear-pressure fractions."""
     layer_fraction = jnp.clip(
-        (log_pressure_surface - log_pressure_boundary[:-1])
-        / jnp.diff(log_pressure_boundary),
+        (pressure_surface - pressure_boundary[:-1]) / jnp.diff(pressure_boundary),
         0.0,
         1.0,
     )

--- a/tests/unittests/rt/atmrt/artabs_test.py
+++ b/tests/unittests/rt/atmrt/artabs_test.py
@@ -1,65 +1,62 @@
 import pytest
 from exojax.rt import ArtAbsPure
-from exojax.utils.grids import wavenumber_grid
 import jax.numpy as jnp
 
 
-def _toy_artabs_case():
+def _constant_opacity_artabs_case():
     art = ArtAbsPure(
         pressure_top=1.0e-3,
         pressure_btm=1.0e1,
         nlayer=5,
         nu_grid=jnp.array([1.0]),
     )
-    dtau = jnp.array([[1.0], [2.0], [4.0], [8.0], [16.0]])
+    dtau = jnp.asarray(art.dParr)[:, jnp.newaxis]
     incoming_flux = jnp.ones(1)
     return art, dtau, incoming_flux
 
 
 def test_artabs_run_at_toa():
-    """Test the run method of ArtAbsPure at TOA
-    Note:
-        why the answer is exp(-3.5*2)? This test assumes the d(log10 P) = 1
-        and pressure = [-3,-2,-1,0,1] this is (log) center of the layers.
-        We integrate the dtau over d log10 P = -3.5 to 0 with dtau = 1 for each layer.
-        3 layers + 0.5 layer = 3.5 layers. we get tau = 3.5,
-        but the observer is lcocated at the top of the atmosphere.
-        then we need to multiply 2.
-
-    """
-    nu_grid, wav, res = wavenumber_grid(22990.0, 23000.0, 2, xsmode="premodit")
-    art = ArtAbsPure(pressure_top=1.0e-3, pressure_btm=1.0e1, nlayer=5, nu_grid=nu_grid)
-    dtau = jnp.ones((art.nlayer, len(nu_grid)))
-    incf = jnp.ones_like(nu_grid)
+    """Test constant-opacity attenuation for an observer at the TOA."""
+    art, dtau, incoming_flux = _constant_opacity_artabs_case()
     ps = 1.0e0  # bar
-    f = art.run(dtau, pressure_surface=ps, incoming_flux=incf, mu_in=1.0, mu_out=1.0)
+    spectrum = art.run(
+        dtau,
+        pressure_surface=ps,
+        incoming_flux=incoming_flux,
+        mu_in=1.0,
+        mu_out=1.0,
+    )
+    expected_tau = ps - art.pressure_boundary[0]
 
-    assert f[0] == pytest.approx(jnp.exp(-3.5 * 2))
+    assert spectrum[0] == pytest.approx(jnp.exp(-2.0 * expected_tau))
 
 
 def test_artabs_run_at_ground():
-    nu_grid, wav, res = wavenumber_grid(22990.0, 23000.0, 2, xsmode="premodit")
-    art = ArtAbsPure(pressure_top=1.0e-3, pressure_btm=1.0e1, nlayer=5, nu_grid=nu_grid)
-    print(art.pressure)
-    dtau = jnp.ones((art.nlayer, len(nu_grid)))
-    incf = jnp.ones_like(nu_grid)
+    art, dtau, incoming_flux = _constant_opacity_artabs_case()
     deltalogp = 0.3
     ps = 10 ** (deltalogp)  # bar
-    f = art.run(dtau, pressure_surface=ps, incoming_flux=incf, mu_in=1.0, mu_out=None)
+    spectrum = art.run(
+        dtau,
+        pressure_surface=ps,
+        incoming_flux=incoming_flux,
+        mu_in=1.0,
+        mu_out=None,
+    )
+    expected_tau = ps - art.pressure_boundary[0]
 
-    assert f[0] == pytest.approx(jnp.exp(-(3.5 + deltalogp)))
+    assert spectrum[0] == pytest.approx(jnp.exp(-expected_tau))
 
 
 @pytest.mark.parametrize(
-    ("pressure_surface", "expected_tau"),
+    "pressure_surface",
     [
-        (1.0, 11.0),
-        (10**-0.5, 7.0),
-        (1.0e-3, 0.5),
+        1.0,
+        10**-0.5,
+        1.0e-3,
     ],
 )
-def test_artabs_run_partial_layer(pressure_surface, expected_tau):
-    art, dtau, incoming_flux = _toy_artabs_case()
+def test_artabs_run_partial_layer(pressure_surface):
+    art, dtau, incoming_flux = _constant_opacity_artabs_case()
 
     spectrum = art.run(
         dtau,
@@ -68,12 +65,13 @@ def test_artabs_run_partial_layer(pressure_surface, expected_tau):
         mu_in=1.0,
         mu_out=None,
     )
+    expected_tau = pressure_surface - art.pressure_boundary[0]
 
     assert spectrum[0] == pytest.approx(jnp.exp(-expected_tau))
 
 
 def test_artabs_run_ckd_partial_layer():
-    art, dtau, incoming_flux = _toy_artabs_case()
+    art, dtau, incoming_flux = _constant_opacity_artabs_case()
     dtau_ckd = jnp.stack([dtau, 2.0 * dtau], axis=1)
     weights = jnp.array([0.25, 0.75])
 
@@ -86,7 +84,8 @@ def test_artabs_run_ckd_partial_layer():
         weights=weights,
     )
 
-    expected = 0.25 * jnp.exp(-11.0) + 0.75 * jnp.exp(-22.0)
+    expected_tau = 1.0 - art.pressure_boundary[0]
+    expected = 0.25 * jnp.exp(-expected_tau) + 0.75 * jnp.exp(-2.0 * expected_tau)
     assert spectrum[0] == pytest.approx(expected)
 
 


### PR DESCRIPTION
## Summary

- integrate `ArtAbsPure` partial layers using linear-pressure fractions
- replace log-pressure regression assumptions with constant-opacity analytic cases
- cover both line-by-line and CKD paths while retaining the boundary cases added in #742

## Root cause

PR #742 fixed partial-layer indexing and exact-boundary handling, but preserved log-pressure interpolation. ExoJAX's standard optical-depth construction uses `dtau ∝ dParr`, so truncating a layer must use its linear-pressure fraction.

## Impact

For the five-layer constant-opacity regression at `pressure_surface = 1 bar`, the optical depth changes from `1.738936` to the analytic value `0.999684`. This prevents overestimated absorption when the surface lies inside a layer. Exact layer boundaries are unchanged.

## Validation

- `JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/rt/atmrt/artabs_test.py` — 6 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/rt/atmrt` — 34 passed
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1 pytest -q tests/unittests/opacity/ckd/abspure_ckd_test.py` — 2 passed
- `git diff --check` passed