### PR TITLE
Add selectable CIA coefficient interpolation

### DIFF
--- a/src/exojax/database/core/abscoeff.py
+++ b/src/exojax/database/core/abscoeff.py
@@ -1,28 +1,110 @@
-"""Interpolates the logarithm of the absorption coefficient."""
+"""Interpolate collision-induced absorption coefficients."""
 
 import jax.numpy as jnp
-from jax import jit, vmap
+from jax import custom_jvp, jit, vmap
+
+
+@custom_jvp
+def _mix_logacia(lower_logac, upper_logac, weight):
+    """Mix two log10 coefficients with a linear coefficient weight."""
+
+    offset = jnp.maximum(lower_logac, upper_logac)
+    offset = jnp.where(jnp.isfinite(offset), offset, 0.0)
+    is_interior = (weight > 0.0) & (weight < 1.0)
+    safe_weight = jnp.where(is_interior, weight, 0.5)
+    interpolated = jnp.log10(
+        (1.0 - safe_weight) * 10.0 ** (lower_logac - offset)
+        + safe_weight * 10.0 ** (upper_logac - offset)
+    ) + offset
+    result = jnp.where(
+        weight <= 0.0,
+        lower_logac,
+        jnp.where(weight >= 1.0, upper_logac, interpolated),
+    )
+    return jnp.where(jnp.isnan(weight), jnp.nan, result)
+
+
+@_mix_logacia.defjvp
+def _mix_logacia_jvp(primals, tangents):
+    lower_logac, upper_logac, weight = primals
+    lower_dot, upper_dot, weight_dot = tangents
+    result = _mix_logacia(lower_logac, upper_logac, weight)
+
+    lower_weight = 1.0 - weight
+    safe_lower_weight = jnp.where(lower_weight > 0.0, lower_weight, 1.0)
+    safe_upper_weight = jnp.where(weight > 0.0, weight, 1.0)
+    lower_fraction = jnp.where(
+        lower_weight > 0.0,
+        10.0
+        ** jnp.minimum(
+            jnp.log10(safe_lower_weight) + lower_logac - result, 0.0
+        ),
+        0.0,
+    )
+    upper_fraction = jnp.where(
+        weight > 0.0,
+        10.0
+        ** jnp.minimum(
+            jnp.log10(safe_upper_weight) + upper_logac - result, 0.0
+        ),
+        0.0,
+    )
+    # Leave headroom when an endpoint derivative exceeds the dtype range.
+    exponent_limit = jnp.log10(
+        jnp.asarray(jnp.finfo(result.dtype).max, dtype=result.dtype)
+    ) - 2.0
+    upper_ratio = 10.0 ** jnp.minimum(
+        upper_logac - result, exponent_limit
+    )
+    lower_ratio = 10.0 ** jnp.minimum(
+        lower_logac - result, exponent_limit
+    )
+    weight_gradient = (upper_ratio - lower_ratio) / jnp.log(
+        jnp.asarray(10.0, dtype=result.dtype)
+    )
+    tangent = (
+        lower_fraction * lower_dot
+        + upper_fraction * upper_dot
+        + weight_gradient * weight_dot
+    )
+    return result, tangent
+
+
+def _interp_logacia_in_coefficient_space(x, xp, logac):
+    """Linearly interpolate coefficients stored as log10 values."""
+
+    if xp.shape[0] == 1:
+        return jnp.broadcast_to(logac[0], jnp.shape(x))
+
+    upper = jnp.clip(jnp.searchsorted(xp, x, side="right"), 1, xp.size - 1)
+    lower = upper - 1
+    raw_weight = (x - xp[lower]) / (xp[upper] - xp[lower])
+    weight = jnp.where(
+        x < xp[0], 0.0, jnp.where(x > xp[-1], 1.0, raw_weight)
+    )
+    return _mix_logacia(logac[lower], logac[upper], weight)
 
 
 @jit
