### PR TITLE
Add hydrostatic radius profile

### DIFF
--- a/src/exojax/atm/atmprof.py
+++ b/src/exojax/atm/atmprof.py
@@ -1,6 +1,6 @@
 """Atmospheric profile function."""
 
-from exojax.utils.constants import kB, m_u
+from exojax.utils.constants import G, bar_cgs, kB, m_u
 import jax.numpy as jnp
 import numpy as np
 from jax.lax import scan
@@ -101,6 +101,60 @@ def pressure_boundary_logspace(
         return np.append(pressure_upper, pressure_bottom_boundary)
     else:
         return jnp.append(pressure_upper, pressure_bottom_boundary)
+
+
+@jit
+def hydrostatic_radius_profile(
+    pressure_boundaries,
+    mass_density_layers,
+    planet_mass,
+    radius_bottom,
+):
+    """Compute radius and gravity at pressure boundaries.
+
+    This function integrates hydrostatic equilibrium from the bottom boundary
+    upward, neglecting atmospheric mass and treating density as constant in
+    each layer.
+
+    Args:
+        pressure_boundaries (1D array): pressure boundaries in bar, ordered
+            from atmospheric top to bottom, with shape (Nlayer + 1,)
+        mass_density_layers (1D array): layer mass densities in g/cm3, ordered
+            from atmospheric top to bottom, with shape (Nlayer,)
+        planet_mass (float): planet mass in g
+        radius_bottom (float): radius in cm at pressure_boundaries[-1]
+
+    Returns:
+        tuple: radius boundaries in cm and gravity boundaries in cm/s2, both
+            with shape (Nlayer + 1,)
+    """
+    delta_pressure_layers = jnp.diff(pressure_boundaries) * bar_cgs
+    gravity_bottom = G * planet_mass / radius_bottom / radius_bottom
+
+    def integrate_layer(normalized_inverse_radius_lower, layer):
+        delta_pressure_layer, mass_density_layer = layer
+        normalized_inverse_radius_upper = (
+            normalized_inverse_radius_lower
+            - delta_pressure_layer
+            / mass_density_layer
+            / gravity_bottom
+            / radius_bottom
+        )
+        return normalized_inverse_radius_upper, normalized_inverse_radius_upper
+
+    normalized_inverse_radius_bottom = jnp.ones_like(radius_bottom)
+    _, normalized_inverse_radius_upper = scan(
+        integrate_layer,
+        normalized_inverse_radius_bottom,
+        (delta_pressure_layers, mass_density_layers),
+        reverse=True,
+    )
+    normalized_inverse_radius_boundaries = jnp.append(
+        normalized_inverse_radius_upper, normalized_inverse_radius_bottom
+    )
+    radius_boundaries = radius_bottom / normalized_inverse_radius_boundaries
+    gravity_boundaries = gravity_bottom * normalized_inverse_radius_boundaries**2
+    return radius_boundaries, gravity_boundaries
 
 
 @jit

--- a/tests/unittests/atm/layer_test.py
+++ b/tests/unittests/atm/layer_test.py
@@ -1,9 +1,13 @@
+import jax
+import jax.numpy as jnp
 import pytest
 import numpy as np
+from exojax.atm.atmprof import hydrostatic_radius_profile
 from exojax.atm.atmprof import pressure_layer_logspace
 from exojax.atm.atmprof import pressure_upper_logspace
 from exojax.atm.atmprof import pressure_lower_logspace
 from exojax.atm.atmprof import pressure_scale_height
+from exojax.utils.constants import G, bar_cgs
 
 
 def test_log_pressure_is_constant():
@@ -53,6 +57,61 @@ def test_pressure_scale_height_earth():
     ref = 843465.7516276574  # cm (8.4km)
 
     assert H == pytest.approx(ref)
+
+
+def test_hydrostatic_radius_profile_matches_layer_solution():
+    pressure_boundaries = jnp.array([1.0, 4.0, 10.0])
+    mass_density_layers = jnp.array([5.0e-4, 2.0e-3])
+    planet_mass = 5.0e27
+    radius_bottom = 6.0e8
+
+    radius, gravity = hydrostatic_radius_profile(
+        pressure_boundaries,
+        mass_density_layers,
+        planet_mass,
+        radius_bottom,
+    )
+
+    gravitational_parameter = G * planet_mass
+    inverse_radius_bottom = 1.0 / radius_bottom
+    inverse_radius_middle = inverse_radius_bottom - (
+        (10.0 - 4.0) * bar_cgs
+        / (2.0e-3 * gravitational_parameter)
+    )
+    inverse_radius_top = inverse_radius_middle - (
+        (4.0 - 1.0) * bar_cgs
+        / (5.0e-4 * gravitational_parameter)
+    )
+    expected_radius = 1.0 / np.array(
+        [inverse_radius_top, inverse_radius_middle, inverse_radius_bottom]
+    )
+    expected_gravity = gravitational_parameter / expected_radius**2
+
+    assert radius.shape == pressure_boundaries.shape
+    assert gravity.shape == pressure_boundaries.shape
+    assert radius[-1] == jnp.asarray(radius_bottom, dtype=radius.dtype)
+    np.testing.assert_allclose(radius, expected_radius, rtol=1.0e-6)
+    np.testing.assert_allclose(gravity, expected_gravity, rtol=1.0e-6)
+
+
+def test_hydrostatic_radius_profile_supports_jit_and_grad():
+    pressure_boundaries = jnp.array([1.0, 4.0, 10.0])
+    mass_density_layers = jnp.array([5.0e-4, 2.0e-3])
+
+    def radius_top(log_scales):
+        density_scale, mass_scale = jnp.exp(log_scales)
+        radius, _ = hydrostatic_radius_profile(
+            pressure_boundaries,
+            mass_density_layers * density_scale,
+            1.8986e30 * mass_scale,
+            7.1492e9,
+        )
+        return radius[0]
+
+    radius, gradient = jax.jit(jax.value_and_grad(radius_top))(jnp.zeros(2))
+    assert jnp.isfinite(radius)
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.all(gradient < 0.0)
 
 
 def test_atmospheric_scale_height_for_isothermal_with_analytic():


### PR DESCRIPTION
## Summary

- add a pure JAX `hydrostatic_radius_profile` kernel that integrates piecewise-constant density layers from the bottom boundary upward
- return radius and gravity on every pressure boundary using ExoJAX's bar/cgs unit convention
- use the normalized inverse radius `radius_bottom / radius` to preserve useful float32 gradients with respect to density and planet mass
- add analytic, endpoint, JIT, and automatic-differentiation tests

## Motivation

This provides a small dependency-free bridge from pressure and mass-density profiles to the radius and gravity anchors required by transmission radiative transfer. It does not import ExoEOS or ExoGibbs and does not change `ArtCommon` or `ArtTransPure`.

## Validation

- `JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu python -m pytest -q tests/unittests/atm` — 26 passed
- `JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu python -m pytest -q tests/unittests/atm/layer_test.py tests/unittests/rt/atmrt/common_test.py` — 8 passed
- `JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu JAX_ENABLE_X64=true python -m pytest -q tests/unittests/atm/layer_test.py -k hydrostatic` — 2 passed
- `git diff --check`