### PR TITLE
Add column-based layer optical depths

### DIFF
--- a/src/exojax/rt/layeropacity.py
+++ b/src/exojax/rt/layeropacity.py
@@ -9,6 +9,180 @@ from exojax.database.hminus  import log_hminus_continuum, log_hminus_continuum_s
 from exojax.utils.constants import bar_cgs, logkB, logm_ucgs, opacity_factor
 
 
+def _geometric_opacity_array(coefficient, number_of_layers, name):
+    """Add a layer axis to a common spectrum or validate a layered array."""
+    coefficient = jnp.asarray(coefficient)
+    if coefficient.ndim == 0:
+        raise ValueError(f"{name} must have at least one dimension.")
+    if coefficient.ndim == 1:
+        return coefficient[None, :]
+    if coefficient.shape[0] != number_of_layers:
+        raise ValueError(
+            f"The leading axis of {name} must have length "
+            f"{number_of_layers}, but has length {coefficient.shape[0]}."
+        )
+    return coefficient
+
+
+def _geometric_layer_profile(profile, number_of_layers, target_ndim, name):
+    """Reshape a scalar or one-dimensional layer profile for broadcasting."""
+    profile = jnp.asarray(profile)
+    if profile.ndim == 0:
+        return profile
+    if profile.ndim != 1 or profile.shape[0] != number_of_layers:
+        raise ValueError(
+            f"{name} must be a scalar or a one-dimensional array of length "
+            f"{number_of_layers}."
+        )
+    return profile.reshape((number_of_layers,) + (1,) * (target_ndim - 1))
+
+
+def _geometric_opacity_inputs(coefficient, layer_height, coefficient_name):
+    """Validate the common shape contract for geometric optical depth."""
+    layer_height = jnp.asarray(layer_height)
+    if layer_height.ndim != 1:
+        raise ValueError("layer_height must be a one-dimensional array.")
+    if layer_height.shape[0] == 0:
+        raise ValueError("layer_height must contain at least one layer.")
+
+    coefficient = _geometric_opacity_array(
+        coefficient, layer_height.shape[0], coefficient_name
+    )
+    layer_height = _geometric_layer_profile(
+        layer_height,
+        layer_height.shape[0],
+        coefficient.ndim,
+        "layer_height",
+    )
+    return coefficient, layer_height
+
+
+def layer_optical_depth_from_cross_section(
+    cross_section, absorber_number_density, layer_height
+):
+    """Compute geometric layer optical depth from an absorption cross section.
+
+    This function evaluates ``dtau = sigma * n_absorber * dz`` in cgs units.
+    A one-dimensional cross section is interpreted as a common spectral vector
+    and is broadcast over all layers. Arrays with two or more dimensions must
+    have the layer axis first, for example ``(Nlayer, Nnu)`` for line-by-line
+    opacity or ``(Nlayer, Ng, Nband)`` for correlated-k opacity.
+
+    Args:
+        cross_section: Absorption cross section in cm2. Its shape is ``(Nnu,)``
+            or ``(Nlayer, ...)``.
+        absorber_number_density: Absorber number density in cm-3, provided as a
+            scalar or an array with shape ``(Nlayer,)``.
+        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+
+    Returns:
+        Dimensionless layer optical depth with shape ``(Nlayer, ...)``.
+    """
+    cross_section, layer_height = _geometric_opacity_inputs(
+        cross_section, layer_height, "cross_section"
+    )
+    absorber_number_density = _geometric_layer_profile(
+        absorber_number_density,
+        layer_height.shape[0],
+        cross_section.ndim,
+        "absorber_number_density",
+    )
+    return cross_section * absorber_number_density * layer_height
+
+
+def layer_optical_depth_from_log_cia(
+    log_cia_coefficient, number_density_1, number_density_2, layer_height
+):
+    """Compute geometric CIA optical depth without linearizing the coefficient.
+
+    The calculation is performed as
+    ``log10(dtau) = log10(k_cia) + log10(n1) + log10(n2) + log10(dz)``.
+    Keeping the CIA coefficient in logarithmic form avoids an intermediate
+    underflow in single precision. No symmetry factor is applied when the two
+    collision partners are identical.
+
+    Args:
+        log_cia_coefficient: Base-10 logarithm of the CIA coefficient in cm5.
+            Its shape is ``(Nnu,)`` or ``(Nlayer, ...)``.
+        number_density_1: Number density of the first collision partner in
+            cm-3, provided as a scalar or an array with shape ``(Nlayer,)``.
+        number_density_2: Number density of the second collision partner in
+            cm-3, provided as a scalar or an array with shape ``(Nlayer,)``.
+        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+
+    Returns:
+        Dimensionless layer optical depth with shape ``(Nlayer, ...)``. A zero
+        number density or zero layer height produces exactly zero.
+    """
+    log_cia_coefficient, layer_height = _geometric_opacity_inputs(
+        log_cia_coefficient, layer_height, "log_cia_coefficient"
+    )
+    number_of_layers = layer_height.shape[0]
+    number_density_1 = _geometric_layer_profile(
+        number_density_1,
+        number_of_layers,
+        log_cia_coefficient.ndim,
+        "number_density_1",
+    )
+    number_density_2 = _geometric_layer_profile(
+        number_density_2,
+        number_of_layers,
+        log_cia_coefficient.ndim,
+        "number_density_2",
+    )
+
+    zero_optical_depth = (
+        (number_density_1 == 0)
+        | (number_density_2 == 0)
+        | (layer_height == 0)
+    )
+    safe_number_density_1 = jnp.where(
+        number_density_1 == 0, jnp.ones_like(number_density_1), number_density_1
+    )
+    safe_number_density_2 = jnp.where(
+        number_density_2 == 0, jnp.ones_like(number_density_2), number_density_2
+    )
+    safe_layer_height = jnp.where(
+        layer_height == 0, jnp.ones_like(layer_height), layer_height
+    )
+    log_optical_depth = (
+        log_cia_coefficient
+        + jnp.log10(safe_number_density_1)
+        + jnp.log10(safe_number_density_2)
+        + jnp.log10(safe_layer_height)
+    )
+    log_optical_depth = jnp.where(
+        zero_optical_depth,
+        jnp.full_like(log_optical_depth, -jnp.inf),
+        log_optical_depth,
+    )
+    return jnp.power(
+        jnp.asarray(10.0, dtype=log_optical_depth.dtype), log_optical_depth
+    )
+
+
+def layer_optical_depth_from_extinction(extinction_coefficient, layer_height):
+    """Compute geometric layer optical depth from an extinction coefficient.
+
+    This function evaluates ``dtau = alpha * dz`` with the extinction
+    coefficient in cm-1 and the layer thickness in cm. A one-dimensional
+    coefficient is interpreted as a common spectral vector; layered arrays
+    must have the layer axis first.
+
+    Args:
+        extinction_coefficient: Extinction coefficient in cm-1. Its shape is
+            ``(Nnu,)`` or ``(Nlayer, ...)``.
+        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+
+    Returns:
+        Dimensionless layer optical depth with shape ``(Nlayer, ...)``.
+    """
+    extinction_coefficient, layer_height = _geometric_opacity_inputs(
+        extinction_coefficient, layer_height, "extinction_coefficient"
+    )
+    return extinction_coefficient * layer_height
+
+
 def single_layer_optical_depth(dpressure, xsv, mixing_ratio, mass, gravity):
     """opacity for a single layer (delta tau) from cross section vector, molecular line/Rayleigh scattering (for opart)
 

--- a/src/exojax/rt/layeropacity.py
+++ b/src/exojax/rt/layeropacity.py
@@ -9,60 +9,137 @@ from exojax.database.hminus  import log_hminus_continuum, log_hminus_continuum_s
 from exojax.utils.constants import bar_cgs, logkB, logm_ucgs, opacity_factor
 
 
-def _geometric_opacity_array(coefficient, number_of_layers, name):
+def _layer_opacity_array(coefficient, number_of_layers, name):
     """Add a layer axis to a common spectrum or validate a layered array."""
     coefficient = jnp.asarray(coefficient)
     if coefficient.ndim == 0:
         raise ValueError(f"{name} must have at least one dimension.")
     if coefficient.ndim == 1:
         return coefficient[None, :]
-    if coefficient.shape[0] != number_of_layers:
+    if coefficient.shape[0] not in (1, number_of_layers):
         raise ValueError(
-            f"The leading axis of {name} must have length "
+            f"The leading axis of {name} must have length 1 or "
             f"{number_of_layers}, but has length {coefficient.shape[0]}."
         )
     return coefficient
 
 
-def _geometric_layer_profile(profile, number_of_layers, target_ndim, name):
-    """Reshape a scalar or one-dimensional layer profile for broadcasting."""
-    profile = jnp.asarray(profile)
-    if profile.ndim == 0:
-        return profile
-    if profile.ndim != 1 or profile.shape[0] != number_of_layers:
+def _layer_factor(value, number_of_layers, target_shape, name):
+    """Reshape a layer-dependent factor for opacity-array broadcasting."""
+    value = jnp.asarray(value)
+    if value.ndim == 0:
+        return value
+    if value.shape[0] not in (1, number_of_layers):
         raise ValueError(
-            f"{name} must be a scalar or a one-dimensional array of length "
-            f"{number_of_layers}."
+            f"The leading axis of {name} must have length 1 or "
+            f"{number_of_layers}, but has length {value.shape[0]}."
         )
-    return profile.reshape((number_of_layers,) + (1,) * (target_ndim - 1))
+    if value.ndim > len(target_shape):
+        raise ValueError(
+            f"{name} has {value.ndim} dimensions, but the opacity array has "
+            f"only {len(target_shape)}."
+        )
+
+    value_shape = value.shape + (1,) * (len(target_shape) - value.ndim)
+    for value_size, target_size in zip(value_shape[1:], target_shape[1:]):
+        if value_size not in (1, target_size):
+            raise ValueError(
+                f"{name} with shape {value.shape} cannot be broadcast to an "
+                f"opacity array with shape {target_shape}."
+            )
+    if value.shape == value_shape:
+        return value
+    return value.reshape(value_shape)
 
 
-def _geometric_opacity_inputs(coefficient, layer_height, coefficient_name):
-    """Validate the common shape contract for geometric optical depth."""
-    layer_height = jnp.asarray(layer_height)
-    if layer_height.ndim != 1:
-        raise ValueError("layer_height must be a one-dimensional array.")
-    if layer_height.shape[0] == 0:
-        raise ValueError("layer_height must contain at least one layer.")
+def _layer_opacity_inputs(coefficient, layer_factor, coefficient_name, factor_name):
+    """Validate and broadcast an opacity coefficient and a layer factor."""
+    coefficient = jnp.asarray(coefficient)
+    if coefficient.ndim == 0:
+        raise ValueError(f"{coefficient_name} must have at least one dimension.")
 
-    coefficient = _geometric_opacity_array(
-        coefficient, layer_height.shape[0], coefficient_name
+    layer_factor = jnp.asarray(layer_factor)
+    if layer_factor.ndim == 0:
+        number_of_layers = coefficient.shape[0] if coefficient.ndim > 1 else 1
+    else:
+        number_of_layers = layer_factor.shape[0]
+        if number_of_layers == 0:
+            raise ValueError(f"{factor_name} must contain at least one layer.")
+
+    coefficient = _layer_opacity_array(
+        coefficient, number_of_layers, coefficient_name
     )
-    layer_height = _geometric_layer_profile(
-        layer_height,
-        layer_height.shape[0],
-        coefficient.ndim,
-        "layer_height",
+    layer_factor = _layer_factor(
+        layer_factor, number_of_layers, coefficient.shape, factor_name
     )
-    return coefficient, layer_height
+    return coefficient, layer_factor
 
 
-def layer_optical_depth_from_cross_section(
-    cross_section, absorber_number_density, layer_height
+def _layer_optical_depth_from_cross_section(
+    cross_section, absorber_number_column
 ):
-    """Compute geometric layer optical depth from an absorption cross section.
+    """Multiply prepared cross sections and absorber number columns."""
+    return cross_section * absorber_number_column
 
