### PR TITLE
Stabilize thick conservative two-stream scattering

### DIFF
--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -599,7 +599,11 @@ class OpartEmisScat(ArtCommon):
         )
         trans_coeff_i, scat_coeff_i, absorption_coeff_i, reduced_piB_i = toon_coeffs[:4]
         pihatB_i = absorption_coeff_i * reduced_piB_i
-        denom = 1.0 - scat_coeff_i * Rphat_prev
+        non_scattering_coeff_i = trans_coeff_i + absorption_coeff_i
+        denom = (
+            non_scattering_coeff_i
+            + scat_coeff_i * (1.0 - Rphat_prev)
+        )
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom
         )

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -501,7 +501,11 @@ class OpartReflectEmis(ArtCommon):
         )
         trans_coeff_i, scat_coeff_i, absorption_coeff_i, reduced_piB_i = toon_coeffs[:4]
         pihatB_i = absorption_coeff_i * reduced_piB_i
-        denom = 1.0 - scat_coeff_i * Rphat_prev
+        non_scattering_coeff_i = trans_coeff_i + absorption_coeff_i
+        denom = (
+            non_scattering_coeff_i
+            + scat_coeff_i * (1.0 - Rphat_prev)
+        )
         Sphat_each = (
             pihatB_i + trans_coeff_i * (Sphat_prev + pihatB_i * Rphat_prev) / denom
         )

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -712,7 +712,10 @@ def settridiag_toohm(
 
     # emission (no reflection)
     if absorption_coeff is None:
-        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+        raw_absorption_coeff = (1.0 - trans_coeff) - scat_coeff
+        absorption_coeff = jnp.where(
+            raw_absorption_coeff < 0.0, 0.0, raw_absorption_coeff
+        )
     vector_top = absorption_coeff[0, :] * reduced_piB[0, :]
 
     # tridiagonal elements

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -11,6 +11,17 @@ import jax.numpy as jnp
 from jax.lax import scan
 
 
+def _pack_scat_and_non_scattering_coeffs(
+    scat_coeff, non_scattering_coeff
+):
+    """Packs the smaller complement, using negative values to mark T + A."""
+    return jnp.where(
+        non_scattering_coeff < scat_coeff,
+        -non_scattering_coeff,
+        scat_coeff,
+    )
+
+
 def solve_fluxadding_twostream(
     trans_coeff,
     scat_coeff,
@@ -69,8 +80,16 @@ def compute_fluxadding_coeffs(
     """
 
     if absorption_coeff is None:
-        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+        raw_absorption_coeff = (1.0 - trans_coeff) - scat_coeff
+        absorption_coeff = jnp.where(
+            raw_absorption_coeff < 0.0, 0.0, raw_absorption_coeff
+        )
+    absorption_coeff = jnp.broadcast_to(absorption_coeff, trans_coeff.shape)
     pihatB = absorption_coeff * reduced_source_function
+    non_scattering_coeff = trans_coeff + absorption_coeff
+    stable_scat_coeff = _pack_scat_and_non_scattering_coeffs(
+        scat_coeff, non_scattering_coeff
+    )
 
     # bottom reflection
     Rplus_bottom = reflectivity_bottom
@@ -78,8 +97,19 @@ def compute_fluxadding_coeffs(
 
     def f(carry_ip1, arr):
         Rplus_prev, Splus_prev = carry_ip1
-        scat_coeff_i, trans_coeff_i, pihatB_i = arr
-        denom = 1.0 - scat_coeff_i * Rplus_prev
+        stable_scat_coeff_i, trans_coeff_i, pihatB_i = arr
+        stores_non_scattering = jnp.signbit(stable_scat_coeff_i)
+        scat_coeff_i = jnp.where(
+            stores_non_scattering,
+            1.0 + stable_scat_coeff_i,
+            stable_scat_coeff_i,
+        )
+        scat_reflect = stable_scat_coeff_i * Rplus_prev
+        denom = jnp.where(
+            stores_non_scattering,
+            (1.0 - Rplus_prev) - scat_reflect,
+            1.0 - scat_reflect,
+        )
         Splus_each = (
             pihatB_i + trans_coeff_i * (Splus_prev + pihatB_i * Rplus_prev) / denom
         )
@@ -89,7 +119,7 @@ def compute_fluxadding_coeffs(
 
     # main loop
     arrin = [
-        scat_coeff[::-1],
+        stable_scat_coeff[::-1],
         trans_coeff[::-1],
         pihatB[::-1],
     ]
@@ -130,15 +160,34 @@ def compute_fluxadding_downward_coeffs(
         source_top = jnp.zeros(Nnus)
 
     if absorption_coeff is None:
-        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+        raw_absorption_coeff = (1.0 - trans_coeff) - scat_coeff
+        absorption_coeff = jnp.where(
+            raw_absorption_coeff < 0.0, 0.0, raw_absorption_coeff
+        )
+    absorption_coeff = jnp.broadcast_to(absorption_coeff, trans_coeff.shape)
     pihatB = absorption_coeff * reduced_source_function
+    non_scattering_coeff = trans_coeff + absorption_coeff
+    stable_scat_coeff = _pack_scat_and_non_scattering_coeffs(
+        scat_coeff, non_scattering_coeff
+    )
     Rminus_top = jnp.zeros(Nnus)
     Sminus_top = source_top
 
     def f(carry_i, arr):
         Rminus_prev, Sminus_prev = carry_i
-        scat_coeff_i, trans_coeff_i, pihatB_i = arr
-        denom = 1.0 - scat_coeff_i * Rminus_prev
+        stable_scat_coeff_i, trans_coeff_i, pihatB_i = arr
+        stores_non_scattering = jnp.signbit(stable_scat_coeff_i)
+        scat_coeff_i = jnp.where(
+            stores_non_scattering,
+            1.0 + stable_scat_coeff_i,
+            stable_scat_coeff_i,
+        )
+        scat_reflect = stable_scat_coeff_i * Rminus_prev
+        denom = jnp.where(
+            stores_non_scattering,
+            (1.0 - Rminus_prev) - scat_reflect,
+            1.0 - scat_reflect,
+        )
         Sminus_each = (
             pihatB_i + trans_coeff_i * (Sminus_prev + pihatB_i * Rminus_prev) / denom
         )
@@ -146,7 +195,7 @@ def compute_fluxadding_downward_coeffs(
         RS = [Rminus_each, Sminus_each]
         return RS, RS
 
-    arrin = [scat_coeff, trans_coeff, pihatB]
+    arrin = [stable_scat_coeff, trans_coeff, pihatB]
     _, stackedRS = scan(f, [Rminus_top, Sminus_top], arrin)
     Rminus_layers, Sminus_layers = stackedRS
 
@@ -196,8 +245,9 @@ def solve_fluxadding_twostream_fluxes(
         absorption_coeff,
     )
 
-    denom = 1.0 - Rplus * Rminus
-    flux_plus = (Rplus * Sminus + Splus) / denom
+    denom = (1.0 - Rplus) + Rplus * (1.0 - Rminus)
+    numerator = Rplus * Sminus + Splus
+    flux_plus = numerator / denom
     flux_minus = Rminus * flux_plus + Sminus
     return flux_plus, flux_minus
 
@@ -363,12 +413,30 @@ def _set_scat_trans_coefficients(
     trans_coeff = jnp.where(
         use_taylor, trans_numerator_taylor, trans_numerator
     ) / selected_denom
+    if not return_absorption:
+        non_scattering_numerator_taylor = (
+            cosh_taylor
+            + (gamma_1 - gamma_2) * dtau * sinhc_taylor
+        )
+        use_scat_complement = use_taylor & (
+            non_scattering_numerator_taylor < scat_numerator_taylor
+        )
+        stable_scat_numerator_taylor = jnp.where(
+            use_scat_complement,
+            non_scattering_numerator_taylor,
+            scat_numerator_taylor,
+        )
+        scat_coeff = jnp.where(
+            use_taylor, stable_scat_numerator_taylor, scat_numerator
+        ) / selected_denom
+        scat_coeff = jnp.where(
+            use_scat_complement, 1.0 - scat_coeff, scat_coeff
+        )
+        return trans_coeff, scat_coeff
+
     scat_coeff = jnp.where(
         use_taylor, scat_numerator_taylor, scat_numerator
     ) / selected_denom
-    if not return_absorption:
-        return trans_coeff, scat_coeff
-
     one_minus_trans_func = -jnp.expm1(-lambda_dtau)
     absorption_numerator = (
         one_minus_trans_func**2 + 2.0 * (gamma_1 - gamma_2) * dtau * phi
@@ -380,7 +448,12 @@ def _set_scat_trans_coefficients(
     absorption_coeff = jnp.where(
         use_taylor, absorption_numerator_taylor, absorption_numerator
     ) / selected_denom
-
+    non_scattering_coeff = trans_coeff + absorption_coeff
+    scat_coeff = jnp.where(
+        non_scattering_coeff < scat_coeff,
+        1.0 - non_scattering_coeff,
+        scat_coeff,
+    )
     return trans_coeff, scat_coeff, absorption_coeff
 
 
@@ -429,7 +502,10 @@ def compute_tridiag_diagonals_and_vector(
 
     # vector
     if absorption_coeff is None:
-        absorption_coeff = 1.0 - trans_coeff - scat_coeff
+        raw_absorption_coeff = (1.0 - trans_coeff) - scat_coeff
+        absorption_coeff = jnp.where(
+            raw_absorption_coeff < 0.0, 0.0, raw_absorption_coeff
+        )
     hatpiB = absorption_coeff * piB
     hatpiB_minus_one = jnp.roll(hatpiB, 1, axis=0)
     vector = rn_minus * hatpiB - rn * (Tn_minus_one - Sn_minus_one) * hatpiB_minus_one

--- a/tests/unittests/rt/atmrt/opart_fluxadding_test.py
+++ b/tests/unittests/rt/atmrt/opart_fluxadding_test.py
@@ -9,9 +9,15 @@ from exojax.rt.rtransfer import (
     rtrun_emis_scat_lart_toonhm_surface,
     rtrun_emis_scat_fluxadding_toonhm,
     rtrun_reflect_fluxadding_toonhm,
+    setrt_toonhm,
     setrt_toonhm_with_absorption,
+    settridiag_toohm,
 )
-from exojax.rt.twostream import solve_fluxadding_twostream_fluxes
+from exojax.rt.twostream import (
+    solve_fluxadding_twostream,
+    solve_fluxadding_twostream_fluxes,
+    solve_lart_twostream,
+)
 
 
 class MockOpaLayer:
@@ -226,3 +232,149 @@ def test_lart_toonhm_thin_float32_layers():
     np.testing.assert_allclose(
         spectrum_surface, expected, rtol=2.0e-6, atol=0.0
     )
+
+
+def test_fluxadding_toonhm_thick_conservative_scattering():
+    def thermal_flux(layer_depth):
+        shape = (2, 1)
+        dtau = jnp.full(shape, layer_depth, dtype=jnp.float32)
+        albedo = jnp.ones(shape, dtype=jnp.float32)
+        asymmetry = jnp.zeros(shape, dtype=jnp.float32)
+        source = jnp.ones(shape, dtype=jnp.float32)
+        return rtrun_emis_scat_fluxadding_toonhm(
+            dtau, albedo, asymmetry, source
+        )[0]
+
+    def reflected_flux(layer_depth):
+        shape = (1, 1)
+        dtau = jnp.full(shape, layer_depth, dtype=jnp.float32)
+        albedo = jnp.ones(shape, dtype=jnp.float32)
+        asymmetry = jnp.zeros(shape, dtype=jnp.float32)
+        source = jnp.ones(shape, dtype=jnp.float32)
+        zeros = jnp.zeros(1, dtype=jnp.float32)
+        ones = jnp.ones(1, dtype=jnp.float32)
+        return rtrun_reflect_fluxadding_toonhm(
+            dtau,
+            albedo,
+            asymmetry,
+            source,
+            zeros,
+            ones,
+            ones,
+        )[0]
+
+    layer_depth = jnp.float32(2**24)
+    np.testing.assert_array_equal(thermal_flux(layer_depth), 0.0)
+    np.testing.assert_array_equal(reflected_flux(layer_depth), 1.0)
+    np.testing.assert_array_equal(
+        thermal_flux(jnp.float32(2**25)), 0.0
+    )
+    np.testing.assert_array_equal(
+        reflected_flux(jnp.float32(2**25)), 1.0
+    )
+
+    dtau = jnp.full((2, 1), layer_depth, dtype=jnp.float32)
+    albedo = jnp.ones_like(dtau)
+    asymmetry = jnp.zeros_like(dtau)
+    source = jnp.ones_like(dtau)
+    boundary = jnp.zeros(1, dtype=jnp.float32)
+    toon_coeffs = setrt_toonhm_with_absorption(
+        dtau, albedo, asymmetry, source
+    )
+    _, transmitted_bottom_source = solve_fluxadding_twostream(
+        toon_coeffs[0],
+        toon_coeffs[1],
+        toon_coeffs[3],
+        boundary,
+        jnp.ones(1, dtype=jnp.float32),
+        absorption_coeff=toon_coeffs[2],
+    )
+    expected_transmission = jnp.array(
+        [1.0 / (1.0 + 2.0 * layer_depth)], dtype=jnp.float32
+    )
+    np.testing.assert_allclose(
+        transmitted_bottom_source, expected_transmission, rtol=2.0e-6
+    )
+
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        toon_coeffs[0],
+        toon_coeffs[1],
+        toon_coeffs[3],
+        boundary,
+        boundary,
+        absorption_coeff=toon_coeffs[2],
+    )
+    np.testing.assert_array_equal(flux_plus, jnp.zeros_like(flux_plus))
+    np.testing.assert_array_equal(flux_minus, jnp.zeros_like(flux_minus))
+
+
+def test_lart_toonhm_thick_conservative_scattering_legacy_coefficients():
+    depth = 2**24
+    shape = (2, 1)
+    dtau = jnp.full(shape, depth, dtype=jnp.float32)
+    albedo = jnp.ones(shape, dtype=jnp.float32)
+    asymmetry = jnp.zeros(shape, dtype=jnp.float32)
+    source = jnp.ones(shape, dtype=jnp.float32)
+
+    trans_coeff, scat_coeff, reduced_source, zeta_plus, zeta_minus, lambdan = (
+        setrt_toonhm(dtau, albedo, asymmetry, source)
+    )
+    diagonal, lower_diagonal, upper_diagonal, vector = settridiag_toohm(
+        dtau,
+        zeta_plus,
+        zeta_minus,
+        lambdan,
+        trans_coeff,
+        scat_coeff,
+        reduced_source,
+    )
+    cumulative_transmission, source_terms, spectrum = solve_lart_twostream(
+        diagonal,
+        lower_diagonal,
+        upper_diagonal,
+        vector,
+        jnp.zeros(1, dtype=jnp.float32),
+    )
+
+    assert jnp.all(jnp.isfinite(cumulative_transmission))
+    assert jnp.all(jnp.isfinite(source_terms))
+    expected_transmission = jnp.array(
+        [1.0, 1.0 / (1.0 + depth), 1.0 / (1.0 + 2.0 * depth)],
+        dtype=jnp.float32,
+    )[:, None]
+    np.testing.assert_allclose(
+        cumulative_transmission,
+        expected_transmission,
+        rtol=2.0e-6,
+    )
+    np.testing.assert_array_equal(source_terms, jnp.zeros_like(source_terms))
+    np.testing.assert_array_equal(spectrum, jnp.zeros_like(spectrum))
+    np.testing.assert_array_equal(
+        rtrun_emis_scat_lart_toonhm(
+            dtau, albedo, asymmetry, source
+        )[0],
+        jnp.zeros(1, dtype=jnp.float32),
+    )
+
+
+def test_fluxadding_uses_explicit_absorption_in_denominator():
+    trans_coeff = jnp.full((1, 1), 2.0**-27, dtype=jnp.float32)
+    scat_coeff = jnp.ones((1, 1), dtype=jnp.float32)
+    absorption_coeff = jnp.float32(2.0**-26)
+    source = jnp.ones((1, 1), dtype=jnp.float32)
+
+    _, effective_source = solve_fluxadding_twostream(
+        trans_coeff,
+        scat_coeff,
+        source,
+        jnp.ones(1, dtype=jnp.float32),
+        jnp.zeros(1, dtype=jnp.float32),
+        absorption_coeff=absorption_coeff,
+    )
+
+    expected = absorption_coeff + (
+        trans_coeff[0, 0]
+        * absorption_coeff
+        / (trans_coeff[0, 0] + absorption_coeff)
+    )
+    np.testing.assert_array_equal(effective_source, expected)

--- a/tests/unittests/rt/twostream/toon_test.py
+++ b/tests/unittests/rt/twostream/toon_test.py
@@ -64,6 +64,80 @@ def test_legacy_scat_trans_coeff_api_matches_full_coefficients():
         assert jnp.array_equal(jitted, full)
 
 
+def test_thick_conservative_scattering_coefficients_float32():
+    thin_dtau = jnp.float32(1.0e-8)
+    dtau = jnp.float32(2**24)
+
+    for coefficient_function in (
+        set_scat_trans_coeffs,
+        set_scat_trans_absorption_coeffs,
+    ):
+        thin_scat_coeff = coefficient_function(
+            1.0, 1.0, thin_dtau
+        )[1]
+        assert thin_scat_coeff > 0.0
+        assert jnp.isclose(thin_scat_coeff, thin_dtau)
+
+    legacy_coeffs = set_scat_trans_coeffs(1.0, 1.0, dtau)
+    full_coeffs = set_scat_trans_absorption_coeffs(1.0, 1.0, dtau)
+
+    for trans_coeff, scat_coeff in (legacy_coeffs, full_coeffs[:2]):
+        assert trans_coeff > 0.0
+        assert scat_coeff < 1.0
+        assert scat_coeff == 1.0 - trans_coeff
+    assert full_coeffs[2] == 0.0
+
+    grad_trans, grad_scat, grad_absorption = jax.jacfwd(
+        lambda depth: set_scat_trans_absorption_coeffs(1.0, 1.0, depth)
+    )(dtau)
+    assert jnp.isfinite(grad_trans)
+    assert grad_scat == -grad_trans
+    assert grad_absorption == 0.0
+    legacy_depth_grad = jax.grad(
+        lambda depth: set_scat_trans_coeffs(1, 1, depth)[1]
+    )(dtau)
+    assert legacy_depth_grad == grad_scat
+
+    def scattering_coeff(single_scattering_albedo, coefficient_function):
+        return coefficient_function(
+            2.0 - single_scattering_albedo,
+            single_scattering_albedo,
+            dtau,
+        )[1]
+
+    legacy_grad = jax.grad(
+        lambda albedo: scattering_coeff(albedo, set_scat_trans_coeffs)
+    )(jnp.float32(1.0))
+    full_grad = jax.grad(
+        lambda albedo: scattering_coeff(
+            albedo, set_scat_trans_absorption_coeffs
+        )
+    )(jnp.float32(1.0))
+    assert legacy_grad > 0.0
+    assert jnp.isclose(legacy_grad, full_grad)
+
+    def thick_nonconservative_scat(gamma_1, coefficient_function):
+        return coefficient_function(
+            gamma_1,
+            jnp.float32(0.21573891),
+            jnp.float32(89321872.0),
+        )[1]
+
+    gamma_1 = jnp.float32(1.9849839)
+    thick_nonconservative_grad = jax.grad(
+        lambda value: thick_nonconservative_scat(
+            value, set_scat_trans_coeffs
+        )
+    )(gamma_1)
+    expected_grad = jax.grad(
+        lambda value: thick_nonconservative_scat(
+            value, set_scat_trans_absorption_coeffs
+        )
+    )(gamma_1)
+    assert jnp.isfinite(thick_nonconservative_grad)
+    assert jnp.isclose(thick_nonconservative_grad, expected_grad)
+
+
 def test_reduced_source_function_isothermal_layer():
     single_scattering_albedo = 0.5
     gamma_1 = 2.0


### PR DESCRIPTION
## Summary

- evaluate the conservative-scattering Taylor endpoint through the smaller complementary numerator, preserving both thin-layer scattering and the thick-layer relation `S = 1 - T` in float32
- construct flux-adding denominators from a stable representation of `S` and `T + A` while retaining the existing three-input scan
- preserve the direct absorption coefficient introduced in #757, including the legacy two-output early return, and prevent roundoff-only negative fallback absorption
- apply the same direct-`A` denominator to the emission/reflection Opart updates

This completes the thick conservative-scattering endpoint case left uncovered by #747. For `omega=1`, `g=0`, and `dtau=2**24`, the coefficients are now `T=5.9604645e-8`, `S=0.99999994`, and `A=0`.

### explanation for emis.py for instance...

The original denominator was

  denom = 1.0 - scat_coeff_i * Rphat_prev

  Let

  - T = trans_coeff_i
  - S = scat_coeff_i
  - A = absorption_coeff_i

  Because these coefficients physically satisfy

  T + S + A = 1,

  the denominator can be rewritten as

  1 - S R
  = (1 - S) + S(1 - R)
  = (T + A) + S(1 - R).

  This leads directly to the following implementation:

  non_scattering_coeff_i = trans_coeff_i + absorption_coeff_i
  denom = (
      non_scattering_coeff_i
      + scat_coeff_i * (1.0 - Rphat_prev)
  )

  For a thick conservative-scattering layer, A = 0, S ≈ 1, and T is very small. With the original expression, S *
  Rphat_prev could round to 1.0 in float32, giving

  1 - S R = 0.

  With the rewritten expression, even when Rphat_prev = 1,

  denom = T + A = T,

  so the small transmission contribution is preserved instead of being lost to rounding.



## Regression coverage

- two conservative layers over a black lower boundary remain finite and have zero thermal source
- one conservative layer over a perfectly reflecting lower boundary remains finite
- legacy and production LART return zero source/spectrum and the analytic cumulative transmission
- endpoint values and gradients, thin float32 layers, explicit scalar absorption, and a thick non-conservative gradient are covered

## Validation

- `PYTHONDONTWRITEBYTECODE=1 NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu pytest -q tests/unittests/rt/twostream tests/unittests/rt/atmrt`
  - 52 passed
- focused two-stream/SFM suite
  - 28 passed
- `git diff --check`
  - passed

A100, float32 `(100, 20000)`, compile excluded and synchronized:

- flux-adding and SFM-2st forward: 0.999x versus the original recurrence (no measurable slowdown)
- reverse AD: about 1.045x; the stable recurrence keeps the original three scan inputs to limit this overhead

## Scope

The reported one-layer perfect-reflector case and the production black-bottom paths are covered. A separate existing float32 limit remains for all-interface fluxes with multiple saturated conservative layers over a perfect reflector, where the effective-reflectivity complement itself is rounded away. Fixing that broader case would require carrying another complement through the scan and was left out to avoid the measured performance regression.