### PR TITLE
Add SFM-2st reflected-light radiative transfer

### DIFF
--- a/documents/userguide/rtransfer.rst
+++ b/documents/userguide/rtransfer.rst
@@ -28,13 +28,16 @@ These are flux-based computations.
 (Toon et al. 1989), with Toon hemispheric-mean two-stream fluxes
 (``rtsolver="sfm2st_toon_hemispheric_mean"``). This scheme first computes the two-stream fluxes,
 then evaluates the emission spectrum by the intensity-based formal solution.
-Regarding reflected light in ExoJAX, the flux-adding treatment can be utilized.
+For reflected light, ``ArtReflectPure`` and ``ArtReflectEmis`` support both the
+flux-adding treatment and SFM-2st. The latter treats ``incoming_flux`` as a
+diffuse hemispheric flux at the top boundary.
 
 See :doc:`../userguide/rtransfer_fbased` for the details of the `fbased` method for reflection and/or emission with scattering.
 
 All of the ``fbased`` schemes are currently based on the two-stream approximation, although the ``ibased`` schemes can specify the number of the streams.
-The SFM-2st emission solver uses a two-stream source function and an intensity-based angular integration with a configurable number of streams.
-Other ibased schemes for scattering/reflection are planned but have not yet been implemented.
+The SFM-2st emission and reflection solvers use a two-stream source function
+and an intensity-based angular integration with a configurable number of
+streams.
 
 For transmission spectroscopy in ExoJAX, the options are primarily limited to differences in the integration methods. 
 Both the Trapezoid integration method and the method using Simpson's rule are available.

--- a/documents/userguide/rtransfer_fbased.rst
+++ b/documents/userguide/rtransfer_fbased.rst
@@ -69,6 +69,36 @@ quadrature is controlled by ``nstream``.
         temperature,
     )
 
+Reflection using SFM-2st
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ArtReflectPure`` and ``ArtReflectEmis`` support the same SFM-2st angular
+formal solution. Set ``rtsolver="sfm2st_toon_hemispheric_mean"`` and use
+``nstream`` to control the outgoing-angle quadrature. ``incoming_flux`` is a
+diffuse hemispheric flux at the top boundary; collimated-beam illumination and
+phase-dependent disk integration are outside this solver.
+
+.. code:: python
+
+    from exojax.rt import ArtReflectPure
+
+    art = ArtReflectPure(
+        pressure_top=1.0e-5,
+        pressure_btm=1.0e1,
+        nlayer=200,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    F0 = art.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        reflectivity_surface,
+        incoming_flux,
+    )
+
 Radiative transfer with scattering and reflection can be classified into three types:
 
 - 1. ``ReflectPure``: The scattering and reflection spectrum of incident light, excluding radiation from the atmospheric layers.  

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -2,7 +2,9 @@ import jax.numpy as jnp
 from exojax.rt.common import ArtCommon
 from exojax.rt.planck import piB, piBarr
 from exojax.rt.rtransfer import (
+    initialize_gaussian_quadrature,
     rtrun_reflect_fluxadding_toonhm,
+    rtrun_reflect_sfm2st_toonhm,
     setrt_toonhm,
     setrt_toonhm_with_absorption,
 )
@@ -124,6 +126,7 @@ class ArtReflectPure(ArtCommon):
         nlayer=100,
         nu_grid=None,
         rtsolver="fluxadding_toon_hemispheric_mean",
+        nstream=8,
     ):
         """initialization of ArtReflectPure
 
@@ -134,12 +137,17 @@ class ArtReflectPure(ArtCommon):
                 atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
-            rtsolver (str): Radiative Transfer Solver, fluxadding_toon_hemispheric_mean
+            rtsolver (str): Radiative transfer solver. Supported values are
+                "fluxadding_toon_hemispheric_mean" and
+                "sfm2st_toon_hemispheric_mean".
+            nstream (int): Number of streams for SFM-2st. Defaults to 8.
 
 
         """
         super().__init__(pressure_top, pressure_btm, nlayer, nu_grid)
         self.rtsolver = rtsolver