-    This function evaluates ``dtau = sigma * n_absorber * dz`` in cgs units.
+
+def _pressure_number_of_layers(cross_section, *layer_factors):
+    """Infer the broadcast layer size of pressure-based opacity inputs."""
+    layer_sizes = []
+    if cross_section.ndim > 1:
+        layer_sizes.append(cross_section.shape[0])
+    for factor in layer_factors:
+        if factor.ndim > 0:
+            layer_sizes.append(factor.shape[0])
+    non_singleton_sizes = [size for size in layer_sizes if size != 1]
+    return max(non_singleton_sizes, default=1)
+
+
+def _layer_optical_depth_from_pressure(
+    dpressure,
+    cross_section,
+    mixing_ratio,
+    mass,
+    gravity,
+    cross_section_name,
+):
+    """Build a pressure-based absorber column and apply its cross section."""
+    cross_section = jnp.asarray(cross_section)
+    dpressure = jnp.asarray(dpressure)
+    mixing_ratio = jnp.asarray(mixing_ratio)
+    mass = jnp.asarray(mass)
+    gravity = jnp.asarray(gravity)
+    number_of_layers = _pressure_number_of_layers(
+        cross_section, dpressure, mixing_ratio, mass, gravity
+    )
+    cross_section = _layer_opacity_array(
+        cross_section, number_of_layers, cross_section_name
+    )
+    dpressure = _layer_factor(
+        dpressure, number_of_layers, cross_section.shape, "dParr"
+    )
+    mixing_ratio = _layer_factor(
+        mixing_ratio, number_of_layers, cross_section.shape, "mixing_ratio"
+    )
+    mass = _layer_factor(mass, number_of_layers, cross_section.shape, "mass")
+    gravity = _layer_factor(
+        gravity, number_of_layers, cross_section.shape, "gravity"
+    )
+    absorber_number_column = (
+        opacity_factor * dpressure * mixing_ratio / (mass * gravity)
+    )
+    return _layer_optical_depth_from_cross_section(
+        cross_section, absorber_number_column
+    )
+
+
+def layer_optical_depth_from_cross_section(cross_section, absorber_number_column):
+    """Compute layer optical depth from an absorption cross section.
+
+    This function evaluates ``dtau = sigma * N_absorber`` in cgs units.
+    The absorber column may be obtained from either a pressure interval or a
+    geometrical path length. This coordinate-independent product is shared by
+    the pressure-based layer optical-depth functions.
+
     A one-dimensional cross section is interpreted as a common spectral vector
     and is broadcast over all layers. Arrays with two or more dimensions must
     have the layer axis first, for example ``(Nlayer, Nnu)`` for line-by-line
@@ -71,27 +148,25 @@ def layer_optical_depth_from_cross_section(
     Args:
         cross_section: Absorption cross section in cm2. Its shape is ``(Nnu,)``
             or ``(Nlayer, ...)``.
-        absorber_number_density: Absorber number density in cm-3, provided as a
-            scalar or an array with shape ``(Nlayer,)``.
-        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+        absorber_number_column: Absorber column number density in cm-2,
+            provided as a scalar or an array with leading layer axis.
 
     Returns:
         Dimensionless layer optical depth with shape ``(Nlayer, ...)``.
     """
