### PR TITLE
Add exact atmospheric pressure boundary contract

### DIFF
--- a/documents/tutorials/get_started.ipynb
+++ b/documents/tutorials/get_started.ipynb
@@ -368,7 +368,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 200 atmospheric layers, with the pressure ranging from 100 bar at the bottom to 1.0e-5 bar at the top.\n",
+    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 100 atmospheric layers whose representative pressures range from 1.0e-5 bar at the top to 10 bar at the bottom.\n",
     "\n",
     "Since v1.5, ExoJAX supports both the flux-based two-stream solver (`fbased2st`) and the intensity-based n-stream solver (`ibased`). This example uses `rtsolver=\"ibased\"`.\n"
    ]

--- a/documents/tutorials/get_started.rst
+++ b/documents/tutorials/get_started.rst
@@ -250,8 +250,8 @@ different temperatures.
 ExoJAX solves radiative transfer and returns the emission spectrum
 through an ``art`` object. ``ArtEmisPure`` means atmospheric radiative
 transfer for emission with pure absorption, without scattering. Here we
-use 200 atmospheric layers, with the pressure ranging from 100 bar at
-the bottom to 1.0e-5 bar at the top.
+use 100 atmospheric layers whose representative pressures range from
+1.0e-5 bar at the top to 10 bar at the bottom.
 
 Since v1.5, ExoJAX supports both the flux-based two-stream solver
 (``fbased2st``) and the intensity-based n-stream solver (``ibased``).
@@ -1017,5 +1017,4 @@ of this!). Let’s create a corner plot to verify the results.
 
 
 This completes the emission-spectrum getting started workflow.
-
 

--- a/documents/tutorials/get_started_ns.ipynb
+++ b/documents/tutorials/get_started_ns.ipynb
@@ -301,7 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 200 atmospheric layers, with the pressure ranging from 100 bar at the bottom to 1.0e-5 bar at the top.\n",
+    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 100 atmospheric layers whose representative pressures range from 1.0e-5 bar at the top to 10 bar at the bottom.\n",
     "\n",
     "Since v1.5, ExoJAX supports both the flux-based two-stream solver (`fbased2st`) and the intensity-based n-stream solver (`ibased`). This example uses `rtsolver=\"ibased\"`.\n"
    ]

--- a/documents/tutorials/get_started_ns.rst
+++ b/documents/tutorials/get_started_ns.rst
@@ -197,8 +197,8 @@ different temperatures.
 ExoJAX solves radiative transfer and returns the emission spectrum
 through an ``art`` object. ``ArtEmisPure`` means atmospheric radiative
 transfer for emission with pure absorption, without scattering. Here we
-use 200 atmospheric layers, with the pressure ranging from 100 bar at
-the bottom to 1.0e-5 bar at the top.
+use 100 atmospheric layers whose representative pressures range from
+1.0e-5 bar at the top to 10 bar at the bottom.
 
 Since v1.5, ExoJAX supports both the flux-based two-stream solver
 (``fbased2st``) and the intensity-based n-stream solver (``ibased``).
@@ -579,5 +579,4 @@ plot using ArviZ.
 
 
 This completes the nested-sampling getting-started workflow.
-
 

--- a/documents/tutorials/get_started_svi.ipynb
+++ b/documents/tutorials/get_started_svi.ipynb
@@ -295,7 +295,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 200 atmospheric layers, with the pressure ranging from 100 bar at the bottom to 1.0e-5 bar at the top.\n",
+    "ExoJAX solves radiative transfer and returns the emission spectrum through an `art` object. `ArtEmisPure` means atmospheric radiative transfer for emission with pure absorption, without scattering. Here we use 100 atmospheric layers whose representative pressures range from 1.0e-5 bar at the top to 10 bar at the bottom.\n",
     "\n",
     "Since v1.5, ExoJAX supports both the flux-based two-stream solver (`fbased2st`) and the intensity-based n-stream solver (`ibased`). This example uses `rtsolver=\"ibased\"`.\n"
    ]

--- a/documents/tutorials/get_started_svi.rst
+++ b/documents/tutorials/get_started_svi.rst
@@ -194,8 +194,8 @@ different temperatures.
 ExoJAX solves radiative transfer and returns the emission spectrum
 through an ``art`` object. ``ArtEmisPure`` means atmospheric radiative
 transfer for emission with pure absorption, without scattering. Here we
-use 200 atmospheric layers, with the pressure ranging from 100 bar at
-the bottom to 1.0e-5 bar at the top.
+use 100 atmospheric layers whose representative pressures range from
+1.0e-5 bar at the top to 10 bar at the bottom.
 
 Since v1.5, ExoJAX supports both the flux-based two-stream solver
 (``fbased2st``) and the intensity-based n-stream solver (``ibased``).