+        self.nstream = nstream
+        self.mus, self.weights = initialize_gaussian_quadrature(self.nstream)
         self.method = "reflection_using_" + self.rtsolver
 
     def run(
@@ -157,7 +165,7 @@ class ArtReflectPure(ArtCommon):
             single_scattering_albedo: single scattering albedo (Nlayer, N_nus)
             asymmetric_parameter: assymetric parameter (Nlayer, N_nus)
             reflectivity_surface: reflectivity from the surface (N_nus)
-            incoming flux: incoming flux F_0^- (N_nus)
+            incoming flux: diffuse incoming flux F_0^- (N_nus)
 
 
         Returns:
@@ -176,6 +184,21 @@ class ArtReflectPure(ArtCommon):
                 source_surface,
                 reflectivity_surface,
                 incoming_flux,
+            )
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            _, Nnus = dtau.shape
+            sourcef = jnp.zeros_like(dtau)
+            source_surface = jnp.zeros(Nnus)
+            return rtrun_reflect_sfm2st_toonhm(
+                dtau,
+                single_scattering_albedo,
+                asymmetric_parameter,
+                sourcef,
+                source_surface,
+                reflectivity_surface,
+                incoming_flux,
+                self.mus,
+                self.weights,
             )
         else:
             print("rtsolver=", self.rtsolver)
@@ -197,7 +220,7 @@ class ArtReflectPure(ArtCommon):
             single_scattering_albedo (2D array): single scattering albedo (Nlayer, Nbands)
             asymmetric_parameter (2D array): asymmetric parameter (Nlayer, Nbands)
             reflectivity_surface (1D array): reflectivity from the surface (Nbands)
-            incoming_flux (1D array): incoming flux F_0^- (Nbands)
+            incoming_flux (1D array): diffuse incoming flux F_0^- (Nbands)
             weights (1D array): weights for the Gaussian quadrature (Ng,)
             
         Returns:
@@ -229,6 +252,20 @@ class ArtReflectPure(ArtCommon):
                 reflectivity_2d,
                 incoming_flux_2d,
             )
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            sourcef = jnp.zeros_like(dtau_2d)
+            source_surface = jnp.zeros(Ng * Nbands)
+            spectrum = rtrun_reflect_sfm2st_toonhm(
+                dtau_2d,
+                ssa_2d,
+                g_2d,
+                sourcef,
+                source_surface,
+                reflectivity_2d,
+                incoming_flux_2d,
+                self.mus,
+                self.weights,
+            )
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
@@ -253,6 +290,7 @@ class ArtReflectEmis(ArtCommon):
         nlayer=100,
         nu_grid=None,
         rtsolver="fluxadding_toon_hemispheric_mean",
+        nstream=8,
     ):
         """initialization of ArtReflectionPure
 
@@ -263,12 +301,17 @@ class ArtReflectEmis(ArtCommon):
                 atmospheric layer in bar. Defaults to 1.0e2.
             nlayer (int, optional): the number of the atmospheric layers. Defaults to 100.
             nu_grid (float, array, optional): the wavenumber grid. Defaults to None.
-            rtsolver (str): Radiative Transfer Solver, fluxadding_toon_hemispheric_mean
+            rtsolver (str): Radiative transfer solver. Supported values are
+                "fluxadding_toon_hemispheric_mean" and
+                "sfm2st_toon_hemispheric_mean".
+            nstream (int): Number of streams for SFM-2st. Defaults to 8.
 
 
         """
         super().__init__(pressure_top, pressure_btm, nlayer, nu_grid)
         self.rtsolver = rtsolver
+        self.nstream = nstream
+        self.mus, self.weights = initialize_gaussian_quadrature(self.nstream)
         self.method = "reflection_using_" + self.rtsolver
 
     def run(
@@ -291,7 +334,7 @@ class ArtReflectEmis(ArtCommon):
             temperature (1D array): temperature profile (Nlayer)
             source_surface: source from the surface (N_nus)
             reflectivity_surface: reflectivity from the surface (N_nus)
-            incoming flux: incoming flux F_0^- (N_nus)
+            incoming flux: diffuse incoming flux F_0^- (N_nus)
             nu_grid (1D array): if nu_grid is not initialized, provide it.
 
 
@@ -314,6 +357,18 @@ class ArtReflectEmis(ArtCommon):
                 source_surface,
                 reflectivity_surface,
                 incoming_flux,
+            )
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            return rtrun_reflect_sfm2st_toonhm(
+                dtau,
+                single_scattering_albedo,
+                asymmetric_parameter,
+                sourcef,
+                source_surface,
+                reflectivity_surface,
+                incoming_flux,
+                self.mus,
+                self.weights,
             )
         else:
             print("rtsolver=", self.rtsolver)
