### PR TITLE
Add lower thermal boundary source to ArtEmisScat SFM

### DIFF
--- a/documents/userguide/rtransfer_fbased.rst
+++ b/documents/userguide/rtransfer_fbased.rst
@@ -69,6 +69,27 @@ quadrature is controlled by ``nstream``.
         temperature,
     )
 
+Use ``run_with_surface`` to add an isotropic thermal source immediately below
+the last atmospheric layer, at ``pressure_boundary[-1]``. The surface source
+uses the same :math:`\pi B_\nu` scale as the atmospheric source function.
+
+.. code:: python
+
+    from exojax.rt.planck import piB
+
+    source_surface = piB(temperature_surface, nu_grid)
+    F0 = art.run_with_surface(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        source_surface,
+    )
+
+``run_with_surface`` currently supports the line-by-line
+``sfm2st_toon_hemispheric_mean`` solver. The existing ``run`` method retains
+its zero lower-boundary source.
+
 Reflection using SFM-2st
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -9,6 +9,7 @@ from exojax.rt.rtransfer import (
     rtrun_emis_scat_fluxadding_toonhm,
     rtrun_emis_scat_lart_toonhm,
     rtrun_emis_scat_sfm2st_toonhm,
+    rtrun_emis_scat_sfm2st_toonhm_surface,
     initialize_gaussian_quadrature,
     setrt_toonhm_with_absorption,
 )
@@ -441,6 +442,13 @@ class ArtEmisScat(ArtCommon):
         self.mus, self.weights = initialize_gaussian_quadrature(self.nstream)
         self.method = "emission_with_scattering_using_" + self.rtsolver
 