-    cross_section, layer_height = _geometric_opacity_inputs(
-        cross_section, layer_height, "cross_section"
+    cross_section, absorber_number_column = _layer_opacity_inputs(
+        cross_section,
+        absorber_number_column,
+        "cross_section",
+        "absorber_number_column",
     )
-    absorber_number_density = _geometric_layer_profile(
-        absorber_number_density,
-        layer_height.shape[0],
-        cross_section.ndim,
-        "absorber_number_density",
+    return _layer_optical_depth_from_cross_section(
+        cross_section, absorber_number_column
     )
-    return cross_section * absorber_number_density * layer_height
 
 
 def layer_optical_depth_from_log_cia(
-    log_cia_coefficient, number_density_1, number_density_2, layer_height
+    log_cia_coefficient, number_density_1, number_density_2, path_length
 ):
     """Compute geometric CIA optical depth without linearizing the coefficient.
 
@@ -108,33 +183,39 @@ def layer_optical_depth_from_log_cia(
             cm-3, provided as a scalar or an array with shape ``(Nlayer,)``.
         number_density_2: Number density of the second collision partner in
             cm-3, provided as a scalar or an array with shape ``(Nlayer,)``.
-        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+        path_length: Geometric path length in cm with shape ``(Nlayer,)``.
 
     Returns:
         Dimensionless layer optical depth with shape ``(Nlayer, ...)``. A zero
-        number density or zero layer height produces exactly zero.
+        number density or zero path length produces exactly zero.
     """
-    log_cia_coefficient, layer_height = _geometric_opacity_inputs(
-        log_cia_coefficient, layer_height, "log_cia_coefficient"
+    path_length = jnp.asarray(path_length)
+    if path_length.ndim != 1:
+        raise ValueError("path_length must be a one-dimensional array.")
+    log_cia_coefficient, path_length = _layer_opacity_inputs(
+        log_cia_coefficient,
+        path_length,
+        "log_cia_coefficient",
+        "path_length",
     )
-    number_of_layers = layer_height.shape[0]
-    number_density_1 = _geometric_layer_profile(
+    number_of_layers = path_length.shape[0]
+    number_density_1 = _layer_factor(
         number_density_1,
         number_of_layers,
-        log_cia_coefficient.ndim,
+        log_cia_coefficient.shape,
         "number_density_1",
     )
-    number_density_2 = _geometric_layer_profile(
+    number_density_2 = _layer_factor(
         number_density_2,
         number_of_layers,
-        log_cia_coefficient.ndim,
+        log_cia_coefficient.shape,
         "number_density_2",
     )
 
     zero_optical_depth = (
         (number_density_1 == 0)
         | (number_density_2 == 0)
-        | (layer_height == 0)
+        | (path_length == 0)
     )
     safe_number_density_1 = jnp.where(
         number_density_1 == 0, jnp.ones_like(number_density_1), number_density_1
@@ -142,14 +223,14 @@ def layer_optical_depth_from_log_cia(
     safe_number_density_2 = jnp.where(
         number_density_2 == 0, jnp.ones_like(number_density_2), number_density_2
     )
-    safe_layer_height = jnp.where(
-        layer_height == 0, jnp.ones_like(layer_height), layer_height
+    safe_path_length = jnp.where(
+        path_length == 0, jnp.ones_like(path_length), path_length
     )
     log_optical_depth = (
         log_cia_coefficient
         + jnp.log10(safe_number_density_1)
         + jnp.log10(safe_number_density_2)
-        + jnp.log10(safe_layer_height)
+        + jnp.log10(safe_path_length)
     )
     log_optical_depth = jnp.where(
         zero_optical_depth,
@@ -161,7 +242,7 @@ def layer_optical_depth_from_log_cia(
     )
 
 
-def layer_optical_depth_from_extinction(extinction_coefficient, layer_height):
+def layer_optical_depth_from_extinction(extinction_coefficient, path_length):
     """Compute geometric layer optical depth from an extinction coefficient.
 
     This function evaluates ``dtau = alpha * dz`` with the extinction
@@ -172,15 +253,21 @@ def layer_optical_depth_from_extinction(extinction_coefficient, layer_height):
     Args:
         extinction_coefficient: Extinction coefficient in cm-1. Its shape is
             ``(Nnu,)`` or ``(Nlayer, ...)``.
-        layer_height: Geometric layer thickness in cm with shape ``(Nlayer,)``.
+        path_length: Geometric path length in cm with shape ``(Nlayer,)``.
 
     Returns:
         Dimensionless layer optical depth with shape ``(Nlayer, ...)``.
     """
-    extinction_coefficient, layer_height = _geometric_opacity_inputs(
-        extinction_coefficient, layer_height, "extinction_coefficient"
+    path_length = jnp.asarray(path_length)
+    if path_length.ndim != 1:
+        raise ValueError("path_length must be a one-dimensional array.")
+    extinction_coefficient, path_length = _layer_opacity_inputs(
+        extinction_coefficient,
+        path_length,
+        "extinction_coefficient",
+        "path_length",
     )
-    return extinction_coefficient * layer_height
+    return extinction_coefficient * path_length
 
 
 def single_layer_optical_depth(dpressure, xsv, mixing_ratio, mass, gravity):
@@ -216,17 +303,16 @@ def layer_optical_depth(dParr, xsmatrix, mixing_ratio, mass, gravity):
         2D array: optical depth matrix, dtau  [N_layer, N_nus]
     """
 
-    if jnp.ndim(mass) == 1:
-        mass = mass[:, None]
-    if jnp.ndim(gravity) == 1:
-        gravity = gravity[:, None]
-
-    return (
-        opacity_factor
-        * xsmatrix
-        * dParr[:, None]
-        * mixing_ratio[:, None]
-        / (mass * gravity)
+    dParr = jnp.asarray(dParr)
+    if dParr.ndim != 1:
+        raise ValueError("dParr must be a one-dimensional array.")
+    return _layer_optical_depth_from_pressure(
+        dParr,
+        xsmatrix,
+        mixing_ratio,
+        mass,
+        gravity,
+        "xsmatrix",
     )
 
 
@@ -244,27 +330,16 @@ def layer_optical_depth_ckd(dParr, xstensor_ckd, mixing_ratio, mass, gravity):
         3D array: optical depth tensor, dtau_ckd [N_layer, N_g, N_bands]
     """
 
-    def _layer_factor(value):
-        value = jnp.asarray(value)
-        if value.ndim == 0:
-            return value
-        if value.ndim == 1:
-            return value[:, None, None]
-        if value.ndim == 2 and value.shape[1] == 1:
-            return value.reshape((value.shape[0], 1, 1))
-        return value
-
-    dParr = _layer_factor(dParr)
-    mixing_ratio = _layer_factor(mixing_ratio)
-    mass = _layer_factor(mass)
-    gravity = _layer_factor(gravity)
-
-    return (
-        opacity_factor
-        * xstensor_ckd
-        * dParr
-        * mixing_ratio
-        / (mass * gravity)
+    xstensor_ckd = jnp.asarray(xstensor_ckd)
+    if xstensor_ckd.ndim != 3:
+        raise ValueError("xstensor_ckd must be a three-dimensional array.")
+    return _layer_optical_depth_from_pressure(
+        dParr,
+        xstensor_ckd,
+        mixing_ratio,
+        mass,
+        gravity,
+        "xstensor_ckd",
     )
 
 

--- a/tests/unittests/opacity/ckd/layeropacity_ckd_test.py
+++ b/tests/unittests/opacity/ckd/layeropacity_ckd_test.py
@@ -1,6 +1,10 @@
+import jax.numpy as jnp
 import numpy as np
 
-from exojax.rt.layeropacity import layer_optical_depth_ckd
+from exojax.rt.layeropacity import (
+    layer_optical_depth_ckd,
+    layer_optical_depth_from_cross_section,
+)
 from exojax.utils.constants import opacity_factor
 
 
@@ -71,3 +75,43 @@ def test_layer_optical_depth_ckd_accepts_prebroadcast_factors():
     expected_layer = opacity_factor * dpressure / (mass * gravity)
     expected = expected_layer[:, None, None] * mixing_ratio
     np.testing.assert_allclose(np.asarray(dtau), expected)
+
+
+def test_layer_optical_depth_ckd_matches_common_number_column_api():
+    dpressure = jnp.array([0.1, 0.2])
+    xstensor_ckd = jnp.arange(1.0, 25.0).reshape((2, 3, 4)) * 1.0e-20
+    mixing_ratio = jnp.array([1.0e-3, 2.0e-3])
+    mass = jnp.array([2.3, 2.4])
+    gravity = jnp.array([900.0, 1000.0])
+
+    pressure_result = layer_optical_depth_ckd(
+        dpressure, xstensor_ckd, mixing_ratio, mass, gravity
+    )
+    absorber_number_column = (
+        opacity_factor * dpressure * mixing_ratio / (mass * gravity)
+    )
+    column_result = layer_optical_depth_from_cross_section(
+        xstensor_ckd, absorber_number_column
+    )
+
+    np.testing.assert_array_equal(pressure_result, column_result)
+
+
+def test_layer_optical_depth_ckd_preserves_leading_singleton_broadcasting():
+    dpressure = jnp.array([0.1, 0.2])
+    xstensor_ckd = jnp.ones((1, 3, 4)) * 1.0e-20
+    mixing_ratio = jnp.array([1.0e-3])
+    mass = jnp.array([2.3])
+    gravity = jnp.array([900.0])
+
+    optical_depth = layer_optical_depth_ckd(
+        dpressure, xstensor_ckd, mixing_ratio, mass, gravity
+    )
+    expected_column = (
+        opacity_factor * dpressure * mixing_ratio[0] / (mass[0] * gravity[0])
+    )
+
+    assert optical_depth.shape == (2, 3, 4)
+    np.testing.assert_allclose(
+        optical_depth, xstensor_ckd * expected_column[:, None, None]
+    )

--- a/tests/unittests/rt/atmrt/geometric_layer_opacity_test.py
+++ b/tests/unittests/rt/atmrt/geometric_layer_opacity_test.py
@@ -1,0 +1,198 @@
+"""Tests for optical depth integrated over geometric layer thickness."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.rt.layeropacity import layer_optical_depth_from_cross_section
+from exojax.rt.layeropacity import layer_optical_depth_from_extinction
+from exojax.rt.layeropacity import layer_optical_depth_from_log_cia
+
+
+def test_cross_section_common_spectrum_matches_analytic_equation():
+    cross_section = jnp.array([1.0e-20, 3.0e-20, 5.0e-20])
+    number_density = jnp.array([2.0e10, 4.0e10])
+    layer_height = jnp.array([1.0e5, 3.0e5])
+
+    optical_depth = layer_optical_depth_from_cross_section(
+        cross_section, number_density, layer_height
+    )
+    expected = (
+        cross_section[None, :]
+        * number_density[:, None]
+        * layer_height[:, None]
+    )
+
+    assert optical_depth.shape == (2, 3)
+    np.testing.assert_allclose(optical_depth, expected)
+
+
+def test_cross_section_layer_resolved_lbl_array():
+    cross_section = jnp.array(
+        [[1.0e-20, 2.0e-20, 3.0e-20], [4.0e-20, 5.0e-20, 6.0e-20]]
+    )
+    number_density = 2.0e10
+    layer_height = jnp.array([1.0e5, 2.0e5])
+
+    optical_depth = layer_optical_depth_from_cross_section(
+        cross_section, number_density, layer_height
+    )
+    expected = cross_section * number_density * layer_height[:, None]
+
+    assert optical_depth.shape == cross_section.shape
+    np.testing.assert_allclose(optical_depth, expected)
+
+
+def test_cross_section_layer_resolved_ckd_array():
+    cross_section = jnp.arange(1.0, 13.0).reshape((2, 2, 3)) * 1.0e-20
+    number_density = jnp.array([2.0e10, 4.0e10])
+    layer_height = jnp.array([1.0e5, 2.0e5])
+
+    optical_depth = layer_optical_depth_from_cross_section(
+        cross_section, number_density, layer_height
+    )
+    expected = (
+        cross_section
+        * number_density[:, None, None]
+        * layer_height[:, None, None]
+    )
+
+    assert optical_depth.shape == cross_section.shape
+    np.testing.assert_allclose(optical_depth, expected)
+
+
+def test_log_cia_matches_analytic_equation_for_layered_ckd_array():
+    log_cia = jnp.log10(jnp.arange(1.0, 13.0).reshape((2, 2, 3)) * 1.0e-45)
+    number_density_1 = jnp.array([2.0e19, 3.0e19])
+    number_density_2 = jnp.array([4.0e18, 5.0e18])
+    layer_height = jnp.array([1.0e5, 2.0e5])
+
+    optical_depth = layer_optical_depth_from_log_cia(
+        log_cia, number_density_1, number_density_2, layer_height
+    )
+    expected = (
+        10.0**log_cia
+        * number_density_1[:, None, None]
+        * number_density_2[:, None, None]
+        * layer_height[:, None, None]
+    )
+
+    assert optical_depth.shape == log_cia.shape
+    np.testing.assert_allclose(optical_depth, expected, rtol=2.0e-6)
+
+
+def test_extinction_common_spectrum_matches_analytic_equation():
+    extinction_coefficient = jnp.array([1.0e-7, 3.0e-7])
+    layer_height = jnp.array([1.0e5, 2.0e5, 4.0e5])
+
+    optical_depth = layer_optical_depth_from_extinction(
+        extinction_coefficient, layer_height
+    )
+    expected = extinction_coefficient[None, :] * layer_height[:, None]
+
+    assert optical_depth.shape == (3, 2)
+    np.testing.assert_allclose(optical_depth, expected)
+
+
+def test_geometric_optical_depth_does_not_silently_make_opacity_positive():
+    optical_depth = layer_optical_depth_from_cross_section(
+        jnp.array([-2.0e-20]), 3.0e10, jnp.array([4.0e5])
+    )
+
+    np.testing.assert_allclose(optical_depth, jnp.array([[-2.4e-4]]))
+
+
+def test_log_cia_preserves_float32_dynamic_range_and_identical_partner_rule():
+    log_cia = jnp.array([-46.0, -60.0], dtype=jnp.float32)
+    number_density = jnp.asarray(1.0e20, dtype=jnp.float32)
+    layer_height = jnp.array([1.0e5], dtype=jnp.float32)
+
+    linearized_coefficient = jnp.power(jnp.float32(10.0), log_cia)
+    optical_depth = layer_optical_depth_from_log_cia(
+        log_cia, number_density, number_density, layer_height
+    )
+
+    np.testing.assert_array_equal(linearized_coefficient, jnp.zeros(2))
+    np.testing.assert_allclose(
+        optical_depth,
+        jnp.array([[1.0e-1, 1.0e-15]], dtype=jnp.float32),
+        rtol=2.0e-5,
+    )
+
+
+def test_log_cia_zero_density_and_height_return_zero_without_nan_gradient():
+    log_cia = jnp.full((2, 2), -46.0)
+    number_density_1 = jnp.array([0.0, 1.0e20])
+    number_density_2 = jnp.full(2, 1.0e20)
+    layer_height = jnp.array([1.0e5, 0.0])
+
+    optical_depth = layer_optical_depth_from_log_cia(
+        log_cia, number_density_1, number_density_2, layer_height
+    )
+    gradient = jax.grad(
+        lambda density: jnp.sum(
+            layer_optical_depth_from_log_cia(
+                log_cia, density, number_density_2, layer_height
+            )
+        )
+    )(number_density_1)
+
+    np.testing.assert_array_equal(optical_depth, jnp.zeros((2, 2)))
+    assert np.all(np.isfinite(gradient))
+
+
+def test_geometric_optical_depth_supports_jit_and_grad():
+    cross_section = jnp.array([1.0e-20, 2.0e-20])
+    log_cia = jnp.array([-46.0, -45.0])
+    extinction_coefficient = jnp.array([1.0e-7, 2.0e-7])
+    number_density = jnp.array([1.0e20, 2.0e20])
+    layer_height = jnp.array([1.0e5, 2.0e5])
+
+    def summed_optical_depth(scale):
+        cross_section_depth = layer_optical_depth_from_cross_section(
+            scale * cross_section, number_density, layer_height
+        )
+        cia_depth = layer_optical_depth_from_log_cia(
+            log_cia + jnp.log10(scale),
+            number_density,
+            number_density,
+            layer_height,
+        )
+        extinction_depth = layer_optical_depth_from_extinction(
+            scale * extinction_coefficient, layer_height
+        )
+        return (
+            jnp.sum(cross_section_depth)
+            + jnp.sum(cia_depth)
+            + jnp.sum(extinction_depth)
+        )
+
+    value, gradient = jax.jit(jax.value_and_grad(summed_optical_depth))(1.0)
+
+    assert jnp.isfinite(value)
+    assert jnp.isfinite(gradient)
+    assert gradient > 0.0
+
+
+def test_geometric_optical_depth_rejects_invalid_shapes():
+    layer_height = jnp.ones(2)
+
+    with pytest.raises(ValueError, match="layer_height must be a one-dimensional"):
+        layer_optical_depth_from_extinction(jnp.ones(3), jnp.ones((2, 1)))
+    with pytest.raises(ValueError, match="at least one layer"):
+        layer_optical_depth_from_extinction(jnp.ones(3), jnp.empty(0))
+    with pytest.raises(ValueError, match="at least one dimension"):
+        layer_optical_depth_from_cross_section(1.0, 1.0, layer_height)
+    with pytest.raises(ValueError, match="leading axis"):
+        layer_optical_depth_from_cross_section(
+            jnp.ones((3, 4)), jnp.ones(2), layer_height
+        )
+    with pytest.raises(ValueError, match="absorber_number_density"):
+        layer_optical_depth_from_cross_section(
+            jnp.ones((2, 4)), jnp.ones((2, 1)), layer_height
+        )
+    with pytest.raises(ValueError, match="number_density_2"):
+        layer_optical_depth_from_log_cia(
+            jnp.ones((2, 4)), jnp.ones(2), jnp.ones(3), layer_height
+        )

--- a/tests/unittests/rt/atmrt/geometric_layer_opacity_test.py
+++ b/tests/unittests/rt/atmrt/geometric_layer_opacity_test.py
@@ -5,18 +5,23 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from exojax.rt.layeropacity import layer_optical_depth_from_cross_section
-from exojax.rt.layeropacity import layer_optical_depth_from_extinction
-from exojax.rt.layeropacity import layer_optical_depth_from_log_cia
+from exojax.rt.layeropacity import (
+    layer_optical_depth,
+    layer_optical_depth_from_cross_section,
+    layer_optical_depth_from_extinction,
+    layer_optical_depth_from_log_cia,
+)
+from exojax.utils.constants import opacity_factor
 
 
 def test_cross_section_common_spectrum_matches_analytic_equation():
     cross_section = jnp.array([1.0e-20, 3.0e-20, 5.0e-20])
     number_density = jnp.array([2.0e10, 4.0e10])
     layer_height = jnp.array([1.0e5, 3.0e5])
+    absorber_number_column = number_density * layer_height
 
     optical_depth = layer_optical_depth_from_cross_section(
-        cross_section, number_density, layer_height
+        cross_section, absorber_number_column
     )
     expected = (
         cross_section[None, :]
@@ -34,9 +39,10 @@ def test_cross_section_layer_resolved_lbl_array():
     )
     number_density = 2.0e10
     layer_height = jnp.array([1.0e5, 2.0e5])
+    absorber_number_column = number_density * layer_height
 
     optical_depth = layer_optical_depth_from_cross_section(
-        cross_section, number_density, layer_height
+        cross_section, absorber_number_column
     )
     expected = cross_section * number_density * layer_height[:, None]
 
@@ -48,15 +54,12 @@ def test_cross_section_layer_resolved_ckd_array():
     cross_section = jnp.arange(1.0, 13.0).reshape((2, 2, 3)) * 1.0e-20
     number_density = jnp.array([2.0e10, 4.0e10])
     layer_height = jnp.array([1.0e5, 2.0e5])
+    absorber_number_column = number_density * layer_height
 
     optical_depth = layer_optical_depth_from_cross_section(
-        cross_section, number_density, layer_height
+        cross_section, absorber_number_column
     )
-    expected = (
-        cross_section
-        * number_density[:, None, None]
-        * layer_height[:, None, None]
-    )
+    expected = cross_section * absorber_number_column[:, None, None]
 
     assert optical_depth.shape == cross_section.shape
     np.testing.assert_allclose(optical_depth, expected)
@@ -96,8 +99,9 @@ def test_extinction_common_spectrum_matches_analytic_equation():
 
 
 def test_geometric_optical_depth_does_not_silently_make_opacity_positive():
+    absorber_number_column = jnp.array([3.0e10 * 4.0e5])
     optical_depth = layer_optical_depth_from_cross_section(
-        jnp.array([-2.0e-20]), 3.0e10, jnp.array([4.0e5])
+        jnp.array([-2.0e-20]), absorber_number_column
     )
 
     np.testing.assert_allclose(optical_depth, jnp.array([[-2.4e-4]]))
@@ -148,10 +152,11 @@ def test_geometric_optical_depth_supports_jit_and_grad():
     extinction_coefficient = jnp.array([1.0e-7, 2.0e-7])
     number_density = jnp.array([1.0e20, 2.0e20])
     layer_height = jnp.array([1.0e5, 2.0e5])
+    absorber_number_column = number_density * layer_height
 
     def summed_optical_depth(scale):
         cross_section_depth = layer_optical_depth_from_cross_section(
-            scale * cross_section, number_density, layer_height
+            scale * cross_section, absorber_number_column
         )
         cia_depth = layer_optical_depth_from_log_cia(
             log_cia + jnp.log10(scale),
@@ -176,23 +181,65 @@ def test_geometric_optical_depth_supports_jit_and_grad():
 
 
 def test_geometric_optical_depth_rejects_invalid_shapes():
-    layer_height = jnp.ones(2)
+    path_length = jnp.ones(2)
 
-    with pytest.raises(ValueError, match="layer_height must be a one-dimensional"):
+    with pytest.raises(ValueError, match="path_length must be a one-dimensional"):
         layer_optical_depth_from_extinction(jnp.ones(3), jnp.ones((2, 1)))
     with pytest.raises(ValueError, match="at least one layer"):
         layer_optical_depth_from_extinction(jnp.ones(3), jnp.empty(0))
     with pytest.raises(ValueError, match="at least one dimension"):
-        layer_optical_depth_from_cross_section(1.0, 1.0, layer_height)
+        layer_optical_depth_from_cross_section(1.0, jnp.ones(2))
     with pytest.raises(ValueError, match="leading axis"):
         layer_optical_depth_from_cross_section(
-            jnp.ones((3, 4)), jnp.ones(2), layer_height
+            jnp.ones((3, 4)), jnp.ones(2)
         )
-    with pytest.raises(ValueError, match="absorber_number_density"):
+    with pytest.raises(ValueError, match="absorber_number_column"):
         layer_optical_depth_from_cross_section(
-            jnp.ones((2, 4)), jnp.ones((2, 1)), layer_height
+            jnp.ones((2, 4)), jnp.ones((2, 2))
         )
     with pytest.raises(ValueError, match="number_density_2"):
         layer_optical_depth_from_log_cia(
-            jnp.ones((2, 4)), jnp.ones(2), jnp.ones(3), layer_height
+            jnp.ones((2, 4)), jnp.ones(2), jnp.ones(3), path_length
         )
+
+
+def test_pressure_wrapper_matches_common_number_column_api():
+    dpressure = jnp.array([0.1, 0.3])
+    cross_section = jnp.array(
+        [[1.0e-20, 2.0e-20], [3.0e-20, 4.0e-20]]
+    )
+    mixing_ratio = jnp.array([1.0e-3, 2.0e-3])
+    mass = jnp.array([18.0, 20.0])
+    gravity = jnp.array([900.0, 1000.0])
+
+    pressure_result = layer_optical_depth(
+        dpressure, cross_section, mixing_ratio, mass, gravity
+    )
+    absorber_number_column = (
+        opacity_factor * dpressure * mixing_ratio / (mass * gravity)
+    )
+    column_result = layer_optical_depth_from_cross_section(
+        cross_section, absorber_number_column
+    )
+
+    np.testing.assert_array_equal(pressure_result, column_result)
+
+
+def test_pressure_wrapper_preserves_leading_singleton_broadcasting():
+    dpressure = jnp.array([0.1, 0.3])
+    cross_section = jnp.array([[1.0e-20, 2.0e-20]])
+    mixing_ratio = jnp.array([1.0e-3])
+    mass = jnp.array([18.0])
+    gravity = jnp.array([900.0])
+
+    optical_depth = layer_optical_depth(
+        dpressure, cross_section, mixing_ratio, mass, gravity
+    )
+    expected_column = (
+        opacity_factor * dpressure * mixing_ratio[0] / (mass[0] * gravity[0])
+    )
+
+    assert optical_depth.shape == (2, 2)
+    np.testing.assert_allclose(
+        optical_depth, cross_section * expected_column[:, None]
+    )


### PR DESCRIPTION
## Summary

- add a coordinate-independent cross-section API based on absorber number column, `dtau = sigma * N_absorber`
- preserve the existing LBL and correlated-k pressure APIs as compatibility wrappers over one shared pressure-to-column implementation
- add cgs path-length optical-depth functions for logarithmic CIA coefficients and extinction coefficients
- keep CIA arithmetic in log space to preserve the single-precision dynamic range
- support common spectra, layer-resolved LBL arrays, and correlated-k arrays, including existing singleton broadcasting

## Performance

Benchmarked against `develop` with float32 inputs, 100 layers, LBL shape `(100, 20000)`, and CKD shape `(100, 16, 1000)`. Each comparison used five alternating isolated processes and synchronized calls.

- A100 steady JIT: LBL 0.100 -> 0.077 ms; CKD 0.097 -> 0.065 ms
- CPU steady JIT: LBL 0.328 -> 0.302 ms; CKD 0.277 -> 0.256 ms
- CPU eager: LBL 3.276 -> 1.194 ms; CKD 3.129 -> 0.961 ms
- compiled FLOPs are reduced by about 67 percent

The CPU-only first XLA compilation has a one-time increase of about 4--5 ms because XLA emits a small column-profile fusion plus the spectral multiplication. It does not recur for value changes: ten calls with unchanged shapes and dtypes produced one trace/compile on both `develop` and this branch. A shape change produced the expected second compile on both.

Float32 results agree with the previous pressure formulas to `rtol=1e-6` (maximum relative difference about `3e-7`, from operation reordering).

## Tests

- `JAX_PLATFORMS=cpu python -m pytest -q tests/unittests/rt/atmrt/geometric_layer_opacity_test.py tests/unittests/opacity/ckd/layeropacity_ckd_test.py tests/unittests/rt/atmrt/opacity_profile_cia_test.py` (20 passed)
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu python -m pytest -q tests/unittests/rt/atmrt` (75 passed)
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu python -m pytest -q tests/unittests/opacity/ckd` (105 passed)
- `git diff --check`