@@ -340,7 +395,7 @@ class ArtReflectEmis(ArtCommon):
             temperature (1D array): temperature profile (Nlayer)
             source_surface (1D array): source from the surface (Nbands)
             reflectivity_surface (1D array): reflectivity from the surface (Nbands)
-            incoming_flux (1D array): incoming flux F_0^- (Nbands)
+            incoming_flux (1D array): diffuse incoming flux F_0^- (Nbands)
             weights (1D array): weights for the Gaussian quadrature (Ng,)
             nu_bands (1D array): wavenumber grid for the CKD (Nbands)
             
@@ -373,6 +428,18 @@ class ArtReflectEmis(ArtCommon):
                 source_surface_2d,
                 reflectivity_2d,
                 incoming_flux_2d,
+            )
+        elif self.rtsolver == "sfm2st_toon_hemispheric_mean":
+            spectrum = rtrun_reflect_sfm2st_toonhm(
+                dtau_2d,
+                ssa_2d,
+                g_2d,
+                sourcef,
+                source_surface_2d,
+                reflectivity_2d,
+                incoming_flux_2d,
+                self.mus,
+                self.weights,
             )
         else:
             print("rtsolver=", self.rtsolver)

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -20,6 +20,10 @@
     -- scattering
     --- SFM-2st: rtrun_emis_scat_sfm2st
 
+    - intensity-based reflection
+    -- scattering
+    --- SFM-2st: rtrun_reflect_sfm2st_toonhm
+
     - transmision: 
     -- trapezoid integration: rtrun_trans_pureabs_trapezoid
     -- simpson integration: rtrun_trans_pureabs_simpson
@@ -203,6 +207,28 @@ def rtrun_emis_pureabs_ibased_intensity(dtau, source_matrix, mus):
 
     _, intensity = scan(f, jnp.zeros(Nnus), mus)
     return intensity
+
+
+@jit
+def rtrun_emis_pureabs_ibased_intensity_surface(
+    dtau, source_matrix, source_surface, mus
+):
+    """Emergent pure-absorption intensities with a lower surface.
+
+    Args:
+        dtau: Layer optical depths with shape ``(N_layer, N_nus)``.
+        source_matrix: Layer source functions with shape
+            ``(N_layer, N_nus)``.
+        source_surface: Isotropic lower-boundary source with shape ``(N_nus,)``.
+        mus: Positive ray-angle cosines with shape ``(N_mu,)``.
+
+    Returns:
+        Emergent intensity matrix with shape ``(N_mu, N_nus)``.
+    """
+    intensity = rtrun_emis_pureabs_ibased_intensity(dtau, source_matrix, mus)
+    tau_bottom = jnp.sum(dtau, axis=0)
+    transmission_surface = jnp.exp(-tau_bottom[None, :] / mus[:, None])
+    return intensity + source_surface[None, :] * transmission_surface
 
 
 @jit