--- a/documents/tutorials/get_started_transmission.ipynb
+++ b/documents/tutorials/get_started_transmission.ipynb
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ExoJAX solves radiative transfer and returns [the transmission spectrum](../userguide/rtransfer_transmission.html) through an `art` object. `ArtTransPure` means atmospheric radiative transfer for transmission with pure absorption, without scattering. The integration scheme can be either trapezoid or Simpson's rule; the default is `integration=\"simpson\"`. Here we use 200 atmospheric layers, with the pressure ranging from 100 bar at the bottom to 1.0e-5 bar at the top.\n"
+    "ExoJAX solves radiative transfer and returns [the transmission spectrum](../userguide/rtransfer_transmission.html) through an `art` object. `ArtTransPure` means atmospheric radiative transfer for transmission with pure absorption, without scattering. The integration scheme can be either trapezoid or Simpson's rule; the default is `integration=\"simpson\"`. Here we use 200 atmospheric layers whose representative pressures range from 1.0e-11 bar at the top to 10 bar at the bottom.\n"
    ]
   },
   {
@@ -382,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Surface gravity is important for transmission spectra. Unlike emission spectra, transmission spectra probe opacity along slant paths from lower to upper atmospheric layers. It is therefore useful to calculate gravity as a function of altitude. This is done by specifying `gravity_btm` and `radius_btm` at the bottom layer and using the layer boundaries in the transmission geometry.\n"
+    "Surface gravity is important for transmission spectra. Unlike emission spectra, transmission spectra probe opacity along slant paths from lower to upper atmospheric layers. It is therefore useful to calculate gravity as a function of altitude. This is done by specifying `gravity_btm` and `radius_btm` at the lower boundary of the bottom layer and using the layer boundaries in the transmission geometry.\n"
    ]
   },
   {
@@ -427,7 +427,7 @@
    "source": [
     "\n",
     "plt.plot(gravity, art.pressure)\n",
-    "plt.plot(gravity_btm, art.pressure[-1], \"ro\", label=\"gravity_btm\")\n",
+    "plt.plot(gravity_btm, art.pressure_btm_boundary, \"ro\", label=\"gravity_btm\")\n",
     "plt.yscale(\"log\")\n",
     "plt.xlim(2300,2600)\n",
     "plt.gca().invert_yaxis()\n",

--- a/documents/tutorials/get_started_transmission.rst
+++ b/documents/tutorials/get_started_transmission.rst
@@ -202,8 +202,8 @@ spectrum <../userguide/rtransfer_transmission.html>`__ through an
 for transmission with pure absorption, without scattering. The
 integration scheme can be either trapezoid or Simpson’s rule; the
 default is ``integration="simpson"``. Here we use 200 atmospheric
-layers, with the pressure ranging from 100 bar at the bottom to 1.0e-5
-bar at the top.
+layers whose representative pressures range from 1.0e-11 bar at the
+top to 10 bar at the bottom.
 
 .. code:: ipython3
 
@@ -249,8 +249,8 @@ Surface gravity is important for transmission spectra. Unlike emission
 spectra, transmission spectra probe opacity along slant paths from lower
 to upper atmospheric layers. It is therefore useful to calculate gravity
 as a function of altitude. This is done by specifying ``gravity_btm``
-and ``radius_btm`` at the bottom layer and using the layer boundaries in
-the transmission geometry.
+and ``radius_btm`` at the lower boundary of the bottom layer and using
+the layer boundaries in the transmission geometry.
 
 .. code:: ipython3
 
@@ -270,7 +270,7 @@ When visualized, it looks like this.
 
     
     plt.plot(gravity, art.pressure)
-    plt.plot(gravity_btm, art.pressure[-1], "ro", label="gravity_btm")
+    plt.plot(gravity_btm, art.pressure_btm_boundary, "ro", label="gravity_btm")
     plt.yscale("log")
     plt.xlim(2300,2600)
     plt.gca().invert_yaxis()
@@ -667,5 +667,4 @@ observed with JWST/NIRSpec G395H is available in the gallery:
 
 -  `WASP-39b transmission spectrum
    example <../examples/WASP39b_transmission_JWST-NIRSpec.html#sphx-glr-examples-wasp39b-transmission-jwst-nirspec-py>`__
-
 

--- a/documents/userguide.rst
+++ b/documents/userguide.rst
@@ -77,6 +77,7 @@ Radiative Transfer
 .. toctree::
    :maxdepth: 1
 
+   userguide/layer_contract.rst
    userguide/rtransfer.rst
    userguide/rtransfer_ibased_pure.rst
    userguide/rtransfer_fbased.rst

--- a/documents/userguide/layer_contract.rst
+++ b/documents/userguide/layer_contract.rst
@@ -1,0 +1,124 @@
+.. _atmospheric-layer-contract:
+
+Atmospheric Layer Contract
+==========================
+
+An ExoJAX pressure grid contains ``nlayer`` atmospheric layers.  All pressure
+arrays are ordered from the low-pressure top to the high-pressure bottom.  The
+physical extent of the grid is defined by ``nlayer + 1`` boundaries::
+
+    pressure_boundary[0]       top of the atmosphere
+             layer 0
+    pressure_boundary[1]
+                ...
+    pressure_boundary[nlayer]  bottom of the atmosphere
+
+``pressure_boundary`` is the source of truth for atmospheric interfaces and
+for joining the atmosphere to another model.  The related arrays obey the
+following contract:
+
+* ``pressure_boundary`` has ``nlayer + 1`` values and contains the physical
+  upper and lower boundary of every layer.  ``pressure_top_boundary`` and
+  ``pressure_btm_boundary`` are aliases for its first and last values.
+* ``pressure`` has ``nlayer`` representative values.  Temperature, abundance,
+  opacity, and other layer profiles are evaluated at these pressures.
+* ``dParr`` has ``nlayer`` values and is defined by
+  ``dParr = pressure_boundary[1:] - pressure_boundary[:-1]``.
+
+Treat these grid arrays as immutable model configuration.  Create a new Art
+object instead of modifying ``pressure_boundary``, ``pressure``, or ``dParr``
+in place, so that all derived quantities remain consistent.  Code should not
+depend on their concrete NumPy/JAX container type; use ``jax.numpy.asarray``
+when a device array is required.
+
+For a logarithmically spaced grid with reference point :math:`r`, the
+representative pressure in layer :math:`i` is
+
+.. math::
+
+   \log P_i = (1-r)\log P_{i,\mathrm{upper}}
+              + r\log P_{i,\mathrm{lower}}.
+
+ExoJAX uses :math:`r=0.5`, so ``pressure[i]`` is the geometric center of its
+two boundaries.  A surface is a boundary condition below the last atmospheric
+layer; it is not an additional layer with another representative pressure.
+
+Creating a grid from exact boundaries
+-------------------------------------
+
+Use ``from_pressure_boundaries`` when either endpoint must be an exact physical
+interface.  The class method is inherited from ``ArtCommon`` and is available
+on the Art and Opart classes.  For example, a transmission atmosphere whose
+bottom is exactly 100 bar can be constructed as follows:
+
+.. code-block:: python
+
+    from exojax.rt import ArtTransPure
+
+    art = ArtTransPure.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-8,
+        pressure_btm_boundary=1.0e2,
+        nlayer=100,
+        integration="simpson",
+    )
+
+Here ``art.pressure_boundary[0]`` and ``art.pressure_boundary[-1]`` are the
+specified pressures.  ExoJAX derives the representative ``art.pressure`` and
+``art.dParr`` arrays from those boundaries.  For compatibility with the
+existing Art API, ``art.pressure_top`` and ``art.pressure_btm`` remain the
+first and last representative pressures.
+
+The factory validates that every boundary, representative pressure,
+``dParr``, and pressure-decrease rate is representable in the active JAX
+precision.  Enable JAX 64-bit mode before constructing the Art object when an
+extreme pressure range requires it.
+
+The atmosphere--surface connection is always at
+``pressure_boundary[-1]``:
+
+* In transmission, ``radius_btm`` and ``gravity_btm`` are defined at this
+  boundary.  The region below ``radius_btm`` is the opaque disk.
+* When an emission or reflection solver exposes a bottom/surface source or
+  reflectivity, that boundary condition is applied immediately below the last
+  atmospheric layer at this boundary.
+* When coupling a lower model, set its top pressure equal to
+  ``pressure_boundary[-1]`` and pass its upward radiation as the bottom/surface
+  source where the selected solver supports one.
+
+Solvers without a bottom/surface argument retain their solver-specific lower
+boundary condition; the pressure-grid contract does not add such an argument.
+
+``ArtAbsPure`` can integrate to a ``pressure_surface`` inside an existing
+layer.  This partial-layer operation is useful for absorption-only paths, but
+it is separate from the canonical atmosphere--surface connection above.  For
+a shared physical interface, construct the grid with that pressure as its
+bottom boundary.
+
+Legacy representative-endpoint constructors
+-------------------------------------------
+
+Existing constructors retain their representative-endpoint interpretation.  In
+
+.. code-block:: python
+
+    art = ArtTransPure(
+        pressure_top=1.0e-8,
+        pressure_btm=1.0e2,
+        nlayer=100,
+    )
+
+``pressure_top`` and ``pressure_btm`` are the first and last representative
+layer pressures, not the physical grid boundaries.  If their logarithmic
+spacing is :math:`\Delta` and the reference point is :math:`r`, the derived
+outer boundaries are
+
+.. math::
+
+   \begin{aligned}
+   \log P_{\mathrm{boundary},0} &= \log P_{\mathrm{top}} - r\Delta, \\
+   \log P_{\mathrm{boundary},N} &= \log P_{\mathrm{btm}} + (1-r)\Delta.
+   \end{aligned}
+
+They therefore extend by half a logarithmic grid cell at each end for the
+default :math:`r=0.5`.  Use ``pressure_boundary[-1]``, rather than
+``pressure_btm``, when connecting a legacy grid to a surface or lower layer.

--- a/documents/userguide/rtransfer_transmission.rst
+++ b/documents/userguide/rtransfer_transmission.rst
@@ -37,7 +37,12 @@ The ``gravity_profile`` instance in the ``ArtTransPure`` class allows for easy c
     from exojax.rt import ArtTransPure
     from exojax.utils.constants import RJ
 
-    art = ArtTransPure(pressure_top=1.e-8, pressure_btm=1.e2, nlayer=100, integration="simpson") # integration="trapezoid" if you want
+    art = ArtTransPure.from_pressure_boundaries(
+        pressure_top_boundary=1.e-8,
+        pressure_btm_boundary=1.e2,
+        nlayer=100,
+        integration="simpson",  # use "trapezoid" if desired
+    )
     art.change_temperature_range(400.0, 1500.0)
     Tarr = art.powerlaw_temperature(1300.0, 0.1)
     mmr_arr = art.constant_mmr_profile(0.1) # constant mass mixing ratio profile 
@@ -54,6 +59,10 @@ The ``gravity_profile`` instance in the ``ArtTransPure`` class allows for easy c
     
     dtau = art.opacity_profile_xs(xsmatrix, mmr_arr, opa.mdb.molmass,gravity)
     Rp2 = art.run(dtau, Tarr, mmw, radius_btm, gravity_btm)
+
+Here ``radius_btm`` and ``gravity_btm`` are defined at the exact pressure
+``art.pressure_btm_boundary``.  See :ref:`atmospheric-layer-contract` for the
+pressure-grid and surface-connection contract.
 
 
 |:jack_o_lantern:| See 

--- a/examples/WASP39b_transmission_JWST-NIRSpec.py
+++ b/examples/WASP39b_transmission_JWST-NIRSpec.py
@@ -291,14 +291,11 @@ def model_c(rp_mean, rp_std):
 
     # Fixed cloud width in log10(P) space (narrow deck).
     width_cloud = 1.0 / 25.0
+    delta_log_pressure = -jnp.log10(art.pressure_decrease_rate)
 
     # Set the Gaussian amplitude so that the *integrated* cloud optical depth
     # over the atmosphere is ~50, independent of the number of layers.
-    dtau_c = (
-        50.0
-        * ((jnp.log10(pressure_btm) - jnp.log10(pressure_top)) / nlayer)
-        / width_cloud
-    )
+    dtau_c = 50.0 * delta_log_pressure / width_cloud
     pressure_arr = jnp.log10(art.pressure)
     cloud_profile = (pressure_arr[:, None] - logP_cloud) / width_cloud
     # Per-layer optical-depth increment: normalized Gaussian in log10(P).

--- a/examples/wasp39b_full_jwst_spectra.py
+++ b/examples/wasp39b_full_jwst_spectra.py
@@ -1970,14 +1970,11 @@ def spectral_model(radius_btm, Mp, Rstar, RV, vmr_arr, T0, logP_cloud):
 
     # Fixed cloud width in log10(P) space (narrow deck).
     width_cloud = 1.0 / 25.0
+    delta_log_pressure = -jnp.log10(art.pressure_decrease_rate)
 
     # Set the Gaussian amplitude so that the *integrated* cloud optical depth
     # over the atmosphere is ~50, independent of the number of layers.
-    dtau_c = (
-        50.0
-        * ((jnp.log10(pressure_btm) - jnp.log10(pressure_top)) / nlayer)
-        / width_cloud
-    )
+    dtau_c = 50.0 * delta_log_pressure / width_cloud
     pressure_arr = jnp.log10(art.pressure)
     cloud_profile = (pressure_arr[:, None] - logP_cloud) / width_cloud
     # Per-layer optical-depth increment: normalized Gaussian in log10(P).

--- a/examples/wasp39b_full_jwst_spectra_self_ckd.py
+++ b/examples/wasp39b_full_jwst_spectra_self_ckd.py
@@ -614,11 +614,8 @@ def compute_transmission(
     ng = opa_ckd.ckd_info.weights.size
     pressure_log = jnp.log10(art.pressure)
     width_cloud = 1.0 / 25.0
-    dtau_c = (
-        args.cloud_tau
-        * ((jnp.log10(args.pressure_btm) - jnp.log10(args.pressure_top)) / args.nlayer)
-        / width_cloud
-    )
+    delta_log_pressure = -jnp.log10(art.pressure_decrease_rate)
+    dtau_c = args.cloud_tau * delta_log_pressure / width_cloud
     cloud_profile = (pressure_log[:, None] - args.logp_cloud) / width_cloud
     dtau_cloud = dtau_c / jnp.sqrt(jnp.pi) * jnp.exp(-jnp.clip(cloud_profile**2, -50, 50))
     dtau_ckd = jnp.broadcast_to(dtau_cloud[:, None], (pressure_log.size, ng, nband))

--- a/src/exojax/atm/atmprof.py
+++ b/src/exojax/atm/atmprof.py
@@ -1,6 +1,7 @@
 """Atmospheric profile function."""
 
 from exojax.utils.constants import G, bar_cgs, kB, m_u
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax.lax import scan
@@ -47,6 +48,177 @@ def pressure_layer_logspace(
         delta_pressures = delta_pressures[::-1]
 
     return pressures, delta_pressures, k
+
+
+def pressure_layer_logspace_from_boundaries(
+    log_pressure_top_boundary,
+    log_pressure_btm_boundary,
+    nlayer,
+    reference_point=0.5,
+    numpy=False,
+):
+    """Create a log-spaced pressure grid from exact layer boundaries.
+
+    Args:
+        log_pressure_top_boundary (float): Log10 pressure in bar at the top
+            boundary.
+        log_pressure_btm_boundary (float): Log10 pressure in bar at the bottom
+            boundary.
+        nlayer (int): Number of atmospheric layers.
+        reference_point (float): Fractional position of the representative
+            pressure within each layer in log pressure. The upper boundary is
+            0, the geometric center is 0.5, and the lower boundary is 1.
+        numpy (bool): If True, use NumPy arrays instead of JAX arrays.
+
+    Returns:
+        tuple: Representative pressures, layer pressure differences, pressure
+            decrease rate, and the ``nlayer + 1`` pressure boundaries. The
+            pressure boundaries are the source of truth for the other arrays.
+
+    Notes:
+        Backend representability is validated during eager execution and is
+        skipped while JAX is tracing. Build the grid eagerly when validation
+        is required. Valid traced inputs remain compatible with JIT
+        compilation and automatic differentiation.
+    """
+    if not isinstance(nlayer, (int, np.integer)) or isinstance(nlayer, bool):
+        raise ValueError("Number of layers must be a positive integer.")
+    if nlayer < 1:
+        raise ValueError("Number of layers must be a positive integer.")
+    for name, value in (
+        ("Top boundary log pressure", log_pressure_top_boundary),
+        ("Bottom boundary log pressure", log_pressure_btm_boundary),
+        ("Reference point", reference_point),
+    ):
+        ndim = value.ndim if hasattr(value, "ndim") else np.ndim(value)
+        if ndim != 0:
+            raise ValueError(f"{name} must be scalar.")
+    top_boundary_is_traced = isinstance(
+        log_pressure_top_boundary, jax.core.Tracer
+    )
+    bottom_boundary_is_traced = isinstance(
+        log_pressure_btm_boundary, jax.core.Tracer
+    )
+    reference_point_is_traced = isinstance(reference_point, jax.core.Tracer)
+    if numpy and (
+        top_boundary_is_traced
+        or bottom_boundary_is_traced
+        or reference_point_is_traced
+    ):
+        raise ValueError("The NumPy backend does not support traced inputs.")
+    if not reference_point_is_traced:
+        if not 0.0 <= reference_point <= 1.0:
+            raise ValueError("Reference point must be between 0 and 1.")
+    if not top_boundary_is_traced and not np.isfinite(
+        log_pressure_top_boundary
+    ):
+        raise ValueError("Pressure boundary logs must be finite.")
+    if not bottom_boundary_is_traced and not np.isfinite(
+        log_pressure_btm_boundary
+    ):
+        raise ValueError("Pressure boundary logs must be finite.")
+    if not top_boundary_is_traced and not bottom_boundary_is_traced:
+        if log_pressure_btm_boundary <= log_pressure_top_boundary:
+            raise ValueError(
+                "Bottom boundary pressure must be greater than the top "
+                "boundary pressure."
+            )
+
+    array_module = np if numpy else jnp
+    if numpy:
+        with np.errstate(over="ignore", under="ignore"):
+            pressure_boundaries = np.logspace(
+                log_pressure_top_boundary,
+                log_pressure_btm_boundary,
+                nlayer + 1,
+            )
+    else:
+        pressure_boundaries = jnp.logspace(
+            log_pressure_top_boundary,
+            log_pressure_btm_boundary,
+            nlayer + 1,
+        )
+    try:
+        with np.errstate(over="ignore", under="ignore"):
+            pressure_endpoints = array_module.asarray(
+                [
+                    10.0**log_pressure_top_boundary,
+                    10.0**log_pressure_btm_boundary,
+                ],
+                dtype=pressure_boundaries.dtype,
+            )
+    except OverflowError as err:
+        raise ValueError(
+            "Pressure boundaries cannot be represented by the array backend."
+        ) from err
+    if numpy:
+        pressure_boundaries[[0, -1]] = pressure_endpoints
+    else:
+        pressure_boundaries = pressure_boundaries.at[0].set(
+            pressure_endpoints[0]
+        )
+        pressure_boundaries = pressure_boundaries.at[-1].set(
+            pressure_endpoints[1]
+        )
+    if not isinstance(pressure_boundaries, jax.core.Tracer):
+        pressure_boundaries_host = np.asarray(pressure_boundaries)
+        smallest_normal = jnp.finfo(pressure_boundaries.dtype).tiny
+        if not np.all(np.isfinite(pressure_boundaries_host)) or np.any(
+            pressure_boundaries_host < smallest_normal
+        ):
+            raise ValueError(
+                "Pressure boundaries cannot be represented by the active "
+                "array dtype."
+            )
+        if np.any(np.diff(pressure_boundaries_host) <= 0.0):
+            raise ValueError(
+                "Pressure layers are not distinct in the active array dtype."
+            )
+    pressure_upper = pressure_boundaries[:-1]
+    pressure_lower = pressure_boundaries[1:]
+    pressures = (
+        pressure_upper ** (1.0 - reference_point)
+        * pressure_lower**reference_point
+    )
+    delta_pressures = array_module.diff(pressure_boundaries)
+    dlogP = (log_pressure_btm_boundary - log_pressure_top_boundary) / nlayer
+    pressure_decrease_rate = array_module.asarray(
+        10.0**-dlogP, dtype=pressure_boundaries.dtype
+    )
+    smallest_normal = jnp.finfo(pressure_boundaries.dtype).tiny
+    if not isinstance(pressures, jax.core.Tracer):
+        pressures_host = np.asarray(pressures)
+        if not np.all(np.isfinite(pressures_host)) or np.any(
+            pressures_host < smallest_normal
+        ):
+            raise ValueError(
+                "Pressure grid cannot be represented by the active array dtype."
+            )
+    if not isinstance(delta_pressures, jax.core.Tracer):
+        delta_pressures_host = np.asarray(delta_pressures)
+        if not np.all(np.isfinite(delta_pressures_host)) or np.any(
+            delta_pressures_host < smallest_normal
+        ):
+            raise ValueError(
+                "Pressure grid cannot be represented by the active array dtype."
+            )
+    if not isinstance(pressure_decrease_rate, jax.core.Tracer):
+        pressure_decrease_rate_host = np.asarray(pressure_decrease_rate)
+        if (
+            not np.isfinite(pressure_decrease_rate_host)
+            or pressure_decrease_rate_host < smallest_normal
+            or pressure_decrease_rate_host >= 1.0
+        ):
+            raise ValueError(
+                "Pressure grid cannot be represented by the active array dtype."
+            )
+
+    return (
+        pressures,
+        delta_pressures,
+        pressure_decrease_rate,
+        pressure_boundaries,
+    )
 
 
 def pressure_upper_logspace(pressures, pressure_decrease_rate, reference_point=0.5):
@@ -319,4 +491,3 @@ def Teff2Tirr(Teff, Tint):
         Here we assume A=0 (albedo) and beta=1 (fully-energy distributed)
     """
     return (4.0 * Teff**4 - Tint**4) ** 0.25
-

--- a/src/exojax/rt/common.py
+++ b/src/exojax/rt/common.py
@@ -20,14 +20,193 @@ from exojax.utils.constants import logkB, logm_ucgs
 class ArtCommon:
     """Common Atmospheric Radiative Transfer"""
 
+    @property
+    def pressure_top_boundary(self):
+        """Pressure at the top boundary of the atmospheric grid in bar."""
+        return self.pressure_boundary[0]
+
+    @property
+    def pressure_btm_boundary(self):
+        """Pressure at the bottom boundary of the atmospheric grid in bar."""
+        return self.pressure_boundary[-1]
+
+    @staticmethod
+    def _pressure_profile_from_exact_boundaries(
+        pressure_top_boundary,
+        pressure_btm_boundary,
+        nlayer,
+        reference_point,
+    ):
+        from exojax.atm.atmprof import pressure_layer_logspace_from_boundaries
+
+        grid_arguments = {
+            "log_pressure_top_boundary": np.log10(pressure_top_boundary),
+            "log_pressure_btm_boundary": np.log10(pressure_btm_boundary),
+            "nlayer": nlayer,
+            "reference_point": reference_point,
+        }
+        (
+            _,
+            _,
+            pressure_decrease_rate,
+            pressure_boundary,
+        ) = pressure_layer_logspace_from_boundaries(
+            **grid_arguments,
+            numpy=True,
+        )
+        pressure_boundary = pressure_boundary.copy()
+        pressure_boundary[0] = pressure_top_boundary
+        pressure_boundary[-1] = pressure_btm_boundary
+        pressure = (
+            pressure_boundary[:-1] ** (1.0 - reference_point)
+            * pressure_boundary[1:] ** reference_point
+        )
+        dpressure = np.diff(pressure_boundary)
+
+        from jax import config
+
+        active_dtype = np.dtype(np.float64 if config.x64_enabled else np.float32)
+        smallest_normal = np.finfo(active_dtype).tiny
+        with np.errstate(over="ignore", under="ignore"):
+            active_boundary = pressure_boundary.astype(active_dtype)
+            active_pressure = pressure.astype(active_dtype)
+            active_dpressure = np.diff(active_boundary)
+            active_decrease_rate = np.asarray(
+                pressure_decrease_rate, dtype=active_dtype
+            )
+        active_grid_values = (
+            active_boundary,
+            active_pressure,
+            active_dpressure,
+            active_decrease_rate,
+        )
+        if any(
+            not np.all(np.isfinite(value)) or np.any(value < smallest_normal)
+            for value in active_grid_values
+        ) or np.any(active_dpressure <= 0.0):
+            raise ValueError(
+                "Pressure grid cannot be represented by the active JAX dtype."
+            )
+        if active_decrease_rate >= 1.0:
+            raise ValueError(
+                "Pressure grid cannot be represented by the active JAX dtype."
+            )
+        return (
+            pressure,
+            dpressure,
+            pressure_decrease_rate,
+            pressure_boundary,
+        )
+
+    @classmethod
+    def from_pressure_boundaries(
+        cls,
+        pressure_top_boundary,
+        pressure_btm_boundary,
+        nlayer,
+        **kwargs,
+    ):
+        """Initialize an atmospheric model from its exact pressure boundaries.
+
+        Args:
+            pressure_top_boundary (float): Pressure at the top boundary in bar.
+            pressure_btm_boundary (float): Pressure at the bottom boundary in bar.
+            nlayer (int): Number of atmospheric layers.
+            **kwargs: Additional arguments passed to the subclass constructor.
+
+        Returns:
+            ArtCommon: An instance whose pressure grid spans the specified
+                boundaries exactly.
+
+        Notes:
+            ``pressure`` contains representative layer pressures, while
+            ``pressure_boundary`` contains the physical layer boundaries.
+            Subclass-specific required arguments, such as ``opalayer``, must be
+            supplied as keyword arguments.
+        """
+        if "pressure_top" in kwargs or "pressure_btm" in kwargs:
+            raise TypeError(
+                "pressure_top and pressure_btm cannot be used with "
+                "from_pressure_boundaries."
+            )
+        if type(nlayer) is not int:
+            raise ValueError("Number of the layer should be integer")
+        if nlayer < 1:
+            raise ValueError("Number of the layer should be positive")
+
+        if np.ndim(pressure_top_boundary) != 0 or np.ndim(
+            pressure_btm_boundary
+        ) != 0:
+            raise ValueError("Pressure boundaries should be scalar values.")
+        try:
+            pressure_top_boundary = float(pressure_top_boundary)
+            pressure_btm_boundary = float(pressure_btm_boundary)
+        except (TypeError, ValueError) as err:
+            raise ValueError("Pressure boundaries should be scalar values.") from err
+        if not np.isfinite(pressure_top_boundary) or not np.isfinite(
+            pressure_btm_boundary
+        ):
+            raise ValueError("Pressure boundaries should be finite.")
+        if pressure_top_boundary <= 0.0 or pressure_btm_boundary <= 0.0:
+            raise ValueError("Pressure boundaries should be positive.")
+        if pressure_btm_boundary <= pressure_top_boundary:
+            raise ValueError(
+                "Pressure at the bottom boundary should be higher than that "
+                "at the top boundary."
+            )
+
+        log_pressure_top_boundary = np.log10(pressure_top_boundary)
+        log_pressure_btm_boundary = np.log10(pressure_btm_boundary)
+        dlog_pressure = (
+            log_pressure_btm_boundary - log_pressure_top_boundary
+        ) / nlayer
+        constructor_kwargs = {
+            "pressure_top": 10.0
+            ** (log_pressure_top_boundary + 0.5 * dlog_pressure),
+            "pressure_btm": 10.0
+            ** (log_pressure_btm_boundary - 0.5 * dlog_pressure),
+            "nlayer": nlayer,
+            **kwargs,
+        }
+
+        if cls.__new__ is object.__new__:
+            instance = cls.__new__(cls)
+        else:
+            instance = cls.__new__(cls, **constructor_kwargs)
+        if not isinstance(instance, cls):
+            raise TypeError(f"{cls.__name__}.__new__ did not return an instance.")
+
+        missing = object()
+        previous_specification = getattr(
+            instance, "_pressure_boundary_specification", missing
+        )
+        instance._pressure_boundary_specification = (
+            pressure_top_boundary,
+            pressure_btm_boundary,
+        )
+        try:
+            type(instance).__init__(instance, **constructor_kwargs)
+        except BaseException:
+            if previous_specification is missing:
+                if hasattr(instance, "_pressure_boundary_specification"):
+                    del instance._pressure_boundary_specification
+            else:
+                instance._pressure_boundary_specification = previous_specification
+            raise
+        instance._pressure_boundary_specification = (
+            pressure_top_boundary,
+            pressure_btm_boundary,
+        )
+        return instance
+
     def __init__(
         self, pressure_top, pressure_btm, nlayer, nu_grid=None, warn_no_nu_grid=True
     ):
         """initialization of art
 
         Args:
-            pressure_top (float):top pressure in bar
-            pressure_bottom (float): bottom pressure in bar
+            pressure_top (float): Representative pressure of the top layer in bar.
+            pressure_btm (float): Representative pressure of the bottom layer in bar.
             nlayer (int): # of atmospheric layers
             nu_grid (nd.array, optional): wavenumber grid in cm-1
             warn_no_nu_grid (bool, optional): Warn when ``nu_grid`` is not given.
@@ -248,6 +427,27 @@ class ArtCommon:
             raise ValueError("Number of the layer should be integer")
 
     def init_pressure_profile(self):
+        pressure_boundary_specification = getattr(
+            self, "_pressure_boundary_specification", None
+        )
+        if pressure_boundary_specification is not None:
+            (
+                self.pressure,
+                self.dParr,
+                self.pressure_decrease_rate,
+                self.pressure_boundary,
+            ) = self._pressure_profile_from_exact_boundaries(
+                pressure_top_boundary=pressure_boundary_specification[0],
+                pressure_btm_boundary=pressure_boundary_specification[1],
+                nlayer=self.nlayer,
+                reference_point=self.reference_point,
+            )
+            self.pressure_top = self.pressure[0]
+            self.pressure_btm = self.pressure[-1]
+            self.log_pressure_top = np.log10(self.pressure_top)
+            self.log_pressure_btm = np.log10(self.pressure_btm)
+            return
+
         from exojax.atm.atmprof import (
             pressure_boundary_logspace,
             pressure_layer_logspace,
@@ -269,7 +469,9 @@ class ArtCommon:
             self.pressure,
             self.pressure_decrease_rate,
             reference_point=self.reference_point,
+            numpy=True,
         )
+        self.dParr = np.diff(self.pressure_boundary)
 
     def change_temperature_range(self, Tlow, Thigh):
         """temperature range to be assumed.

--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -13,7 +13,6 @@ from exojax.rt.rtransfer import (
     setrt_toonhm_with_absorption,
 )
 from exojax.rt.rtlayer import fluxsum_scan
-from exojax.rt.common import ArtCommon
 from exojax.postproc.limb_darkening import (
     average_limb_darkening_coefficients,
     quadratic_ld_from_intensity,
@@ -47,8 +46,10 @@ class ArtEmisPure(ArtCommon):
         initialization of ArtEmisPure
 
         Args:
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
             rtsolver (str, optional): radiative transfer solver (ibased, fbased2st, ibased_linsap). Defaults to "ibased".
@@ -253,8 +254,10 @@ class OpartEmisPure(ArtCommon):
 
         Args:
             opalayer (class): user defined class, needs to define self.nu_grid
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nstream (int, optional): the number of the gaussian quadrature. Defaults to 8.
         """
@@ -418,8 +421,10 @@ class ArtEmisScat(ArtCommon):
         """initialization of ArtEmisScat
 
         Args:
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
             rtsolver (str): Radiative Transfer Solver,
@@ -566,8 +571,10 @@ class OpartEmisScat(ArtCommon):
 
         Args:
             opalayer (class): user defined class, needs to define self.nu_grid
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
         """
         super().__init__(pressure_top, pressure_btm, nlayer, opalayer.nu_grid)

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -6,9 +6,6 @@ from exojax.rt.rtransfer import (
     setrt_toonhm,
     setrt_toonhm_with_absorption,
 )
-from exojax.rt.common import ArtCommon
-
-import jax.numpy as jnp
 from jax.lax import scan
 
 
@@ -33,8 +30,10 @@ class ArtAbsPure(ArtCommon):
         """initialization of ArtAbsPure
 
         Args:
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
         """
@@ -129,8 +128,10 @@ class ArtReflectPure(ArtCommon):
         """initialization of ArtReflectPure
 
         Args:
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
             rtsolver (str): Radiative Transfer Solver, fluxadding_toon_hemispheric_mean
@@ -256,8 +257,10 @@ class ArtReflectEmis(ArtCommon):
         """initialization of ArtReflectionPure
 
         Args:
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
             rtsolver (str): Radiative Transfer Solver, fluxadding_toon_hemispheric_mean
@@ -393,8 +396,10 @@ class OpartReflectPure(ArtCommon):
 
         Args:
             opalayer (class): user defined class, needs to define self.nu_grid
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
         """
         super().__init__(pressure_top, pressure_btm, nlayer, opalayer.nu_grid)
@@ -468,8 +473,10 @@ class OpartReflectEmis(ArtCommon):
 
         Args:
             opalayer (class): user defined class, needs to define self.nu_grid
-            pressure_top (float, optional): top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
         """
         super().__init__(pressure_top, pressure_btm, nlayer, opalayer.nu_grid)

--- a/src/exojax/rt/trans.py
+++ b/src/exojax/rt/trans.py
@@ -29,8 +29,10 @@ class ArtTransPure(ArtCommon):
         """initialization of ArtTransPure
 
         Args:
-            pressure_top (float, optional): layer top pressure in bar. Defaults to 1.0e-8.
-            pressure_btm (float, optional): layer bottom pressure in bar. Defaults to 1.0e2.
+            pressure_top (float, optional): Representative pressure of the top
+                atmospheric layer in bar. Defaults to 1.0e-8.
+            pressure_btm (float, optional): Representative pressure of the bottom
+                atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): The number of the layers Defaults to 100.
             integration (str, optional): Integration scheme ("simpson", "trapezoid"). Defaults to "simpson".
             nu_grid (nd.array, optional): Wavenumber grid in cm-1 for line-by-line ``run`` use.

--- a/tests/unittests/atm/layer_test.py
+++ b/tests/unittests/atm/layer_test.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -10,6 +12,16 @@ from exojax.atm.atmprof import pressure_upper_logspace
 from exojax.atm.atmprof import pressure_lower_logspace
 from exojax.atm.atmprof import pressure_scale_height
 from exojax.utils.constants import G, bar_cgs
+
+
+@contextmanager
+def temporary_x64(enabled):
+    previous = jax.config.read("jax_enable_x64")
+    try:
+        jax.config.update("jax_enable_x64", enabled)
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", previous)
 
 
 def test_log_pressure_is_constant():
@@ -74,12 +86,7 @@ def test_log_pressure_from_boundaries_preserves_endpoints(use_numpy):
 
 @pytest.mark.parametrize("enable_x64", [False, True])
 def test_log_pressure_from_boundaries_uses_active_jax_dtype(enable_x64):
-    context = (
-        jax.experimental.enable_x64()
-        if enable_x64
-        else jax.experimental.disable_x64()
-    )
-    with context:
+    with temporary_x64(enable_x64):
         pressure, dpressure, k, pressure_boundary = (
             pressure_layer_logspace_from_boundaries(-4.0, 2.0, nlayer=4)
         )
@@ -175,7 +182,7 @@ def test_log_pressure_from_boundaries_validates_static_outputs_during_grad():
         )
         return jnp.sum(pressure)
 
-    with jax.experimental.disable_x64():
+    with temporary_x64(False):
         with pytest.raises(ValueError, match="active array dtype"):
             jax.grad(pressure_sum)(0.5)
 
@@ -338,7 +345,7 @@ def test_log_pressure_from_boundaries_rejects_unrepresentable_numpy_bounds(
 def test_log_pressure_from_boundaries_rejects_unrepresentable_jax_bounds(
     top_boundary, bottom_boundary
 ):
-    with jax.experimental.disable_x64():
+    with temporary_x64(False):
         with pytest.raises(ValueError, match="cannot be represented"):
             pressure_layer_logspace_from_boundaries(
                 top_boundary, bottom_boundary, nlayer=1
@@ -346,7 +353,7 @@ def test_log_pressure_from_boundaries_rejects_unrepresentable_jax_bounds(
 
 
 def test_log_pressure_from_boundaries_rejects_indistinct_jax_layers():
-    with jax.experimental.disable_x64():
+    with temporary_x64(False):
         with pytest.raises(ValueError, match="not distinct"):
             pressure_layer_logspace_from_boundaries(0.0, 1.0e-8, nlayer=2)
 
@@ -362,7 +369,7 @@ def test_log_pressure_from_boundaries_rejects_indistinct_jax_layers():
 def test_log_pressure_from_boundaries_rejects_unstable_float32_grid(
     top_boundary, bottom_boundary, nlayer
 ):
-    with jax.experimental.disable_x64():
+    with temporary_x64(False):
         with pytest.raises(ValueError, match="active array dtype"):
             pressure_layer_logspace_from_boundaries(
                 top_boundary, bottom_boundary, nlayer

--- a/tests/unittests/atm/layer_test.py
+++ b/tests/unittests/atm/layer_test.py
@@ -3,7 +3,9 @@ import jax.numpy as jnp
 import pytest
 import numpy as np
 from exojax.atm.atmprof import hydrostatic_radius_profile
+from exojax.atm.atmprof import pressure_boundary_logspace
 from exojax.atm.atmprof import pressure_layer_logspace
+from exojax.atm.atmprof import pressure_layer_logspace_from_boundaries
 from exojax.atm.atmprof import pressure_upper_logspace
 from exojax.atm.atmprof import pressure_lower_logspace
 from exojax.atm.atmprof import pressure_scale_height
@@ -21,6 +23,357 @@ def test_log_pressure_is_constant():
 
     # check P[n-1] = k P[n]
     assert np.all(np.abs(1.0 - pressure[1:] * k / pressure[:-1]) < 1.0e-5)
+
+
+@pytest.mark.parametrize("use_numpy", [False, True])
+def test_log_pressure_from_boundaries(use_numpy):
+    pressure, dpressure, k, pressure_boundary = (
+        pressure_layer_logspace_from_boundaries(
+            log_pressure_top_boundary=-4.0,
+            log_pressure_btm_boundary=2.0,
+            nlayer=3,
+            numpy=use_numpy,
+        )
+    )
+
+    expected_boundary = np.array([1.0e-4, 1.0e-2, 1.0, 1.0e2])
+    expected_pressure = np.sqrt(expected_boundary[:-1] * expected_boundary[1:])
+    np.testing.assert_allclose(pressure_boundary, expected_boundary, rtol=1.0e-6)
+    np.testing.assert_allclose(pressure, expected_pressure, rtol=1.0e-6)
+    np.testing.assert_allclose(
+        dpressure, np.diff(expected_boundary), rtol=1.0e-6
+    )
+    assert k == pytest.approx(1.0e-2)
+    assert pressure.dtype == pressure_boundary.dtype
+    assert dpressure.dtype == pressure_boundary.dtype
+    assert k.dtype == pressure_boundary.dtype
+    assert isinstance(pressure_boundary, np.ndarray) is use_numpy
+
+
+@pytest.mark.parametrize("use_numpy", [False, True])
+def test_log_pressure_from_boundaries_preserves_endpoints(use_numpy):
+    top_boundary = 3.7e-7
+    bottom_boundary = 42.3
+    _, _, _, pressure_boundary = pressure_layer_logspace_from_boundaries(
+        np.log10(top_boundary),
+        np.log10(bottom_boundary),
+        nlayer=7,
+        numpy=use_numpy,
+    )
+    array_module = np if use_numpy else jnp
+
+    expected_top = array_module.asarray(
+        top_boundary, dtype=pressure_boundary.dtype
+    )
+    expected_bottom = array_module.asarray(
+        bottom_boundary, dtype=pressure_boundary.dtype
+    )
+    assert pressure_boundary[0] == expected_top
+    assert pressure_boundary[-1] == expected_bottom
+
+
+@pytest.mark.parametrize("enable_x64", [False, True])
+def test_log_pressure_from_boundaries_uses_active_jax_dtype(enable_x64):
+    context = (
+        jax.experimental.enable_x64()
+        if enable_x64
+        else jax.experimental.disable_x64()
+    )
+    with context:
+        pressure, dpressure, k, pressure_boundary = (
+            pressure_layer_logspace_from_boundaries(-4.0, 2.0, nlayer=4)
+        )
+        expected_dtype = np.dtype(np.float64 if enable_x64 else np.float32)
+
+        assert pressure.dtype == expected_dtype
+        assert dpressure.dtype == expected_dtype
+        assert k.dtype == expected_dtype
+        assert pressure_boundary.dtype == expected_dtype
+
+
+def test_log_pressure_from_boundaries_supports_jit_and_grad():
+    def grid_sum(log_pressure_boundaries):
+        pressure, dpressure, k, pressure_boundary = (
+            pressure_layer_logspace_from_boundaries(
+                log_pressure_boundaries[0],
+                log_pressure_boundaries[1],
+                nlayer=4,
+            )
+        )
+        return (
+            jnp.sum(pressure)
+            + jnp.sum(dpressure)
+            + k
+            + jnp.sum(pressure_boundary)
+        )
+
+    value, gradient = jax.jit(jax.value_and_grad(grid_sum))(
+        jnp.array([-4.0, 2.0])
+    )
+
+    assert jnp.isfinite(value)
+    assert jnp.all(jnp.isfinite(gradient))
+
+    static_grid = jax.jit(
+        lambda top, bottom: pressure_layer_logspace_from_boundaries(
+            top, bottom, nlayer=4
+        ),
+        static_argnums=(0, 1),
+    )(-4.0, 2.0)
+    assert static_grid[0].shape == (4,)
+    assert static_grid[3].shape == (5,)
+
+
+@pytest.mark.parametrize(
+    "bottom_boundary, reference_point, message",
+    [(2.0, 2.0, "between 0 and 1"), (np.inf, 0.5, "finite")],
+)
+def test_log_pressure_from_boundaries_validates_static_values_during_jit(
+    bottom_boundary, reference_point, message
+):
+    compiled_grid = jax.jit(
+        lambda top_boundary: pressure_layer_logspace_from_boundaries(
+            top_boundary,
+            bottom_boundary,
+            nlayer=4,
+            reference_point=reference_point,
+        )
+    )
+
+    with pytest.raises(ValueError, match=message):
+        compiled_grid(-4.0)
+
+
+@pytest.mark.parametrize(
+    "top_boundary, reference_point",
+    [(np.array([-4.0]), 0.5), (-4.0, np.array([0.5]))],
+)
+def test_log_pressure_from_boundaries_rejects_nonscalar_inputs(
+    top_boundary, reference_point
+):
+    with pytest.raises(ValueError, match="must be scalar"):
+        pressure_layer_logspace_from_boundaries(
+            top_boundary, 2.0, nlayer=4, reference_point=reference_point
+        )
+
+
+def test_log_pressure_from_boundaries_rejects_numpy_backend_during_jit():
+    compiled_grid = jax.jit(
+        lambda top_boundary: pressure_layer_logspace_from_boundaries(
+            top_boundary, 2.0, nlayer=4, numpy=True
+        )
+    )
+
+    with pytest.raises(ValueError, match="NumPy backend"):
+        compiled_grid(-4.0)
+
+
+def test_log_pressure_from_boundaries_validates_static_outputs_during_grad():
+    def pressure_sum(reference_point):
+        pressure, _, _, _ = pressure_layer_logspace_from_boundaries(
+            -37.0, 37.0, nlayer=1, reference_point=reference_point
+        )
+        return jnp.sum(pressure)
+
+    with jax.experimental.disable_x64():
+        with pytest.raises(ValueError, match="active array dtype"):
+            jax.grad(pressure_sum)(0.5)
+
+
+def test_log_pressure_from_boundaries_supports_jax_bfloat16():
+    pressure, dpressure, k, pressure_boundary = (
+        pressure_layer_logspace_from_boundaries(
+            jnp.asarray(-4.0, dtype=jnp.bfloat16),
+            jnp.asarray(2.0, dtype=jnp.bfloat16),
+            nlayer=4,
+        )
+    )
+
+    assert pressure.dtype == jnp.bfloat16
+    assert dpressure.dtype == jnp.bfloat16
+    assert k.dtype == jnp.bfloat16
+    assert pressure_boundary.dtype == jnp.bfloat16
+
+
+def test_log_pressure_from_boundaries_matches_boundary_helpers():
+    reference_point = 0.25
+    pressure, _, k, pressure_boundary = (
+        pressure_layer_logspace_from_boundaries(
+            -4.0,
+            2.0,
+            nlayer=4,
+            reference_point=reference_point,
+            numpy=True,
+        )
+    )
+
+    np.testing.assert_allclose(
+        pressure_upper_logspace(pressure, k, reference_point),
+        pressure_boundary[:-1],
+    )
+    np.testing.assert_allclose(
+        pressure_lower_logspace(pressure, k, reference_point),
+        pressure_boundary[1:],
+    )
+
+
+@pytest.mark.parametrize("reference_point", [0.0, 0.5, 1.0])
+def test_log_pressure_from_boundaries_matches_legacy_grid(reference_point):
+    log_pressure_top = -3.0
+    log_pressure_btm = 2.0
+    nlayer = 6
+    pressure, dpressure, k = pressure_layer_logspace(
+        log_pressure_top,
+        log_pressure_btm,
+        nlayer,
+        reference_point=reference_point,
+        numpy=True,
+    )
+    dlogP = (log_pressure_btm - log_pressure_top) / (nlayer - 1)
+    exact_grid = pressure_layer_logspace_from_boundaries(
+        log_pressure_top - reference_point * dlogP,
+        log_pressure_btm + (1.0 - reference_point) * dlogP,
+        nlayer,
+        reference_point=reference_point,
+        numpy=True,
+    )
+
+    np.testing.assert_allclose(exact_grid[0], pressure)
+    np.testing.assert_allclose(exact_grid[1], dpressure)
+    assert exact_grid[2] == pytest.approx(k)
+    np.testing.assert_allclose(
+        exact_grid[3],
+        pressure_boundary_logspace(
+            pressure, k, reference_point=reference_point, numpy=True
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "reference_point, expected",
+    [
+        (0.0, 1.0e-3),
+        (0.25, 10.0**-2.25),
+        (0.5, 10.0**-1.5),
+        (1.0, 1.0),
+    ],
+)
+def test_log_pressure_from_boundaries_reference_point(reference_point, expected):
+    pressure, _, _, _ = pressure_layer_logspace_from_boundaries(
+        log_pressure_top_boundary=-3.0,
+        log_pressure_btm_boundary=0.0,
+        nlayer=1,
+        reference_point=reference_point,
+        numpy=True,
+    )
+
+    assert pressure.shape == (1,)
+    assert pressure[0] == pytest.approx(expected)
+
+
+def test_log_pressure_from_boundaries_single_layer():
+    pressure, dpressure, k, pressure_boundary = (
+        pressure_layer_logspace_from_boundaries(
+            log_pressure_top_boundary=-2.0,
+            log_pressure_btm_boundary=1.0,
+            nlayer=1,
+        )
+    )
+
+    np.testing.assert_allclose(pressure_boundary, [1.0e-2, 1.0e1])
+    np.testing.assert_allclose(pressure, [np.sqrt(1.0e-2 * 1.0e1)])
+    np.testing.assert_allclose(dpressure, [1.0e1 - 1.0e-2])
+    assert k == pytest.approx(1.0e-3)
+
+
+@pytest.mark.parametrize("nlayer", [0, -1, 1.5, True])
+def test_log_pressure_from_boundaries_rejects_invalid_nlayer(nlayer):
+    with pytest.raises(ValueError, match="positive integer"):
+        pressure_layer_logspace_from_boundaries(-3.0, 1.0, nlayer)
+
+
+@pytest.mark.parametrize("reference_point", [-0.1, 1.1])
+def test_log_pressure_from_boundaries_rejects_invalid_reference_point(
+    reference_point,
+):
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        pressure_layer_logspace_from_boundaries(
+            -3.0, 1.0, 4, reference_point=reference_point
+        )
+
+
+@pytest.mark.parametrize(
+    "top_boundary, bottom_boundary, message",
+    [
+        (-3.0, -3.0, "greater than"),
+        (0.0, -1.0, "greater than"),
+        (np.nan, 1.0, "finite"),
+        (-3.0, np.inf, "finite"),
+    ],
+)
+def test_log_pressure_from_boundaries_rejects_invalid_boundaries(
+    top_boundary, bottom_boundary, message
+):
+    with pytest.raises(ValueError, match=message):
+        pressure_layer_logspace_from_boundaries(
+            top_boundary, bottom_boundary, nlayer=4
+        )
+
+
+@pytest.mark.parametrize(
+    "top_boundary, bottom_boundary", [(-400.0, 0.0), (0.0, 400.0)]
+)
+def test_log_pressure_from_boundaries_rejects_unrepresentable_numpy_bounds(
+    top_boundary, bottom_boundary
+):
+    with pytest.raises(ValueError, match="cannot be represented"):
+        pressure_layer_logspace_from_boundaries(
+            top_boundary, bottom_boundary, nlayer=1, numpy=True
+        )
+
+
+@pytest.mark.parametrize(
+    "top_boundary, bottom_boundary", [(-50.0, 0.0), (0.0, 40.0)]
+)
+def test_log_pressure_from_boundaries_rejects_unrepresentable_jax_bounds(
+    top_boundary, bottom_boundary
+):
+    with jax.experimental.disable_x64():
+        with pytest.raises(ValueError, match="cannot be represented"):
+            pressure_layer_logspace_from_boundaries(
+                top_boundary, bottom_boundary, nlayer=1
+            )
+
+
+def test_log_pressure_from_boundaries_rejects_indistinct_jax_layers():
+    with jax.experimental.disable_x64():
+        with pytest.raises(ValueError, match="not distinct"):
+            pressure_layer_logspace_from_boundaries(0.0, 1.0e-8, nlayer=2)
+
+
+@pytest.mark.parametrize(
+    "top_boundary, bottom_boundary, nlayer",
+    [
+        (-38.0, 0.0, 1),
+        (-37.0, -36.99999, 1),
+        (-37.0, 37.0, 1),
+    ],
+)
+def test_log_pressure_from_boundaries_rejects_unstable_float32_grid(
+    top_boundary, bottom_boundary, nlayer
+):
+    with jax.experimental.disable_x64():
+        with pytest.raises(ValueError, match="active array dtype"):
+            pressure_layer_logspace_from_boundaries(
+                top_boundary, bottom_boundary, nlayer
+            )
+
+
+def test_log_pressure_from_boundaries_rejects_underflowed_numpy_k():
+    with pytest.raises(ValueError, match="active array dtype"):
+        pressure_layer_logspace_from_boundaries(
+            -300.0, 300.0, nlayer=1, numpy=True
+        )
 
 
 def test_pressure_upper_logspace():

--- a/tests/unittests/rt/atmrt/common_test.py
+++ b/tests/unittests/rt/atmrt/common_test.py
@@ -1,6 +1,36 @@
+import copy
+import pickle
+
+import jax
 import numpy as np
+import pytest
 
 from exojax.rt.common import ArtCommon
+from exojax.rt.reflect import ArtAbsPure, OpartReflectPure
+from exojax.rt.trans import ArtTransPure
+
+
+def test_legacy_pressure_arguments_remain_representative_values():
+    art = ArtCommon(
+        pressure_top=1.0e-2,
+        pressure_btm=1.0,
+        nlayer=3,
+        warn_no_nu_grid=False,
+    )
+
+    np.testing.assert_allclose(art.pressure, [1.0e-2, 1.0e-1, 1.0])
+    np.testing.assert_allclose(
+        art.pressure_boundary,
+        [
+            1.0e-2 / np.sqrt(10.0),
+            1.0e-2 * np.sqrt(10.0),
+            1.0e-1 * np.sqrt(10.0),
+            np.sqrt(10.0),
+        ],
+    )
+    np.testing.assert_allclose(art.dParr, np.diff(art.pressure_boundary))
+    assert art.pressure_top_boundary == art.pressure_boundary[0]
+    assert art.pressure_btm_boundary == art.pressure_boundary[-1]
 
 
 def test_gravity_profile_obeys_inverse_square_law(monkeypatch):
@@ -30,3 +60,307 @@ def test_gravity_profile_obeys_inverse_square_law(monkeypatch):
     expected = gravity_btm / normalized_radius_layer**2
     assert gravity.shape == (2, 1)
     np.testing.assert_allclose(np.asarray(gravity[:, 0]), expected)
+
+
+def test_from_pressure_boundaries_defines_canonical_grid():
+    pressure_top_boundary = 3.7e-8
+    pressure_btm_boundary = 987.654321
+    art = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=pressure_top_boundary,
+        pressure_btm_boundary=pressure_btm_boundary,
+        nlayer=4,
+        warn_no_nu_grid=False,
+    )
+
+    assert art.pressure_top_boundary == pressure_top_boundary
+    assert art.pressure_btm_boundary == pressure_btm_boundary
+    np.testing.assert_allclose(art.dParr, np.diff(art.pressure_boundary))
+    np.testing.assert_allclose(
+        art.pressure,
+        np.sqrt(art.pressure_boundary[:-1] * art.pressure_boundary[1:]),
+    )
+    np.testing.assert_allclose(
+        art.pressure_decrease_rate,
+        art.pressure_boundary[0] / art.pressure_boundary[1],
+    )
+    assert art.pressure_top == art.pressure[0]
+    assert art.pressure_btm == art.pressure[-1]
+
+
+def test_exact_factory_reproduces_an_equivalent_legacy_grid():
+    legacy = ArtCommon(
+        pressure_top=1.0e-4,
+        pressure_btm=10.0,
+        nlayer=6,
+        warn_no_nu_grid=False,
+    )
+    exact = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=legacy.pressure_top_boundary,
+        pressure_btm_boundary=legacy.pressure_btm_boundary,
+        nlayer=legacy.nlayer,
+        warn_no_nu_grid=False,
+    )
+
+    np.testing.assert_allclose(exact.pressure_boundary, legacy.pressure_boundary)
+    np.testing.assert_allclose(exact.pressure, legacy.pressure)
+    np.testing.assert_allclose(exact.dParr, legacy.dParr)
+    np.testing.assert_allclose(
+        exact.pressure_decrease_rate, legacy.pressure_decrease_rate
+    )
+
+
+def test_from_pressure_boundaries_supports_one_layer():
+    art = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-4,
+        pressure_btm_boundary=1.0,
+        nlayer=1,
+        warn_no_nu_grid=False,
+    )
+
+    np.testing.assert_allclose(art.pressure_boundary, [1.0e-4, 1.0])
+    np.testing.assert_allclose(art.pressure, [1.0e-2])
+    np.testing.assert_allclose(art.dParr, [1.0 - 1.0e-4])
+
+
+def test_from_pressure_boundaries_rejects_grid_unstable_in_active_jax_dtype():
+    with jax.experimental.disable_x64():
+        with pytest.raises(ValueError, match="active JAX dtype"):
+            ArtCommon.from_pressure_boundaries(
+                pressure_top_boundary=1.0e-40,
+                pressure_btm_boundary=1.0,
+                nlayer=1,
+                warn_no_nu_grid=False,
+            )
+
+    with jax.experimental.enable_x64():
+        art = ArtCommon.from_pressure_boundaries(
+            pressure_top_boundary=1.0e-40,
+            pressure_btm_boundary=1.0,
+            nlayer=1,
+            warn_no_nu_grid=False,
+        )
+        np.testing.assert_array_equal(
+            art.pressure_boundary[[0, -1]], [1.0e-40, 1.0]
+        )
+
+
+@pytest.mark.parametrize("nlayer", [1, 4])
+def test_from_pressure_boundaries_survives_pressure_profile_reinitialization(
+    nlayer,
+):
+    art = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=3.7e-8,
+        pressure_btm_boundary=987.654321,
+        nlayer=nlayer,
+        warn_no_nu_grid=False,
+    )
+    expected_boundary = art.pressure_boundary.copy()
+
+    art.init_pressure_profile()
+
+    np.testing.assert_array_equal(art.pressure_boundary, expected_boundary)
+    np.testing.assert_allclose(art.dParr, np.diff(expected_boundary))
+    assert np.all(np.isfinite(art.pressure))
+
+
+def test_exact_pressure_grid_survives_copy_and_pickle():
+    art = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=3.7e-8,
+        pressure_btm_boundary=987.654321,
+        nlayer=4,
+        warn_no_nu_grid=False,
+    )
+
+    copies = [copy.copy(art), copy.deepcopy(art), pickle.loads(pickle.dumps(art))]
+    for copied_art in copies:
+        copied_art.init_pressure_profile()
+        np.testing.assert_array_equal(
+            copied_art.pressure_boundary[[0, -1]], [3.7e-8, 987.654321]
+        )
+        np.testing.assert_allclose(
+            copied_art.dParr, np.diff(copied_art.pressure_boundary)
+        )
+
+
+def test_from_pressure_boundaries_passes_constructor_arguments_to_new():
+    class ArtWithCustomNew(ArtCommon):
+        new_arguments = None
+
+        def __new__(cls, pressure_top, pressure_btm, nlayer, token):
+            cls.new_arguments = (pressure_top, pressure_btm, nlayer, token)
+            return super().__new__(cls)
+
+        def __init__(self, pressure_top, pressure_btm, nlayer, token):
+            self.token = token
+            super().__init__(
+                pressure_top,
+                pressure_btm,
+                nlayer,
+                warn_no_nu_grid=False,
+            )
+
+    art = ArtWithCustomNew.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-4,
+        pressure_btm_boundary=1.0,
+        nlayer=1,
+        token="sentinel",
+    )
+
+    assert ArtWithCustomNew.new_arguments == (0.01, 0.01, 1, "sentinel")
+    assert art.token == "sentinel"
+    np.testing.assert_array_equal(art.pressure_boundary, [1.0e-4, 1.0])
+
+
+def test_from_pressure_boundaries_cleans_state_after_constructor_failure():
+    class FailingArt(ArtCommon):
+        allocated_instance = None
+
+        def __new__(cls, **kwargs):
+            cls.allocated_instance = super().__new__(cls)
+            return cls.allocated_instance
+
+        def __init__(self, **kwargs):
+            raise RuntimeError("constructor failed")
+
+    with pytest.raises(RuntimeError, match="constructor failed"):
+        FailingArt.from_pressure_boundaries(
+            pressure_top_boundary=1.0e-4,
+            pressure_btm_boundary=1.0,
+            nlayer=1,
+        )
+
+    assert not hasattr(
+        FailingArt.allocated_instance, "_pressure_boundary_specification"
+    )
+
+
+def test_one_layer_grid_supports_geometry_and_opacity():
+    art = ArtTransPure.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-4,
+        pressure_btm_boundary=1.0,
+        nlayer=1,
+        warn_no_nu_grid=False,
+    )
+    temperature = np.array([1000.0])
+    mean_molecular_weight = np.array([2.3])
+    radius_btm = 7.0e9
+    gravity_btm = 2.5e3
+
+    height, radius_lower = art.atmosphere_height(
+        temperature,
+        mean_molecular_weight,
+        radius_btm,
+        gravity_btm,
+    )
+    gravity = art.gravity_profile(
+        temperature,
+        mean_molecular_weight,
+        radius_btm,
+        gravity_btm,
+    )
+    dtau = art.opacity_profile_xs(
+        xs=np.ones((1, 2)) * 1.0e-25,
+        mixing_ratio=np.array([1.0e-3]),
+        molmass=2.3,
+        gravity=gravity,
+    )
+
+    assert height.shape == (1,)
+    assert radius_lower.shape == (1,)
+    assert gravity.shape == (1, 1)
+    assert dtau.shape == (1, 2)
+    assert np.all(np.isfinite(np.asarray(height)))
+    assert np.all(np.isfinite(np.asarray(dtau)))
+
+
+def test_pressure_boundary_grids_join_exactly():
+    junction_pressure = 3.7
+    atmosphere = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-6,
+        pressure_btm_boundary=junction_pressure,
+        nlayer=4,
+        warn_no_nu_grid=False,
+    )
+    lower_model = ArtCommon.from_pressure_boundaries(
+        pressure_top_boundary=junction_pressure,
+        pressure_btm_boundary=1.0e3,
+        nlayer=3,
+        warn_no_nu_grid=False,
+    )
+
+    assert atmosphere.pressure_btm_boundary == junction_pressure
+    assert lower_model.pressure_top_boundary == junction_pressure
+    assert atmosphere.pressure_boundary[-1] == lower_model.pressure_boundary[0]
+
+
+@pytest.mark.parametrize(
+    "pressure_top_boundary, pressure_btm_boundary",
+    [
+        (0.0, 1.0),
+        (1.0, 1.0),
+        (2.0, 1.0),
+        (np.nan, 1.0),
+        (np.array([1.0e-4]), 1.0),
+        (1.0e-4, np.array([1.0])),
+    ],
+)
+def test_from_pressure_boundaries_rejects_invalid_bounds(
+    pressure_top_boundary, pressure_btm_boundary
+):
+    with pytest.raises(ValueError):
+        ArtCommon.from_pressure_boundaries(
+            pressure_top_boundary=pressure_top_boundary,
+            pressure_btm_boundary=pressure_btm_boundary,
+            nlayer=2,
+            warn_no_nu_grid=False,
+        )
+
+
+@pytest.mark.parametrize("legacy_keyword", ["pressure_top", "pressure_btm"])
+def test_from_pressure_boundaries_rejects_legacy_pressure_kwargs(legacy_keyword):
+    with pytest.raises(TypeError, match="cannot be used"):
+        ArtCommon.from_pressure_boundaries(
+            pressure_top_boundary=1.0e-4,
+            pressure_btm_boundary=1.0,
+            nlayer=2,
+            warn_no_nu_grid=False,
+            **{legacy_keyword: 0.1},
+        )
+
+
+def test_from_pressure_boundaries_is_inherited_by_art_subclasses():
+    trans = ArtTransPure.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-6,
+        pressure_btm_boundary=10.0,
+        nlayer=3,
+        integration="trapezoid",
+        warn_no_nu_grid=False,
+    )
+    absorption = ArtAbsPure.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-6,
+        pressure_btm_boundary=10.0,
+        nlayer=3,
+        nu_grid=np.array([1000.0]),
+    )
+
+    assert trans.integration == "trapezoid"
+    np.testing.assert_allclose(trans.pressure_boundary[[0, -1]], [1.0e-6, 10.0])
+    np.testing.assert_allclose(
+        absorption.pressure_boundary[[0, -1]], [1.0e-6, 10.0]
+    )
+
+
+def test_from_pressure_boundaries_accepts_required_opart_keyword():
+    class FakeOpacityLayer:
+        nu_grid = np.array([1000.0])
+
+    opalayer = FakeOpacityLayer()
+    opart = OpartReflectPure.from_pressure_boundaries(
+        pressure_top_boundary=1.0e-5,
+        pressure_btm_boundary=1.0,
+        nlayer=2,
+        opalayer=opalayer,
+    )
+
+    assert opart.opalayer is opalayer
+    np.testing.assert_allclose(opart.pressure_boundary[[0, -1]], [1.0e-5, 1.0])

--- a/tests/unittests/rt/atmrt/common_test.py
+++ b/tests/unittests/rt/atmrt/common_test.py
@@ -1,5 +1,6 @@
 import copy
 import pickle
+from contextlib import contextmanager
 
 import jax
 import numpy as np
@@ -8,6 +9,16 @@ import pytest
 from exojax.rt.common import ArtCommon
 from exojax.rt.reflect import ArtAbsPure, OpartReflectPure
 from exojax.rt.trans import ArtTransPure
+
+
+@contextmanager
+def temporary_x64(enabled):
+    previous = jax.config.read("jax_enable_x64")
+    try:
+        jax.config.update("jax_enable_x64", enabled)
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", previous)
 
 
 def test_legacy_pressure_arguments_remain_representative_values():
@@ -123,7 +134,7 @@ def test_from_pressure_boundaries_supports_one_layer():
 
 
 def test_from_pressure_boundaries_rejects_grid_unstable_in_active_jax_dtype():
-    with jax.experimental.disable_x64():
+    with temporary_x64(False):
         with pytest.raises(ValueError, match="active JAX dtype"):
             ArtCommon.from_pressure_boundaries(
                 pressure_top_boundary=1.0e-40,
@@ -132,7 +143,7 @@ def test_from_pressure_boundaries_rejects_grid_unstable_in_active_jax_dtype():
                 warn_no_nu_grid=False,
             )
 
-    with jax.experimental.enable_x64():
+    with temporary_x64(True):
         art = ArtCommon.from_pressure_boundaries(
             pressure_top_boundary=1.0e-40,
             pressure_btm_boundary=1.0,


### PR DESCRIPTION
## Summary

- add an exact-boundary pressure-grid generator and `ArtCommon.from_pressure_boundaries(...)`
- make pressure boundaries the shared layer/surface connection contract across Art and Opart models
- preserve legacy representative-endpoint constructors while documenting their half-grid extrapolation
- update tutorials and pressure-spacing-dependent WASP-39b examples
- cover numerical precision, reinitialization, one-layer grids, and subclass compatibility

## Tests

- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu pytest -q tests/unittests/atm tests/unittests/rt tests/unittests/multi/opart tests/unittests/opacity/ckd` (256 passed)
- `ruff check src/exojax/atm/atmprof.py src/exojax/rt/common.py src/exojax/rt/emis.py src/exojax/rt/reflect.py src/exojax/rt/trans.py tests/unittests/atm/layer_test.py tests/unittests/rt/atmrt/common_test.py`
- `git diff --check`