-def interp_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac):
-    """interpolated function of log10(alpha_CIA)
+def _interp_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac):
+    """Interpolate linear CIA coefficients and return their logarithms."""
 
-    Args:
-        Tarr (1D array): temperature array (K) [Nlayer]
-        nu_grid (1D array): wavenumber array (cm-1) [Nnus]
-        nucia: CIA wavenumber (cm-1)
-        tcia: CIA temperature (K)
-        logac: log10 cia coefficient
+    def interpolate_temperature(temperature):
+        return vmap(
+            _interp_logacia_in_coefficient_space,
+            in_axes=(None, None, 1),
+        )(temperature, tcia, logac)
 
-    Returns:
-        logarithm of absorption coefficient [Nlayer, Nnus] in the unit of cm5
+    logac_at_temperature = vmap(interpolate_temperature)(Tarr)
+    return vmap(
+        _interp_logacia_in_coefficient_space,
+        in_axes=(None, None, 0),
+    )(nu_grid, nucia, logac_at_temperature)
 
-    Example:
-        nucia,tcia,ac=read_cia("../../data/CIA/H2-H2_2011.cia",nus[0]-1.0,nus[-1]+1.0)
-        logac=jnp.array(np.log10(ac))
-        interp_logacia_matrix(Tarr,nus,nucia,tcia,logac)
-    """
+
+@jit
+def _digitize_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac):
+    """Apply the legacy log-temperature and wavenumber-bin interpolation."""
 
     def fcia(x, i):
         return jnp.interp(x, tcia, logac[:, i])
@@ -33,22 +115,57 @@ def interp_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac):
     return mfcia(Tarr, inus)
 
 
-@jit
-def interp_logacia_vector(T, nu_grid, nucia, tcia, logac):
-    """interpolated function of log10(alpha_CIA)
+def interp_logacia_matrix(
+    Tarr,
+    nu_grid,
+    nucia,
+    tcia,
+    logac,
+    wavenumber_interpolation="interp",
+):
+    """Interpolate log10 CIA coefficients for an atmospheric profile.
 
     Args:
-        T (float): temperature (K)
-        nu_grid: wavenumber array (cm-1)
-        nucia: CIA wavenumber (cm-1)
-        tcia: CIA temperature (K)
-        logac: log10 cia coefficient
+        Tarr (1D array): temperature array (K) [Nlayer]
+        nu_grid (1D array): wavenumber array (cm-1) [Nnus]
+        nucia: Native CIA wavenumber grid (cm-1).
+        tcia: Native CIA temperature grid (K).
+        logac: Native log10 CIA coefficients in cm5.
+        wavenumber_interpolation: ``"interp"`` interpolates linear
+            coefficients in temperature and wavenumber. ``"digitize"``
+            reproduces the legacy log-temperature interpolation and
+            right-bin wavenumber selection.
 
     Returns:
-        logarithm of absorption coefficient [Nnus] at T in the unit of cm5
-        
+        Log10 absorption coefficient [Nlayer, Nnus] in units of cm5.
 
