### PR TITLE
Add pointwise ESLOG resolution definition

### DIFF
--- a/src/exojax/utils/instfunc.py
+++ b/src/exojax/utils/instfunc.py
@@ -25,16 +25,23 @@ def resolution_to_gaussian_std(resolution):
     return c / (2.0 * np.sqrt(2.0 * np.log(2.0)) * resolution)
 
 
-def resolution_eslog(nu_grid):
-    """spectral resolution for ESLOG.
+def resolution_eslog(nu_grid, *, definition="log"):
+    """Compute the spectral resolution of an ESLOG grid.
 
     Args:
         nu_grid: wavenumber bin
+        definition: Resolution definition. ``"log"`` returns the inverse
+            logarithmic spacing. ``"pointwise"`` returns the minimum of
+            ``nu_grid[:-1] / np.diff(nu_grid)``.
 
     Returns:
         resolution
     """
-    return (len(nu_grid) - 1) / np.log(nu_grid[-1] / nu_grid[0])
+    if definition == "log":
+        return (len(nu_grid) - 1) / np.log(nu_grid[-1] / nu_grid[0])
+    if definition == "pointwise":
+        return np.min(nu_grid[:-1] / np.diff(nu_grid))
+    raise ValueError("definition must be 'log' or 'pointwise'.")
 
 
 def resolution_eslin(nu_grid):
@@ -56,16 +63,29 @@ def resolution_eslin(nu_grid):
     )
 
 
-def nx_even_from_resolution_eslog(nu0, nu1, resolution):
-    """Compute the even number of wavenumber grid for a given resolution for ESLOG
+def nx_even_from_resolution_eslog(nu0, nu1, resolution, *, definition="log"):
+    """Compute an even ESLOG grid size for a given resolution.
 
     Args:
         nu0 (float): wavenumber min
         nu1 (float): wavenumber max
         resolution (float): resolution
+        definition: Resolution definition. ``"log"`` preserves the existing
+            inverse-log-spacing behavior. ``"pointwise"`` returns the
+            smallest even grid size whose adjacent-point resolving power is
+            at least ``resolution``.
 
     Returns:
         int: the even number of wavenumber grid for a given resolution
     """
-    N = np.ceil(resolution * np.log(nu1 / nu0))
-    return int(np.ceil(N / 2.0) * 2  )
+    if definition == "log":
+        number_of_points = np.ceil(resolution * np.log(nu1 / nu0))
+    elif definition == "pointwise":
+        log_span = np.log(nu1) - np.log(nu0)
+        number_of_intervals = np.ceil(
+            log_span / np.log1p(1.0 / resolution)
+        )
+        number_of_points = number_of_intervals + 1
+    else:
+        raise ValueError("definition must be 'log' or 'pointwise'.")
+    return int(np.ceil(number_of_points / 2.0) * 2)

--- a/tests/unittests/utils/misc/instfunc_test.py
+++ b/tests/unittests/utils/misc/instfunc_test.py
@@ -16,8 +16,41 @@ def test_nx_from_resolution_eslog():
     nu1 = 4500.0
     resolution = 849010.2113833647
     Nx = nx_even_from_resolution_eslog(nu0, nu1, resolution)
-    
+
     assert Nx == 100000
+    assert (
+        nx_even_from_resolution_eslog(
+            nu0, nu1, resolution, definition="log"
+        )
+        == Nx
+    )
+
+
+def test_nx_from_pointwise_resolution_eslog():
+    nu0 = 1.0
+    nu1 = 2.0
+    requested_resolution = 10.0
+
+    Nx = nx_even_from_resolution_eslog(
+        nu0,
+        nu1,
+        requested_resolution,
+        definition="pointwise",
+    )
+    nus = np.logspace(np.log10(nu0), np.log10(nu1), Nx)
+    previous_even_nus = np.logspace(
+        np.log10(nu0), np.log10(nu1), Nx - 2
+    )
+
+    assert Nx == 10
+    assert (
+        resolution_eslog(nus, definition="pointwise")
+        >= requested_resolution
+    )
+    assert (
+        resolution_eslog(previous_even_nus, definition="pointwise")
+        < requested_resolution
+    )
 
 
 def test_resolution_to_gaussian_std():
@@ -38,6 +71,24 @@ def test_resolution_eslog():
     Nx = 100000
     nus = np.logspace(np.log10(nu0), np.log10(nu1), Nx)
     assert resolution_eslog(nus) == pytest.approx(849010.2113833647)
+    assert resolution_eslog(nus, definition="log") == pytest.approx(
+        849010.2113833647
+    )
+    assert resolution_eslog(nus, definition="pointwise") == pytest.approx(
+        np.min(nus[:-1] / np.diff(nus))
+    )
+
+
+@pytest.mark.parametrize(
+    "function, arguments",
+    [
+        (resolution_eslog, (np.array([1.0, 2.0]),)),
+        (nx_even_from_resolution_eslog, (1.0, 2.0, 100.0)),
+    ],
+)
+def test_unknown_eslog_resolution_definition(function, arguments):
+    with pytest.raises(ValueError, match="definition"):
+        function(*arguments, definition="unknown")
 
 
 if __name__ == "__main__":
@@ -45,3 +96,4 @@ if __name__ == "__main__":
     test_resolution_eslin()
     test_resolution_eslog()
     test_nx_from_resolution_eslog()
+    test_nx_from_pointwise_resolution_eslog()


### PR DESCRIPTION
## Summary

- add a keyword-only `definition` option to `resolution_eslog` and `nx_even_from_resolution_eslog`
- preserve the existing inverse-log-spacing behavior as the default
- support minimum adjacent-point resolving power and exact even ESLOG grid sizing
- reject unknown resolution definitions

## Tests

- `python -m pytest -p no:cacheprovider tests/unittests/utils/misc/instfunc_test.py -q`
- `NUMBA_DISABLE_JIT=1 JAX_PLATFORMS=cpu python -m pytest -p no:cacheprovider tests/unittests/utils/misc/grids_test.py tests/unittests/opacity/diffgrid/diffgrid_io_test.py tests/unittests/opacity/premodit/premodit_save_load_test.py -q`