+    def _source_function(self, temperature, nu_grid):
+        if self.nu_grid is not None:
+            return piBarr(temperature, self.nu_grid)
+        if nu_grid is not None:
+            return piBarr(temperature, nu_grid)
+        raise ValueError("the wavenumber grid is not given.")
+
     def run(
         self,
         dtau,
@@ -461,12 +469,7 @@ class ArtEmisScat(ArtCommon):
         Returns:
             1D array: spectrum
         """
-        if self.nu_grid is not None:
-            sourcef = piBarr(temperature, self.nu_grid)
-        elif nu_grid is not None:
-            sourcef = piBarr(temperature, nu_grid)
-        else:
-            raise ValueError("the wavenumber grid is not given.")
+        sourcef = self._source_function(temperature, nu_grid)
 
         if self.rtsolver == "lart_toon_hemispheric_mean":
             (
@@ -507,6 +510,48 @@ class ArtEmisScat(ArtCommon):
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
 
         return spectrum
+
+    def run_with_surface(
+        self,
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        source_surface,
+        nu_grid=None,
+    ):
+        """Run SFM-2st emission with an isotropic lower thermal source.
+
+        Args:
+            dtau (2D array): Layer optical depths, shape ``(N_layer, N_nus)``.
+            single_scattering_albedo (2D array): Single-scattering albedo.
+            asymmetric_parameter (2D array): Scattering asymmetry parameter.
+            temperature (1D array): Layer temperatures, shape ``(N_layer,)``.
+            source_surface (1D array): Upward source at
+                ``pressure_boundary[-1]`` in pi B_nu scale. Use
+                ``piB(temperature_surface, nu_grid)`` for a black lower
+                boundary.
+            nu_grid (1D array): Wavenumber grid when it was not initialized.
+
+        Returns:
+            1D array: Top-of-atmosphere emission spectrum.
+        """
+        if self.rtsolver != "sfm2st_toon_hemispheric_mean":
+            raise ValueError(
+                "run_with_surface currently supports "
+                "rtsolver='sfm2st_toon_hemispheric_mean'."
+            )
+
+        sourcef = self._source_function(temperature, nu_grid)
+        return rtrun_emis_scat_sfm2st_toonhm_surface(
+            dtau,
+            single_scattering_albedo,
+            asymmetric_parameter,
+            sourcef,
+            source_surface,
+            self.mus,
+            self.weights,
+        )
 
     def run_ckd(self, dtau_ckd, single_scattering_albedo, asymmetric_parameter, 
                 temperature, weights, nu_bands):

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -18,7 +18,8 @@
     --- isothermal: rtrun_emis_pureabs_ibased
     --- linear source approximation: rtrun_emis_pureabs_ibased_linsap
     -- scattering
-    --- SFM-2st: rtrun_emis_scat_sfm2st
+    --- SFM-2st: rtrun_emis_scat_sfm2st_toonhm,
+        rtrun_emis_scat_sfm2st_toonhm_surface
 
     - intensity-based reflection
     -- scattering
@@ -639,6 +640,34 @@ def _solve_sfm2st_layer_source(
     return source_sfm, flux_plus[-1]
 
 
+def _rtrun_sfm2st_toonhm(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+    source_surface,
+    reflectivity_surface,
+    incoming_flux,
+    mus,
+    weights,
+):
+    """Run the shared SFM-2st formal solution with boundary sources."""
+    source_sfm, source_bottom = _solve_sfm2st_layer_source(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        reflectivity_surface,
+        source_surface,
+        incoming_flux,
+    )
+
+    intensity = rtrun_emis_pureabs_ibased_intensity_surface(
+        dtau, source_sfm, source_bottom, mus
+    )
+    return rtrun_emis_pureabs_ibased_flux_from_intensity(intensity, mus, weights)
+
+
 @jit
 def rtrun_emis_scat_sfm2st_toonhm(
     dtau,
@@ -683,6 +712,44 @@ def rtrun_emis_scat_sfm2st_toonhm(
 
 
 @jit
+def rtrun_emis_scat_sfm2st_toonhm_surface(
+    dtau,
+    single_scattering_albedo,
+    asymmetric_parameter,
+    source_matrix,
+    source_surface,
+    mus,
+    weights,
+):
+    """Radiative transfer for SFM-2st emission with a lower thermal source.
+
+    Args:
+        dtau: Layer optical depths with shape ``(N_layer, N_nus)``.
+        single_scattering_albedo: Single-scattering albedo.
+        asymmetric_parameter: Scattering asymmetry parameter.
+        source_matrix: Thermal layer source in pi B scale.
+        source_surface: Isotropic lower-boundary source in pi B scale.
+        mus: Positive ray-angle cosines.
+        weights: Gaussian quadrature weights.
+
+    Returns:
+        Top-of-atmosphere emission flux.
+    """
+    _, Nnus = dtau.shape
+    return _rtrun_sfm2st_toonhm(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        source_surface,
+        jnp.zeros(Nnus),
+        jnp.zeros(Nnus),
+        mus,
+        weights,
+    )
+
+
+@jit
 def rtrun_reflect_sfm2st_toonhm(
     dtau,
     single_scattering_albedo,
@@ -715,21 +782,16 @@ def rtrun_reflect_sfm2st_toonhm(
     Returns:
         Reflected and emitted top-of-atmosphere flux.
     """
-    source_sfm, source_bottom = _solve_sfm2st_layer_source(
+    return _rtrun_sfm2st_toonhm(
         dtau,
         single_scattering_albedo,
         asymmetric_parameter,
         source_matrix,
-        reflectivity_surface,
         source_surface,
+        reflectivity_surface,
         incoming_flux,
-    )
-
-    intensity = rtrun_emis_pureabs_ibased_intensity_surface(
-        dtau, source_sfm, source_bottom, mus
-    )
-    return rtrun_emis_pureabs_ibased_flux_from_intensity(
-        intensity, mus, weights
+        mus,
+        weights,
     )
 
 

--- a/tests/unittests/rt/atmrt/emisscat_sfm2st_test.py
+++ b/tests/unittests/rt/atmrt/emisscat_sfm2st_test.py
@@ -1,8 +1,10 @@
+import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from exojax.rt import ArtEmisPure, ArtEmisScat
-from exojax.rt.planck import piBarr
+from exojax.rt import ArtEmisPure, ArtEmisScat, ArtReflectEmis
+from exojax.rt.planck import piB, piBarr
 from exojax.rt.rtransfer import rtrun_emis_pureabs_ibased
 
 
@@ -81,6 +83,171 @@ def test_rtrun_emis_scat_sfm2st_returns_finite_flux_with_scattering():
     assert jnp.shape(spectrum) == jnp.shape(nu_grid)
     assert jnp.all(jnp.isfinite(spectrum))
     assert jnp.all(spectrum > 0.0)
+
+
+def test_rtrun_emis_scat_sfm2st_surface_pure_absorption_boundary_term():
+    from exojax.rt.rtransfer import (
+        initialize_gaussian_quadrature,
+        rtrun_emis_scat_sfm2st_toonhm,
+        rtrun_emis_scat_sfm2st_toonhm_surface,
+    )
+
+    dtau = jnp.array(
+        [
+            [0.10, 0.20, 0.30],
+            [0.05, 0.10, 0.20],
+            [0.20, 0.05, 0.10],
+        ]
+    )
+    source_matrix = jnp.ones_like(dtau)
+    single_scattering_albedo = jnp.zeros_like(dtau)
+    asymmetric_parameter = jnp.zeros_like(dtau)
+    source_surface = jnp.array([2.0, 3.0, 4.0])
+    mus, weights = initialize_gaussian_quadrature(8)
+
+    without_surface = rtrun_emis_scat_sfm2st_toonhm(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        mus,
+        weights,
+    )
+    with_surface = rtrun_emis_scat_sfm2st_toonhm_surface(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        source_matrix,
+        source_surface,
+        mus,
+        weights,
+    )
+
+    tau_bottom = jnp.sum(dtau, axis=0)
+    surface_transmission = jnp.sum(
+        2.0
+        * mus[:, None]
+        * weights[:, None]
+        * jnp.exp(-tau_bottom[None, :] / mus[:, None]),
+        axis=0,
+    )
+    expected_boundary_term = source_surface * surface_transmission
+    np.testing.assert_allclose(
+        with_surface - without_surface,
+        expected_boundary_term,
+        rtol=1.0e-6,
+    )
+
+
+def test_artemisscat_sfm2st_run_with_surface_matches_existing_boundary_paths():
+    nlayer = 4
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.linspace(800.0, 1200.0, nlayer)
+    dtau = jnp.full((nlayer, len(nu_grid)), 0.1)
+    single_scattering_albedo = jnp.full_like(dtau, 0.5)
+    asymmetric_parameter = jnp.full_like(dtau, 0.1)
+    art = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+    art_reflect_emis = ArtReflectEmis(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    expected = art.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+    )
+    zero_surface = art.run_with_surface(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        jnp.zeros_like(nu_grid),
+    )
+    source_surface = piB(1300.0, nu_grid)
+    with_surface = art.run_with_surface(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        source_surface,
+    )
+    expected_with_surface = art_reflect_emis.run(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        source_surface,
+        jnp.zeros_like(nu_grid),
+        jnp.zeros_like(nu_grid),
+    )
+
+    np.testing.assert_array_equal(zero_surface, expected)
+    np.testing.assert_array_equal(with_surface, expected_with_surface)
+
+
+def test_artemisscat_sfm2st_run_with_surface_transparent_limit_and_grad():
+    nlayer = 2
+    nu_grid = jnp.array([1000.0, 1001.0, 1002.0])
+    temperature = jnp.array([800.0, 1000.0])
+    dtau = jnp.zeros((nlayer, len(nu_grid)))
+    single_scattering_albedo = jnp.full_like(dtau, 0.5)
+    asymmetric_parameter = jnp.full_like(dtau, 0.1)
+    source_surface = jnp.array([2.0, 3.0, 4.0])
+    art = ArtEmisScat(
+        nlayer=nlayer,
+        nu_grid=nu_grid,
+        rtsolver="sfm2st_toon_hemispheric_mean",
+        nstream=8,
+    )
+
+    def summed_flux(surface_scale):
+        spectrum = art.run_with_surface(
+            dtau,
+            single_scattering_albedo,
+            asymmetric_parameter,
+            temperature,
+            surface_scale * source_surface,
+        )
+        return jnp.sum(spectrum)
+
+    actual = jax.jit(art.run_with_surface)(
+        dtau,
+        single_scattering_albedo,
+        asymmetric_parameter,
+        temperature,
+        source_surface,
+    )
+    derivative = jax.grad(summed_flux)(1.0)
+
+    np.testing.assert_allclose(actual, source_surface, rtol=1.0e-6)
+    np.testing.assert_allclose(derivative, jnp.sum(source_surface), rtol=1.0e-6)
+
+
+def test_artemisscat_run_with_surface_rejects_non_sfm_solver():
+    art = ArtEmisScat(
+        nlayer=2,
+        nu_grid=jnp.array([1000.0]),
+        rtsolver="fluxadding_toon_hemispheric_mean",
+    )
+    layer = jnp.ones((2, 1))
+
+    with pytest.raises(ValueError, match="currently supports"):
+        art.run_with_surface(
+            layer,
+            layer,
+            layer,
+            jnp.array([900.0, 1000.0]),
+            jnp.ones(1),
+        )
 
 
 def test_artemisscat_sfm2st_ckd_reduces_to_pure_absorption_ibased_ckd():


### PR DESCRIPTION
## Summary

- Add ArtEmisScat.run_with_surface for an isotropic lower-boundary thermal source with SFM-2st.
- Share the SFM boundary formal solution between emission and reflection paths.
- Preserve the existing ArtEmisScat.run zero-boundary behavior.
- Document the source convention, usage, and supported solver scope.

## Tests

- pytest -q tests/unittests/rt/atmrt/emisscat_sfm2st_test.py tests/unittests/rt/atmrt/reflect_sfm2st_test.py tests/unittests/rt/atmrt/emispure_intensity_test.py tests/unittests/rt/atmrt/opart_fluxadding_test.py
- 37 passed