+    Example:
+        nucia,tcia,ac=read_cia(
+            "../../data/CIA/H2-H2_2011.cia", nus[0]-1.0, nus[-1]+1.0
+        )
+        logac=jnp.array(np.log10(ac))
+        interp_logacia_matrix(Tarr,nus,nucia,tcia,logac)
     """
+
+    if wavenumber_interpolation == "interp":
+        return _interp_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac)
+    if wavenumber_interpolation == "digitize":
+        return _digitize_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac)
+    raise ValueError("wavenumber_interpolation must be 'interp' or 'digitize'.")
+
+
+@jit
+def _interp_logacia_vector(T, nu_grid, nucia, tcia, logac):
+    """Interpolate one linear CIA coefficient vector in log representation."""
+
+    return _interp_logacia_matrix(
+        jnp.atleast_1d(T), nu_grid, nucia, tcia, logac
+    )[0]
+
+
+@jit
+def _digitize_logacia_vector(T, nu_grid, nucia, tcia, logac):
+    """Apply the legacy interpolation to one CIA coefficient vector."""
 
     def fcia(x, i):
         return jnp.interp(x, tcia, logac[:, i])
@@ -56,3 +173,36 @@ def interp_logacia_vector(T, nu_grid, nucia, tcia, logac):
     vfcia = vmap(fcia, (None, 0), 0)
     inus = jnp.digitize(nu_grid, nucia)
     return vfcia(T, inus)
+
+
+def interp_logacia_vector(
+    T,
+    nu_grid,
+    nucia,
+    tcia,
+    logac,
+    wavenumber_interpolation="interp",
+):
+    """Interpolate a log10 CIA coefficient vector at one temperature.
+
+    Args:
+        T (float): Temperature in Kelvin.
+        nu_grid: Wavenumber array (cm-1).
+        nucia: Native CIA wavenumber grid (cm-1).
+        tcia: Native CIA temperature grid (K).
+        logac: Native log10 CIA coefficients in cm5.
+        wavenumber_interpolation: ``"interp"`` interpolates linear
+            coefficients in temperature and wavenumber. ``"digitize"``
+            reproduces the legacy log-temperature interpolation and
+            right-bin wavenumber selection.
+
+    Returns:
+        Log10 absorption coefficient [Nnus] at T in units of cm5.
+
+    """
+
+    if wavenumber_interpolation == "interp":
+        return _interp_logacia_vector(T, nu_grid, nucia, tcia, logac)
+    if wavenumber_interpolation == "digitize":
+        return _digitize_logacia_vector(T, nu_grid, nucia, tcia, logac)
+    raise ValueError("wavenumber_interpolation must be 'interp' or 'digitize'.")

--- a/src/exojax/opacity/opacont.py
+++ b/src/exojax/opacity/opacont.py
@@ -41,30 +41,40 @@ class OpaCIA(OpaCont):
         method: Always "cia" for this calculator
         cdb: CIA continuum database instance
         nu_grid: Wavenumber grid in cm⁻¹
+        wavenumber_interpolation: CIA interpolation method
         ready: Whether the calculator is ready for computation
     """
 
     def __init__(
-        self, 
-        cdb, 
-        nu_grid: Union[np.ndarray, jnp.ndarray]
+        self,
+        cdb,
+        nu_grid: Union[np.ndarray, jnp.ndarray],
+        wavenumber_interpolation: str = "interp",
     ) -> None:
         """Initialize opacity calculator for CIA.
 
         Args:
             cdb: Continuum database containing CIA coefficients
             nu_grid: Wavenumber grid in cm⁻¹
+            wavenumber_interpolation: ``"interp"`` interpolates linear CIA
+                coefficients in temperature and wavenumber. ``"digitize"``
+                reproduces the legacy interpolation.
             
         Raises:
-            ValueError: If nu_grid is empty or invalid
+            ValueError: If nu_grid or wavenumber_interpolation is invalid
         """
         if len(nu_grid) == 0:
             raise ValueError("nu_grid cannot be empty")
+        if wavenumber_interpolation not in ("interp", "digitize"):
+            raise ValueError(
+                "wavenumber_interpolation must be 'interp' or 'digitize'."
+            )
             
         self.method = "cia"
         self.warning = True
         self.nu_grid = nu_grid
         self.cdb = cdb
+        self.wavenumber_interpolation = wavenumber_interpolation
         self.ready = True
 
     def logacia_vector(self, T: float) -> jnp.ndarray:
@@ -77,7 +87,12 @@ class OpaCIA(OpaCont):
             Logarithm of absorption coefficient [Nnus] at T in units of cm⁵
         """
         return interp_logacia_vector(
-            T, self.nu_grid, self.cdb.nucia, self.cdb.tcia, self.cdb.logac
+            T,
+            self.nu_grid,
+            self.cdb.nucia,
+            self.cdb.tcia,
+            self.cdb.logac,
+            self.wavenumber_interpolation,
         )
 
     def logacia_matrix(
@@ -93,7 +108,12 @@ class OpaCIA(OpaCont):
             Logarithm of absorption coefficient [Nlayer, Nnus] in units of cm⁵
         """
         return interp_logacia_matrix(
-            temperatures, self.nu_grid, self.cdb.nucia, self.cdb.tcia, self.cdb.logac
+            temperatures,
+            self.nu_grid,
+            self.cdb.nucia,
+            self.cdb.tcia,
+            self.cdb.logac,
+            self.wavenumber_interpolation,
         )
 
 

