### PR TITLE
Fix direct PyMieScatt execution

### DIFF
--- a/src/exojax/database/mie.py
+++ b/src/exojax/database/mie.py
@@ -248,6 +248,11 @@ def mie_lognormal_pymiescatt(
     Returns:
         _type_: _description_
     """
+    from scipy import integrate
+
+    if not hasattr(integrate, "trapz"):
+        integrate.trapz = integrate.trapezoid
+
     from PyMieScatt.Mie import Mie_SD
 
     from exojax.special.lognormal import pdf

--- a/src/exojax/opacity/opacont.py
+++ b/src/exojax/opacity/opacont.py
@@ -440,9 +440,22 @@ class OpaMie(OpaCont):
                 - asymmetric_factor: Asymmetry parameter matrix [Nlayer, Nnu]
 
         Notes:
-            Uses vectorized direct PyMieScatt calculations.
+            Evaluates each layer sequentially because PyMieScatt uses NumPy.
             Slower than grid interpolation but avoids pre-computation requirements.
         """
 
-        f = vmap(self.mieparams_vector_direct_from_pymiescatt, (0, 0), 0)
-        return f(rg_layer, sigmag_layer)
+        rg_layer = np.asarray(rg_layer)
+        sigmag_layer = np.asarray(sigmag_layer)
+        if len(rg_layer) != len(sigmag_layer):
+            raise ValueError("rg_layer and sigmag_layer must have the same length")
+
+        mieparams = [
+            self.mieparams_vector_direct_from_pymiescatt(rg, sigmag)
+            for rg, sigmag in zip(rg_layer, sigmag_layer)
+        ]
+        sigma_extinction, sigma_scattering, asymmetric_factor = zip(*mieparams)
+        return (
+            jnp.stack(sigma_extinction),
+            jnp.stack(sigma_scattering),
+            jnp.stack(asymmetric_factor),
+        )

--- a/tests/unittests/database/clouds/mie_test.py
+++ b/tests/unittests/database/clouds/mie_test.py
@@ -1,7 +1,9 @@
 from exojax.special.lognormal import cubeweighted_pdf
 from exojax.database.mie import auto_rgrid
 from exojax.database.mie import cubeweighted_integral_checker
+from exojax.database.mie import mie_lognormal_pymiescatt
 import numpy as np
+from scipy import integrate
 
 
 def test_autogrid():
@@ -50,6 +52,23 @@ def test_cubeweighted_integral_checker():
     check = cubeweighted_integral_checker(rgrid, rg_nm, sigmag)
 
     assert check
+
+
+def test_mie_lognormal_pymiescatt_without_scipy_trapz(monkeypatch):
+    monkeypatch.delattr(integrate, "trapz", raising=False)
+
+    coefficients = mie_lognormal_pymiescatt(
+        1.5 + 0.01j,
+        wavelength=500.0,
+        sigmag=2.0,
+        rg=100.0,
+        N0=1.0,
+        rgrid=np.linspace(1.0, 1000.0, 10),
+    )
+
+    assert integrate.trapz is integrate.trapezoid
+    assert np.shape(coefficients) == (7,)
+    assert np.all(np.isfinite(coefficients))
 
 
 if __name__ == "__main__":

--- a/tests/unittests/database/clouds/opamie_test.py
+++ b/tests/unittests/database/clouds/opamie_test.py
@@ -56,6 +56,31 @@ def test_mieparams_vector_direct_uses_wavelength_nm(monkeypatch):
     np.testing.assert_allclose(passed_wavelengths, wavelength_nm)
 
 
+def test_mieparams_matrix_direct_uses_scalar_calls(monkeypatch):
+    opa = OpaMie(SimpleNamespace(), np.arange(3))
+
+    def mock_mieparams_vector(rg, sigmag):
+        rg = float(rg)
+        sigmag = float(sigmag)
+        return (
+            np.full(3, rg),
+            np.full(3, sigmag),
+            np.full(3, rg + sigmag),
+        )
+
+    monkeypatch.setattr(
+        opa, "mieparams_vector_direct_from_pymiescatt", mock_mieparams_vector
+    )
+
+    result = opa.mieparams_matrix_direct_from_pymiescatt(
+        jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])
+    )
+
+    np.testing.assert_allclose(result[0], [[1.0] * 3, [2.0] * 3])
+    np.testing.assert_allclose(result[1], [[3.0] * 3, [4.0] * 3])
+    np.testing.assert_allclose(result[2], [[4.0] * 3, [6.0] * 3])
+
+
 def test_mieparams_matrix():
     pdb = mock_PdbPlouds(nurange=[12000.0, 15000.0])
     pdb.load_miegrid()


### PR DESCRIPTION
## Summary

- replace `jax.vmap` around the NumPy/PyMieScatt direct Mie path with sequential per-layer evaluation
- add a SciPy compatibility alias for PyMieScatt when `scipy.integrate.trapz` is unavailable
- add regression tests for matrix execution and SciPy 1.14+ compatibility

## Root cause

The direct matrix method passed JAX tracers into Python conditionals and NumPy/PyMieScatt code, causing `TracerBoolConversionError`. Separately, PyMieScatt 1.8.1.1 imports the removed `scipy.integrate.trapz` symbol and fails with SciPy 1.14+.

This is a follow-up to #754. The wavelength conversion fixed there remains unchanged.

## Impact

Both scalar and layer-matrix direct Mie calculations work with current SciPy while preserving the matrix method's JAX array outputs.

## Validation

- `pytest -q tests/unittests/database/clouds/opamie_test.py tests/unittests/database/clouds/mie_test.py` (9 passed)
- `pytest -q tests/unittests/database/clouds` (13 passed)
- real PyMieScatt two-layer calculation: three `(2, 3)` finite outputs
- `git diff --check`
