### PR TITLE
Add Diffgrid interpolation diagnostics

### DIFF
--- a/documents/userguide/diffgrid.rst
+++ b/documents/userguide/diffgrid.rst
@@ -1,7 +1,7 @@
 DiffGrid
 ========
 
-`Last update: August 8th (2026)`
+`Last update: August 25th (2026)`
 
 **DiffGrid** is a pressure-layer-aligned opacity table for repeated,
 differentiable spectral calculations.  It is useful when the atmospheric
@@ -143,20 +143,49 @@ Checking interpolation accuracy
 -------------------------------
 
 The required node density depends on the molecule, spectral range,
-temperature range, and data precision.  Compare DiffGrid with its teacher at
-representative profiles, including the edges of the intended parameter range.
+temperature range, and data precision. Compare DiffGrid with its teacher away
+from the stored nodes, where interpolation error can be measured. The helper
+below returns the temperature at the midpoint of every interval in
+:math:`1/T`; these are harmonic, not arithmetic, temperature means.
 
 .. code-block:: python
 
-    expected = teacher.xsmatrix(temperature, art.pressure)
-    actual = opa.xsmatrix(temperature)
-
-    comparison_floor = 1.0e-35
-    log10_error = jnp.abs(
-        jnp.log10(jnp.maximum(actual, comparison_floor))
-        - jnp.log10(jnp.maximum(expected, comparison_floor))
+    from exojax.opacity.diffgrid.diagnostics import (
+        compare_diffgrid_with_teacher,
+        diffgrid_interval_midpoint_temperatures,
     )
-    print("maximum absolute log10 error:", float(jnp.max(log10_error)))
+
+    validation_temperatures = diffgrid_interval_midpoint_temperatures(opa)
+    for validation_temperature in validation_temperatures:
+        validation_profile = np.full(
+            art.pressure.shape,
+            validation_temperature,
+        )
+        summary = compare_diffgrid_with_teacher(
+            opa,
+            teacher,
+            validation_profile,
+            quantiles=(0.99,),
+        )
+        print(
+            validation_temperature,
+            summary.absolute_log_cross_section_error_quantiles[0],
+            summary.maximum_absolute_log_cross_section_error,
+        )
+
+The reported error is the absolute natural-log cross-section ratio after the
+cross-section floor stored by ``opa`` has been applied to both calculators.
+For example, an error of 0.05 corresponds to a multiplicative ratio of about
+1.05. Quantiles combine every pressure-layer and wavenumber entry. The
+diagnostic reports numbers only; the application chooses its thresholds and
+decides whether to reject a table.
+
+``compare_diffgrid_with_teacher`` is a host-side archive-build diagnostic, not
+an operation for a JIT-compiled retrieval. It processes one temperature
+profile at a time, uses a reusable JAX kernel for the pointwise error, and
+transfers that one error matrix to the host for exact NumPy quantiles. Looping
+over profiles as above therefore avoids constructing a large
+``(nprofile, nlayer, nnu)`` batch.
 
 A stronger application-level test propagates both matrices through the full
 forward model and compares the spectral difference with the observational

--- a/src/exojax/opacity/diffgrid/diagnostics.py
+++ b/src/exojax/opacity/diffgrid/diagnostics.py
@@ -1,0 +1,287 @@
+"""Build-time diagnostics for Diffgrid temperature interpolation.
+
+The functions in this module report numerical errors only. Accuracy
+thresholds, pass/fail decisions, and archive provenance belong to the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+@dataclass(frozen=True)
+class DiffgridComparison:
+    """Scalar summary of one Diffgrid-to-teacher comparison.
+
+    Attributes:
+        quantiles: Requested quantile levels in caller-supplied order.
+        absolute_log_cross_section_error_quantiles: Absolute natural-log
+            cross-section errors at ``quantiles``.
+        maximum_absolute_log_cross_section_error: Largest absolute natural-log
+            cross-section error.
+        maximum_error_layer_index: Layer index of the largest error.
+        maximum_error_wavenumber_index: Wavenumber index of the largest error.
+    """
+
+    quantiles: tuple[float, ...]
+    absolute_log_cross_section_error_quantiles: tuple[float, ...]
+    maximum_absolute_log_cross_section_error: float
+    maximum_error_layer_index: int
+    maximum_error_wavenumber_index: int
+
+
+@jax.jit
+def _absolute_log_cross_section_error(
+    diffgrid_cross_section,
+    teacher_cross_section,
+    log_cross_section_floor,
+):
+    """Return the pointwise error and source finiteness flags."""
+
+    cross_section_floor = jnp.exp(log_cross_section_floor)
+    diffgrid_is_finite = jnp.all(jnp.isfinite(diffgrid_cross_section))
+    teacher_is_finite = jnp.all(jnp.isfinite(teacher_cross_section))
+    error = jnp.abs(
+        jnp.log(jnp.maximum(diffgrid_cross_section, cross_section_floor))
+        - jnp.log(jnp.maximum(teacher_cross_section, cross_section_floor))
+    )
+    return error, diffgrid_is_finite, teacher_is_finite
+
+
+def diffgrid_interval_midpoint_temperatures(diffgrid) -> np.ndarray:
+    """Return temperatures at all stored inverse-temperature midpoints.
+
+    The returned temperatures follow the order of the strictly increasing
+    ``diffgrid.inverse_temperature_grid``. No assumption of uniform spacing is
+    made.
+
+    Raises:
+        ValueError: If the Diffgrid object is not ready or its stored
+            inverse-temperature grid is invalid.
+    """
+
+    if hasattr(diffgrid, "ready") and not diffgrid.ready:
+        raise ValueError("diffgrid must be ready before it can be diagnosed.")
+    if not hasattr(diffgrid, "inverse_temperature_grid"):
+        raise ValueError("diffgrid must provide inverse_temperature_grid.")
+
+    inverse_temperature_grid = np.asarray(diffgrid.inverse_temperature_grid)
+    if (
+        inverse_temperature_grid.ndim != 1
+        or inverse_temperature_grid.size < 2
+    ):
+        raise ValueError(
+            "diffgrid inverse_temperature_grid must contain at least two "
+            "one-dimensional nodes."
+        )
+    if (
+        not np.all(np.isfinite(inverse_temperature_grid))
+        or np.any(inverse_temperature_grid <= 0.0)
+        or np.any(np.diff(inverse_temperature_grid) <= 0.0)
+    ):
+        raise ValueError(
+            "diffgrid inverse_temperature_grid must be finite, positive, and "
+            "strictly increasing."
+        )
+
+    inverse_temperature_midpoints = 0.5 * (
+        inverse_temperature_grid[:-1] + inverse_temperature_grid[1:]
+    )
+    return 1.0 / inverse_temperature_midpoints
+
+
+def _validated_quantiles(quantiles: Sequence[float]) -> tuple[float, ...]:
+    quantile_array = np.asarray(quantiles, dtype=float)
+    if quantile_array.ndim != 1 or quantile_array.size == 0:
+        raise ValueError(
+            "quantiles must be a non-empty one-dimensional sequence."
+        )
+    if not np.all(np.isfinite(quantile_array)) or np.any(
+        (quantile_array < 0.0) | (quantile_array > 1.0)
+    ):
+        raise ValueError("quantiles must contain finite values in [0, 1].")
+    return tuple(float(value) for value in quantile_array)
+
+
+def _validated_comparison_grids(diffgrid, teacher):
+    if hasattr(diffgrid, "ready") and not diffgrid.ready:
+        raise ValueError("diffgrid must be ready before it can be diagnosed.")
+    if not hasattr(diffgrid, "xsmatrix") or not hasattr(diffgrid, "nu_grid"):
+        raise ValueError("diffgrid must provide nu_grid and xsmatrix.")
+    if hasattr(teacher, "ready") and not teacher.ready:
+        raise ValueError("teacher must be ready before it can be diagnosed.")
+    if not hasattr(teacher, "xsmatrix") or not hasattr(teacher, "nu_grid"):
+        raise ValueError("teacher must provide nu_grid and xsmatrix.")
+    if not hasattr(diffgrid, "pressure_grid"):
+        raise ValueError("diffgrid must provide pressure_grid.")
+
+    diffgrid_nu_grid = np.asarray(diffgrid.nu_grid)
+    teacher_nu_grid = np.asarray(teacher.nu_grid)
+    if (
+        diffgrid_nu_grid.ndim != 1
+        or diffgrid_nu_grid.size == 0
+        or not np.all(np.isfinite(diffgrid_nu_grid))
+        or np.any(diffgrid_nu_grid <= 0.0)
+        or teacher_nu_grid.shape != diffgrid_nu_grid.shape
+        or not np.array_equal(teacher_nu_grid, diffgrid_nu_grid)
+    ):
+        raise ValueError(
+            "teacher and diffgrid wavenumber grids must match point by point."
+        )
+
+    pressure_grid = np.asarray(diffgrid.pressure_grid)
+    if (
+        pressure_grid.ndim != 1
+        or pressure_grid.size == 0
+        or not np.all(np.isfinite(pressure_grid))
+        or np.any(pressure_grid <= 0.0)
+    ):
+        raise ValueError(
+            "diffgrid pressure_grid must be finite, positive, and non-empty."
+        )
+    return pressure_grid, diffgrid_nu_grid
+
+
+def _validated_log_cross_section_floor(diffgrid):
+    diffgrid_info = getattr(diffgrid, "diffgrid_info", None)
+    if diffgrid_info is not None:
+        log_cross_section_floor = (
+            diffgrid_info.log_cross_section_floor
+        )
+    elif hasattr(diffgrid, "log_cross_section_floor"):
+        log_cross_section_floor = diffgrid.log_cross_section_floor
+    else:
+        raise ValueError("diffgrid must provide log_cross_section_floor.")
+    log_floor = jnp.asarray(log_cross_section_floor)
+    if log_floor.ndim != 0:
+        raise ValueError("diffgrid log_cross_section_floor must be scalar.")
+    active_floor = np.asarray(jnp.exp(log_floor))
+    if not np.isfinite(active_floor).item() or active_floor.item() <= 0.0:
+        raise ValueError(
+            "diffgrid log_cross_section_floor must represent a finite, "
+            "positive value in the active JAX dtype."
+        )
+    return log_floor
+
+
+def compare_diffgrid_with_teacher(
+    diffgrid,
+    teacher,
+    temperature_profile,
+    quantiles: Sequence[float] = (0.99,),
+) -> DiffgridComparison:
+    """Compare one Diffgrid profile with its reference opacity calculator.
+
+    The comparison uses the pressure and cross-section floor stored by
+    ``diffgrid``. It computes
+
+    ``abs(log(max(diffgrid_xs, floor)) - log(max(teacher_xs, floor)))``
+
+    at every layer and wavenumber. This function reports metrics but does not
+    apply an accuracy threshold. Quantiles combine all layer-wavenumber
+    entries.
+    This is a host-side build-time diagnostic, not a JIT-compatible model
+    operation. It transfers one pointwise error matrix to the host for exact
+    NumPy quantiles.
+
+    Args:
+        diffgrid: Ready pressure-aligned Diffgrid opacity calculator.
+        teacher: Ready reference opacity calculator on the same wavenumber
+            grid. Its ``xsmatrix`` method must accept temperature and pressure
+            profiles.
+        temperature_profile: Layer temperatures in K, shape ``(nlayer,)``.
+        quantiles: Quantile levels to report. Defaults to ``(0.99,)``.
+
+    Returns:
+        A :class:`DiffgridComparison` containing host scalar metrics.
+
+    Raises:
+        ValueError: If the calculators, grids, floor, profile, or requested
+            quantiles are incompatible.
+        FloatingPointError: If either calculator returns non-finite cross
+            sections.
+    """
+
+    quantiles = _validated_quantiles(quantiles)
+    pressure_grid, nu_grid = _validated_comparison_grids(diffgrid, teacher)
+    log_cross_section_floor = _validated_log_cross_section_floor(diffgrid)
+
+    temperature_profile = np.asarray(temperature_profile)
+    if (
+        temperature_profile.ndim != 1
+        or temperature_profile.shape != pressure_grid.shape
+    ):
+        raise ValueError(
+            "temperature_profile shape must match diffgrid pressure_grid."
+        )
+    if not np.all(np.isfinite(temperature_profile)) or np.any(
+        temperature_profile <= 0.0
+    ):
+        raise ValueError("temperature_profile must be finite and positive.")
+
+    expected_shape = (pressure_grid.size, nu_grid.size)
+    diffgrid_cross_section = jnp.asarray(
+        diffgrid.xsmatrix(temperature_profile)
+    )
+    if diffgrid_cross_section.shape != expected_shape:
+        raise ValueError(
+            "Diffgrid cross-section matrix must have shape "
+            f"{expected_shape}; got {diffgrid_cross_section.shape}."
+        )
+    teacher_cross_section = jnp.asarray(
+        teacher.xsmatrix(temperature_profile, pressure_grid)
+    )
+    if teacher_cross_section.shape != expected_shape:
+        raise ValueError(
+            "Teacher cross-section matrix must have shape "
+            f"{expected_shape}; got {teacher_cross_section.shape}."
+        )
+
+    error_device, diffgrid_is_finite, teacher_is_finite = (
+        _absolute_log_cross_section_error(
+            diffgrid_cross_section,
+            teacher_cross_section,
+            log_cross_section_floor,
+        )
+    )
+    del diffgrid_cross_section, teacher_cross_section
+    if not bool(np.asarray(diffgrid_is_finite)):
+        raise FloatingPointError(
+            "Diffgrid produced non-finite cross sections."
+        )
+    if not bool(np.asarray(teacher_is_finite)):
+        raise FloatingPointError("Teacher produced non-finite cross sections.")
+    error = np.array(error_device)
+    del error_device
+
+    flat_maximum_index = int(np.argmax(error))
+    maximum_error = float(error.ravel()[flat_maximum_index])
+    layer_index, wavenumber_index = np.unravel_index(
+        flat_maximum_index, error.shape
+    )
+    quantile_errors = np.quantile(
+        error,
+        np.asarray(quantiles),
+        overwrite_input=True,
+    )
+    return DiffgridComparison(
+        quantiles=quantiles,
+        absolute_log_cross_section_error_quantiles=tuple(
+            float(value) for value in np.atleast_1d(quantile_errors)
+        ),
+        maximum_absolute_log_cross_section_error=maximum_error,
+        maximum_error_layer_index=int(layer_index),
+        maximum_error_wavenumber_index=int(wavenumber_index),
+    )
+
+
+__all__ = [
+    "DiffgridComparison",
+    "compare_diffgrid_with_teacher",
+    "diffgrid_interval_midpoint_temperatures",
+]

--- a/tests/unittests/opacity/diffgrid/diffgrid_diagnostics_test.py
+++ b/tests/unittests/opacity/diffgrid/diffgrid_diagnostics_test.py
@@ -1,0 +1,196 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.opacity import OpaDiffgrid
+from exojax.opacity.diffgrid.diagnostics import (
+    compare_diffgrid_with_teacher,
+    diffgrid_interval_midpoint_temperatures,
+)
+
+
+class _LogLinearTeacher:
+    method = "analytic"
+    ready = True
+    nu_grid = np.asarray([1000.0, 1001.0, 1002.0], dtype=np.float32)
+
+    def xsmatrix(self, temperature, pressure):
+        temperature = jnp.asarray(temperature)
+        pressure = jnp.asarray(pressure)
+        spectral_offset = jnp.asarray([-0.2, 0.0, 0.3])
+        log_cross_section = (
+            -700.0 / temperature[:, None]
+            + 0.1 * jnp.log(pressure[:, None])
+            + spectral_offset[None, :]
+        )
+        return jnp.exp(log_cross_section)
+
+
+class _FixedDiffgrid:
+    ready = True
+    nu_grid = np.asarray([1000.0, 1001.0])
+    pressure_grid = jnp.asarray([0.1, 1.0])
+    inverse_temperature_grid = jnp.asarray(
+        [1.0 / 1600.0, 1.0 / 800.0, 1.0 / 400.0]
+    )
+    log_cross_section_floor = jnp.log(jnp.asarray(1.0e-4))
+
+    def __init__(self, cross_section):
+        self.cross_section = jnp.asarray(cross_section)
+
+    def xsmatrix(self, temperature):
+        return self.cross_section
+
+
+class _FixedTeacher:
+    ready = True
+
+    def __init__(self, cross_section, nu_grid=(1000.0, 1001.0)):
+        self.cross_section = jnp.asarray(cross_section)
+        self.nu_grid = np.asarray(nu_grid)
+        self.received_pressure = None
+
+    def xsmatrix(self, temperature, pressure):
+        self.received_pressure = np.asarray(pressure)
+        return self.cross_section
+
+
+def test_diffgrid_midpoint_temperatures_are_harmonic_means():
+    diffgrid = _FixedDiffgrid(np.ones((2, 2)))
+
+    actual = diffgrid_interval_midpoint_temperatures(diffgrid)
+
+    np.testing.assert_allclose(actual, [3200.0 / 3.0, 1600.0 / 3.0])
+
+
+def test_comparison_uses_archive_floor_and_reports_scalar_metrics():
+    diffgrid = _FixedDiffgrid(
+        [[1.0e-4, 2.0e-4], [4.0e-4, 8.0e-4]]
+    )
+    teacher = _FixedTeacher(
+        [[-1.0e-5, 1.0e-4], [2.0e-4, 2.0e-4]]
+    )
+
+    summary = compare_diffgrid_with_teacher(
+        diffgrid,
+        teacher,
+        np.asarray([500.0, 600.0]),
+        quantiles=(0.5, 1.0),
+    )
+
+    assert summary.quantiles == (0.5, 1.0)
+    np.testing.assert_allclose(
+        summary.absolute_log_cross_section_error_quantiles,
+        [np.log(2.0), np.log(4.0)],
+        rtol=2.0e-6,
+    )
+    np.testing.assert_allclose(
+        summary.maximum_absolute_log_cross_section_error,
+        np.log(4.0),
+        rtol=2.0e-6,
+    )
+    assert summary.maximum_error_layer_index == 1
+    assert summary.maximum_error_wavenumber_index == 1
+    np.testing.assert_array_equal(
+        teacher.received_pressure,
+        np.asarray(diffgrid.pressure_grid),
+    )
+
+
+def test_real_diffgrid_matches_log_linear_teacher_at_interval_midpoints():
+    teacher = _LogLinearTeacher()
+    pressure_grid = np.asarray([0.1, 1.0], dtype=np.float32)
+    diffgrid = OpaDiffgrid(
+        teacher,
+        temperature_grid=np.asarray(
+            [1200.0, 800.0, 400.0], dtype=np.float32
+        ),
+        pressure_grid=pressure_grid,
+    )
+
+    midpoint_temperatures = diffgrid_interval_midpoint_temperatures(diffgrid)
+    np.testing.assert_allclose(
+        midpoint_temperatures,
+        [960.0, 1600.0 / 3.0],
+        rtol=2.0e-7,
+    )
+    for temperature in midpoint_temperatures:
+        summary = compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.full(pressure_grid.shape, temperature),
+        )
+        assert summary.maximum_absolute_log_cross_section_error < 2.0e-6
+
+
+@pytest.mark.parametrize("quantiles", [(), 0.5, (-0.01,), (1.01,), (np.nan,)])
+def test_comparison_rejects_invalid_quantiles(quantiles):
+    diffgrid = _FixedDiffgrid(np.ones((2, 2)))
+    teacher = _FixedTeacher(np.ones((2, 2)))
+
+    with pytest.raises(ValueError, match="quantiles"):
+        compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.asarray([500.0, 600.0]),
+            quantiles=quantiles,
+        )
+
+
+def test_comparison_rejects_pointwise_wavenumber_mismatch():
+    diffgrid = _FixedDiffgrid(np.ones((2, 2)))
+    teacher = _FixedTeacher(np.ones((2, 2)), nu_grid=(1001.0, 1000.0))
+
+    with pytest.raises(ValueError, match="point by point"):
+        compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.asarray([500.0, 600.0]),
+        )
+
+
+def test_comparison_rejects_wrong_temperature_and_output_shapes():
+    diffgrid = _FixedDiffgrid(np.ones((2, 2)))
+    teacher = _FixedTeacher(np.ones((2, 2)))
+    with pytest.raises(ValueError, match="temperature_profile shape"):
+        compare_diffgrid_with_teacher(diffgrid, teacher, np.asarray([500.0]))
+
+    diffgrid = _FixedDiffgrid(np.ones((2, 3)))
+    with pytest.raises(ValueError, match="Diffgrid cross-section matrix"):
+        compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.asarray([500.0, 600.0]),
+        )
+
+    diffgrid = _FixedDiffgrid(np.ones((2, 2)))
+    teacher = _FixedTeacher(np.ones((2, 3)))
+    with pytest.raises(ValueError, match="Teacher cross-section matrix"):
+        compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.asarray([500.0, 600.0]),
+        )
+
+
+@pytest.mark.parametrize(
+    ("source", "diffgrid_values", "teacher_values"),
+    [
+        ("Diffgrid", [[np.nan, 1.0], [1.0, 1.0]], np.ones((2, 2))),
+        ("Teacher", np.ones((2, 2)), [[np.inf, 1.0], [1.0, 1.0]]),
+    ],
+)
+def test_comparison_rejects_nonfinite_cross_sections(
+    source,
+    diffgrid_values,
+    teacher_values,
+):
+    diffgrid = _FixedDiffgrid(diffgrid_values)
+    teacher = _FixedTeacher(teacher_values)
+
+    with pytest.raises(FloatingPointError, match=source):
+        compare_diffgrid_with_teacher(
+            diffgrid,
+            teacher,
+            np.asarray([500.0, 600.0]),
+        )


### PR DESCRIPTION
## Summary
- add reusable build-time comparison of Diffgrid and teacher cross sections
- generate inverse-temperature interval midpoint temperatures
- report archive-floor-aware natural-log quantiles, maximum error, and its location
- document the host-streamed exact-quantile workflow

## Design
- callers retain ownership of accuracy thresholds and pass/fail policy
- each call evaluates one temperature profile to bound peak memory
- a module-level JAX kernel is reused for pointwise errors; exact quantiles are reduced on the host
- no teacher state or diagnostic metadata is added to saved Diffgrid archives

## Tests
- JAX_PLATFORMS=cpu python -m pytest -p no:cacheprovider -q tests/unittests/opacity/diffgrid (64 passed)
- flake8 on the new implementation and tests
- git diff --check
- isolated Sphinx HTML build with warnings treated as errors