@@ -575,6 +601,44 @@ def rtrun_emis_scat_fluxadding_toonhm(
     return spectrum
 
 
+def _solve_sfm2st_layer_source(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+    reflectivity_bottom,
+    source_bottom,
+    source_top=None,
+):
+    """Build the SFM-2st layer source from the two-stream flux solution."""
+    toon_coeffs = setrt_toonhm_with_absorption(
+        dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
+    )
+    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
+
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        trans_coeff,
+        scat_coeff,
+        reduced_piB,
+        reflectivity_bottom,
+        source_bottom,
+        source_top=source_top,
+        absorption_coeff=absorption_coeff,
+    )
+
+    flux_plus_layer = 0.5 * (flux_plus[:-1] + flux_plus[1:])
+    flux_minus_layer = 0.5 * (flux_minus[:-1] + flux_minus[1:])
+    source_sfm = (1.0 - single_scattering_albedo) * source_matrix + (
+        0.5
+        * single_scattering_albedo
+        * (
+            (1.0 + asymmetric_parameter) * flux_plus_layer
+            + (1.0 - asymmetric_parameter) * flux_minus_layer
+        )
+    )
+    return source_sfm, flux_plus[-1]
+
+
 @jit
 def rtrun_emis_scat_sfm2st_toonhm(
     dtau,
@@ -606,33 +670,67 @@ def rtrun_emis_scat_sfm2st_toonhm(
     source_surface = jnp.zeros(Nnus)
     reflectivity_surface = jnp.zeros(Nnus)
 
-    toon_coeffs = setrt_toonhm_with_absorption(
-        dtau, single_scattering_albedo, asymmetric_parameter, source_matrix
-    )
-    trans_coeff, scat_coeff, absorption_coeff, reduced_piB = toon_coeffs[:4]
-
-    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
-        trans_coeff,
-        scat_coeff,
-        reduced_piB,
+    source_sfm, _ = _solve_sfm2st_layer_source(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
         reflectivity_surface,
         source_surface,
-        absorption_coeff=absorption_coeff,
-    )
-
-    flux_plus_layer = 0.5 * (flux_plus[:-1] + flux_plus[1:])
-    flux_minus_layer = 0.5 * (flux_minus[:-1] + flux_minus[1:])
-
-    source_sfm = (1.0 - single_scattering_albedo) * source_matrix + (
-        0.5
-        * single_scattering_albedo
-        * (
-            (1.0 + asymmetric_parameter) * flux_plus_layer
-            + (1.0 - asymmetric_parameter) * flux_minus_layer
-        )
     )
 
     return rtrun_emis_pureabs_ibased(dtau, source_sfm, mus, weights)
+
+
+@jit
+def rtrun_reflect_sfm2st_toonhm(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+    source_surface,
+    reflectivity_surface,
+    incoming_flux,
+    mus,
+    weights,
+):
+    """Radiative transfer for diffuse reflection using SFM-2st.
+
+    Toon hemispheric-mean two-stream fluxes are converted into layer source
+    functions. The final outgoing flux is obtained from an intensity-based
+    formal solution. The incident radiation is a diffuse hemispheric flux at
+    the top boundary.
+
+    Args:
+        dtau: Layer optical depths with shape ``(N_layer, N_nus)``.
+        single_scattering_albedo: Single-scattering albedo.
+        asymmetric_parameter: Scattering asymmetry parameter.
+        source_matrix: Thermal layer source in pi B scale.
+        source_surface: Emitting lower-boundary source.
+        reflectivity_surface: Lambertian lower-boundary reflectivity.
+        incoming_flux: Diffuse downward flux at the top boundary.
+        mus: Positive ray-angle cosines.
+        weights: Gaussian quadrature weights.
+
+    Returns:
+        Reflected and emitted top-of-atmosphere flux.
+    """
+    source_sfm, source_bottom = _solve_sfm2st_layer_source(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        reflectivity_surface,
+        source_surface,
+        incoming_flux,
+    )
+
+    intensity = rtrun_emis_pureabs_ibased_intensity_surface(
+        dtau, source_sfm, source_bottom, mus
+    )
+    return rtrun_emis_pureabs_ibased_flux_from_intensity(
+        intensity, mus, weights
+    )
 
 
 def setrt_toonhm(

--- a/tests/unittests/rt/atmrt/emispure_intensity_test.py
+++ b/tests/unittests/rt/atmrt/emispure_intensity_test.py
@@ -9,6 +9,7 @@ from exojax.rt.rtransfer import (
     rtrun_emis_pureabs_ibased,
     rtrun_emis_pureabs_ibased_flux_from_intensity,
     rtrun_emis_pureabs_ibased_intensity,
+    rtrun_emis_pureabs_ibased_intensity_surface,
 )
 
 
@@ -41,6 +42,22 @@ def test_ibased_intensity_reconstructs_flux():
     flux = rtrun_emis_pureabs_ibased(dtau, source_matrix, art.mus, art.weights)
 
     assert flux_from_intensity == pytest.approx(flux)
+
+
+def test_ibased_intensity_surface_adds_attenuated_lower_boundary():
+    dtau = jnp.array([[0.2, 0.4], [0.3, 0.1]])
+    source_matrix = jnp.zeros_like(dtau)
+    source_surface = jnp.array([2.0, 3.0])
+    mus = jnp.array([0.25, 0.75])
+
+    actual = rtrun_emis_pureabs_ibased_intensity_surface(
+        dtau, source_matrix, source_surface, mus
+    )
+    expected = source_surface[None, :] * jnp.exp(
+        -jnp.sum(dtau, axis=0)[None, :] / mus[:, None]
+    )
+
+    assert actual == pytest.approx(expected)
 
 
 def test_artemispure_run_with_limb_darkening_reuses_intensity():

--- a/tests/unittests/rt/atmrt/reflect_sfm2st_test.py
+++ b/tests/unittests/rt/atmrt/reflect_sfm2st_test.py
@@ -1,0 +1,287 @@
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.rt import ArtEmisScat, ArtReflectEmis, ArtReflectPure
+from exojax.rt.rtransfer import rtrun_reflect_sfm2st_toonhm
+
+
+def _reflection_inputs(nlayer=4, nnus=3):
+    dtau = jnp.full((nlayer, nnus), 0.1)
+    single_scattering_albedo = jnp.full_like(dtau, 0.5)
+    asymmetric_parameter = jnp.full_like(dtau, 0.1)
+    reflectivity_surface = jnp.zeros(nnus)
+    incoming_flux = jnp.ones(nnus)
+    return (
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        reflectivity_surface,
+        incoming_flux,
+    )
+
+
+def test_reflect_sfm2st_transparent_lambert_surface():
+    nlayer = 2
+    nnus = 3
+    art = ArtReflectPure(
+        nlayer=nlayer,
+        nu_grid=jnp.arange(nnus) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+    dtau = jnp.zeros((nlayer, nnus))
+    zeros = jnp.zeros_like(dtau)
+    reflectivity_surface = jnp.array([0.2, 0.4, 0.6])
+    incoming_flux = jnp.array([1.0, 2.0, 3.0])
+
+    actual = art.run(
+        dtau,
+        zeros,
+        zeros,
+        reflectivity_surface,
+        incoming_flux,
+    )
+
+    np.testing.assert_allclose(
+        actual, reflectivity_surface * incoming_flux, rtol=1.0e-6
+    )
+
+
+def test_reflect_sfm2st_black_atmosphere_and_surface_returns_zero():
+    nlayer = 4
+    nnus = 3
+    art = ArtReflectPure(
+        nlayer=nlayer,
+        nu_grid=jnp.arange(nnus) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+    )
+    dtau = jnp.full((nlayer, nnus), 0.2)
+    zeros = jnp.zeros_like(dtau)
+
+    actual = art.run(
+        dtau,
+        zeros,
+        zeros,
+        jnp.zeros(nnus),
+        jnp.ones(nnus),
+    )
+
+    np.testing.assert_array_equal(actual, jnp.zeros(nnus))
+
+
+def test_reflect_sfm2st_absorbing_atmosphere_attenuates_surface_reflection():
+    nlayer = 2
+    nnus = 3
+    art = ArtReflectPure(
+        nlayer=nlayer,
+        nu_grid=jnp.arange(nnus) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+    )
+    dtau = jnp.array([[0.1, 0.2, 0.3], [0.2, 0.2, 0.2]])
+    zeros = jnp.zeros_like(dtau)
+    reflectivity_surface = jnp.array([0.2, 0.4, 0.6])
+    incoming_flux = jnp.array([1.0, 2.0, 3.0])
+
+    actual = art.run(
+        dtau,
+        zeros,
+        zeros,
+        reflectivity_surface,
+        incoming_flux,
+    )
+    tau_bottom = jnp.sum(dtau, axis=0)
+    downward_surface_flux = (
+        reflectivity_surface * incoming_flux * jnp.exp(-2.0 * tau_bottom)
+    )
+    upward_transmission = jnp.sum(
+        2.0
+        * art.mus[:, None]
+        * art.weights[:, None]
+        * jnp.exp(-tau_bottom[None, :] / art.mus[:, None]),
+        axis=0,
+    )
+
+    np.testing.assert_allclose(
+        actual, downward_surface_flux * upward_transmission, rtol=1.0e-6
+    )
+
+
+def test_reflect_sfm2st_returns_finite_nonnegative_flux():
+    inputs = _reflection_inputs()
+    art = ArtReflectPure(
+        nlayer=inputs[0].shape[0],
+        nu_grid=jnp.arange(inputs[0].shape[1]) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+    )
+
+    spectrum = art.run(*inputs)
+
+    assert jnp.all(jnp.isfinite(spectrum))
+    assert jnp.all(spectrum >= 0.0)
+    assert jnp.all(spectrum <= inputs[-1])
+
+
+def test_reflect_sfm2st_conservative_scattering_is_energy_bounded():
+    nlayer = 100
+    nnus = 2
+    art = ArtReflectPure(
+        nlayer=nlayer,
+        nu_grid=jnp.arange(nnus) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+    )
+    dtau = jnp.full((nlayer, nnus), 0.1)
+    single_scattering_albedo = jnp.ones_like(dtau)
+    asymmetric_parameter = jnp.zeros_like(dtau)
+    incoming_flux = jnp.ones(nnus)
+
+    spectrum = art.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        jnp.zeros(nnus),
+        incoming_flux,
+    )
+
+    assert jnp.all(jnp.isfinite(spectrum))
+    assert jnp.all(spectrum >= 0.0)
+    assert jnp.all(spectrum <= incoming_flux)
+
+
+def test_artreflectpure_sfm2st_matches_low_level_solver():
+    inputs = _reflection_inputs()
+    dtau, single_scattering_albedo, asymmetric_parameter, _, _ = inputs
+    art = ArtReflectPure(
+        nlayer=dtau.shape[0],
+        nu_grid=jnp.arange(dtau.shape[1]) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+    )
+
+    actual = art.run(*inputs)
+    expected = rtrun_reflect_sfm2st_toonhm(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        jnp.zeros_like(dtau),
+        jnp.zeros(dtau.shape[1]),
+        inputs[-2],
+        inputs[-1],
+        art.mus,
+        art.weights,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+
+
+def test_artreflectemis_sfm2st_reduces_to_emission_sfm2st():
+    nlayer = 4
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau = jnp.full((nlayer, len(nu_grid)), 0.1)
+    single_scattering_albedo = jnp.full_like(dtau, 0.5)
+    asymmetric_parameter = jnp.full_like(dtau, 0.1)
+    art_emis = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+    art_reflect_emis = ArtReflectEmis(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    expected = art_emis.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+    )
+    actual = art_reflect_emis.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        jnp.zeros(len(nu_grid)),
+        jnp.zeros(len(nu_grid)),
+        jnp.zeros(len(nu_grid)),
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)
+
+
+def test_artreflectpure_sfm2st_ckd_transparent_lambert_surface():
+    nlayer = 2
+    ng = 3
+    nbands = 2
+    art = ArtReflectPure(
+        nlayer=nlayer,
+        nu_grid=jnp.arange(nbands) + 1000.0,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+    dtau_ckd = jnp.zeros((nlayer, ng, nbands))
+    zeros = jnp.zeros((nlayer, nbands))
+    reflectivity_surface = jnp.array([0.25, 0.5])
+    incoming_flux = jnp.array([2.0, 3.0])
+    weights = jnp.array([0.2, 0.3, 0.5])
+
+    actual = art.run_ckd(
+        dtau_ckd,
+        zeros,
+        zeros,
+        reflectivity_surface,
+        incoming_flux,
+        weights,
+    )
+
+    np.testing.assert_allclose(
+        actual, reflectivity_surface * incoming_flux, rtol=1.0e-6
+    )
+
+
+def test_artreflectemis_sfm2st_ckd_reduces_to_emission_sfm2st():
+    nlayer = 4
+    ng = 3
+    nbands = 2
+    nu_bands = jnp.array([1000.0, 1005.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau_ckd = jnp.full((nlayer, ng, nbands), 0.1)
+    weights = jnp.array([0.2, 0.3, 0.5])
+    single_scattering_albedo = jnp.full((nlayer, nbands), 0.5)
+    asymmetric_parameter = jnp.full((nlayer, nbands), 0.1)
+    art_emis = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_bands,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+    art_reflect_emis = ArtReflectEmis(
+        nlayer=nlayer,
+        nu_grid=nu_bands,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    expected = art_emis.run_ckd(
+        dtau_ckd,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        weights,
+        nu_bands,
+    )
+    actual = art_reflect_emis.run_ckd(
+        dtau_ckd,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        jnp.zeros(nbands),
+        jnp.zeros(nbands),
+        jnp.zeros(nbands),
+        weights,
+        nu_bands,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-6)


### PR DESCRIPTION
## Summary

- add an SFM-2st solver for diffuse reflected light
- share the two-stream layer-source construction with the emission SFM solver
- expose the solver through ArtReflectPure and ArtReflectEmis for LBL and CKD paths
- document the diffuse hemispheric incoming-flux convention

## Tests

- NUMBA_DISABLE_JIT=1 pytest -q tests/unittests/rt/atmrt tests/unittests/rt/twostream tests/unittests/opacity/ckd/reflectpure_ckd_test.py tests/unittests/opacity/ckd/reflectemis_ckd_test.py
- 99 passed