--- a/src/exojax/rt/layeropacity.py
+++ b/src/exojax/rt/layeropacity.py
@@ -128,7 +128,18 @@ def single_layer_optical_depth_CIA(
 
 
 def layer_optical_depth_CIA(
-    nu_grid, temperature, pressure, dParr, vmr1arr, vmr2arr, mmw, g, nucia, tcia, logac
+    nu_grid,
+    temperature,
+    pressure,
+    dParr,
+    vmr1arr,
+    vmr2arr,
+    mmw,
+    g,
+    nucia,
+    tcia,
+    logac,
+    wavenumber_interpolation="interp",
 ):
     """dtau of the CIA continuum.
 
@@ -147,6 +158,8 @@ def layer_optical_depth_CIA(
         nucia (array): wavenumber array for CIA
         tcia (array): temperature array for CIA
         logac: log10(absorption coefficient of CIA)
+        wavenumber_interpolation: CIA interpolation method, ``"interp"`` or
+            ``"digitize"``.
 
     Returns:
         2D array: optical depth matrix, dtau  [N_layer, N_nus]
@@ -159,7 +172,14 @@ def layer_optical_depth_CIA(
     dtauc = (
         10
         ** (
-            interp_logacia_matrix(temperature, nu_grid, nucia, tcia, logac)
+            interp_logacia_matrix(
+                temperature,
+                nu_grid,
+                nucia,
+                tcia,
+                logac,
+                wavenumber_interpolation,
+            )
             + lognarr1[:, None]
             + lognarr2[:, None]
             + logkB

--- a/tests/unittests/database/cia/hitrancia_test.py
+++ b/tests/unittests/database/cia/hitrancia_test.py
@@ -1,11 +1,14 @@
 from exojax.database.core.abscoeff import interp_logacia_matrix
 from exojax.database.core.abscoeff import interp_logacia_vector
 from exojax.database.cia.io import read_cia
+from exojax.opacity import OpaCIA
 from exojax.test.data import TESTDATA_H2_H2_CIA
 from exojax.utils.grids import wavenumber_grid
 from importlib.resources import files
+import jax
 import numpy as np
 import pytest
+
 
 def test_interp_logacia_matrix():
     nus = 4310.0
@@ -17,7 +20,17 @@ def test_interp_logacia_matrix():
     nu_grid, wav, r = wavenumber_grid(nus, nue, 10000, xsmode="premodit")
     logac_cia = interp_logacia_matrix(Tarr, nu_grid, nucia, tcia, logac)
     assert np.all(np.shape(logac_cia) == (2, 10000))
-    assert np.sum(logac_cia) == pytest.approx(-891133.44)
+    expected = np.log10(np.interp(nu_grid, nucia, ac[0]))
+    np.testing.assert_allclose(logac_cia, np.broadcast_to(expected, (2, 10000)))
+    legacy = interp_logacia_matrix(
+        Tarr,
+        nu_grid,
+        nucia,
+        tcia,
+        logac,
+        wavenumber_interpolation="digitize",
+    )
+    assert np.sum(legacy) == pytest.approx(-891133.44)
 
 
 def test_interp_logacia_vector():
@@ -30,7 +43,139 @@ def test_interp_logacia_vector():
     nu_grid, wav, r = wavenumber_grid(nus, nue, 10000, xsmode="premodit")
     logac_cia = interp_logacia_vector(T, nu_grid, nucia, tcia, logac)
     assert np.all(np.shape(logac_cia) == (10000,))
-    assert np.sum(logac_cia) == pytest.approx(-445566.72)
+    expected = np.log10(np.interp(nu_grid, nucia, ac[0]))
+    np.testing.assert_allclose(logac_cia, expected)
+
+
+def test_interp_logacia_uses_linear_coefficients_on_both_axes():
+    tcia = np.array([200.0, 400.0], dtype=np.float32)
+    nucia = np.array([1000.0, 2000.0], dtype=np.float32)
+    coefficient = np.array(
+        [
+            [1.0e-46, 5.0e-46],
+            [9.0e-46, 13.0e-46],
+        ]
+    )
+    logac = np.log10(coefficient).astype(np.float32)
+    nu_grid = np.array([500.0, 1500.0, 2500.0], dtype=np.float32)
+
+    actual = interp_logacia_matrix(
+        np.array([300.0], dtype=np.float32), nu_grid, nucia, tcia, logac
+    )
+
+    expected = np.log10(np.array([[5.0e-46, 7.0e-46, 9.0e-46]]))
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+    vector = interp_logacia_vector(300.0, nu_grid, nucia, tcia, logac)
+    np.testing.assert_allclose(vector, actual[0], rtol=1.0e-6)
+    assert np.all(np.isfinite(actual))
+
+
+def test_interp_logacia_preserves_large_float32_dynamic_range():
+    logac = np.array([[-40.0, -100.0], [-41.0, -101.0]], dtype=np.float32)
+    nu_grid = np.array([1000.0, 2000.0], dtype=np.float32)
+    nucia = np.array([1000.0, 2000.0], dtype=np.float32)
+    tcia = np.array([200.0, 400.0], dtype=np.float32)
+    actual = interp_logacia_vector(
+        np.float32(300.0),
+        nu_grid,
+        nucia,
+        tcia,
+        logac,
+    )
+    expected = np.log10(
+        0.5 * 10.0 ** logac[0].astype(float)
+        + 0.5 * 10.0 ** logac[1].astype(float)
+    )
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+    assert np.all(np.isfinite(actual))
+    gradient = jax.grad(
+        lambda temperature: interp_logacia_vector(
+            temperature, nu_grid, nucia, tcia, logac
+        ).sum()
+    )(np.float32(300.0))
+    assert np.isfinite(gradient)
+
+
+def test_interp_logacia_gradient_at_native_temperature_and_nan():
+    tcia = np.array([200.0, 300.0, 400.0], dtype=np.float32)
+    nucia = np.array([1000.0, 2000.0], dtype=np.float32)
+    nu_grid = np.array([1000.0], dtype=np.float32)
+    coefficient = np.array([1.0, 4.0, 9.0], dtype=np.float32) * 1.0e-30
+    logac = np.log10(np.column_stack((coefficient, coefficient)))
+
+    gradient = jax.grad(
+        lambda temperature: interp_logacia_vector(
+            temperature, nu_grid, nucia, tcia, logac
+        ).sum()
+    )(np.float32(300.0))
+    expected_gradient = 5.0 / (400.0 * np.log(10.0))
+    assert gradient == pytest.approx(expected_gradient, rel=1.0e-5)
+
+    nan_result = interp_logacia_vector(
+        np.float32(np.nan), nu_grid, nucia, tcia, logac
+    )
+    assert np.all(np.isnan(nan_result))
+
+
+def test_digitize_reproduces_legacy_interpolation():
+    tcia = np.array([200.0, 400.0])
+    nucia = np.array([1000.0, 2000.0])
+    logac = np.log10(
+        np.array(
+            [
+                [1.0e-40, 5.0e-40],
+                [9.0e-40, 13.0e-40],
+            ]
+        )
+    )
+    nu_grid = np.array([500.0, 1000.0, 1500.0, 2000.0, 2500.0])
+
+    actual = interp_logacia_vector(
+        300.0,
+        nu_grid,
+        nucia,
+        tcia,
+        logac,
+        wavenumber_interpolation="digitize",
+    )
+    native_at_temperature = np.array(
+        [
+            np.interp(300.0, tcia, logac[:, index])
+            for index in range(nucia.size)
+        ]
+    )
+    indices = np.clip(np.digitize(nu_grid, nucia), 0, nucia.size - 1)
+    np.testing.assert_allclose(actual, native_at_temperature[indices])
+
+
+def test_opacia_defaults_to_interp_and_accepts_digitize():
+    class Cdb:
+        nucia = np.array([1000.0, 2000.0])
+        tcia = np.array([200.0, 400.0])
+        logac = np.log10(
+            np.array(
+                [
+                    [1.0e-40, 5.0e-40],
+                    [9.0e-40, 13.0e-40],
+                ]
+            )
+        )
+
+    nu_grid = np.array([1500.0])
+    default = OpaCIA(Cdb(), nu_grid)
+    legacy = OpaCIA(Cdb(), nu_grid, wavenumber_interpolation="digitize")
+
+    assert default.wavenumber_interpolation == "interp"
+    assert legacy.wavenumber_interpolation == "digitize"
+    assert not np.allclose(
+        default.logacia_vector(300.0),
+        legacy.logacia_vector(300.0),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+    with pytest.raises(ValueError, match="wavenumber_interpolation"):
+        OpaCIA(Cdb(), nu_grid, wavenumber_interpolation="unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make linear-coefficient interpolation in temperature and wavenumber the default CIA policy
- retain the previous log-temperature and native-bin behavior through wavenumber_interpolation="digitize"
- expose the selector through OpaCIA and layer_optical_depth_CIA
- preserve float32 dynamic range, endpoint behavior, NaN propagation, and differentiability

## Tests

- CPU float32 CIA and opacity-profile tests: 9 passed
- CPU x64 CIA and opacity-profile tests: 9 passed
- git diff --check