### PR TITLE
utils: speed up PreMODIT row index generation

### DIFF
--- a/src/exojax/utils/indexing.py
+++ b/src/exojax/utils/indexing.py
@@ -89,6 +89,13 @@ def npgetix(x, xv):
     return cont, index.astype(int)
 
 
+def _structured_row_view(x):
+    """View each row as one structured value without copying the array."""
+    if not x.data.contiguous:
+        warnings.warn("input should be contiguous.", UserWarning)
+    return x.view(x.dtype.descr * x.shape[1])
+
+
 def unique_rows(x):
     """memory saved version of np.unique(,axis=0)
 
@@ -102,9 +109,7 @@ def unique_rows(x):
     Returns:
         2D array: unique 2D array (N' x M), where N' <= N, removed duplicated M vector.
     """
-    if not x.data.contiguous:
-        warnings.warn("input should be contiguous.", UserWarning)
-    uniq = np.unique(x.view(x.dtype.descr * x.shape[1]))
+    uniq = np.unique(_structured_row_view(x))
     return uniq.view(x.dtype).reshape(-1, x.shape[1])
 
 
@@ -123,8 +128,10 @@ def uniqidx(input_array):
         >>> uidx, uval=uniqidx(a) #->[0,1,2,1,3,0], [[4,1],[7,1],[7,2],[8,0]]
 
     """
-    uniqvals = unique_rows(input_array)
-    uidx = genearte_uidx_from_uniqvals(input_array, uniqvals)
+    uniq, uidx = np.unique(_structured_row_view(input_array), return_inverse=True)
+    uniqvals = uniq.view(input_array.dtype).reshape(-1, input_array.shape[1])
+    # NumPy versions differ in the shape of inverse indices for a 2D view.
+    uidx = uidx.reshape(-1).astype(int, copy=False)
     return uidx, uniqvals
 
 def genearte_uidx_from_uniqvals(input_array, uniqvals):

--- a/tests/unittests/utils/misc/indexing_test.py
+++ b/tests/unittests/utils/misc/indexing_test.py
@@ -5,6 +5,7 @@ from exojax.utils.indexing import unique_rows
 from exojax.utils.indexing import get_smooth_index
 from exojax.utils.indexing import get_value_at_smooth_index
 import numpy as np
+import pytest
 
 
 def test_uniqidx_2D():
@@ -23,6 +24,42 @@ def test_uniqidx_3D():
     assert np.all(uidx - ref == 0.0)
     refval = np.array([[4, 1, 1], [4, 1, 2], [7, 1, 2], [7, 2, 2], [8, 0, 2]])
     assert np.all(val - refval == 0.0)
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float64])
+@pytest.mark.parametrize(
+    "rows, expected_indices, expected_rows",
+    [
+        (
+            [[2], [-1], [2], [0], [-1], [-1]],
+            [2, 0, 2, 1, 0, 0],
+            [[-1], [0], [2]],
+        ),
+        (
+            [[2, -1], [-1, 2], [2, -1], [0, -2], [-1, 2], [-1, 2]],
+            [2, 0, 2, 1, 0, 0],
+            [[-1, 2], [0, -2], [2, -1]],
+        ),
+        (
+            [[2, -1, 3], [-1, 2, -3], [2, -1, 3], [0, -2, 1],
+             [-1, 2, -3], [-1, 2, 1]],
+            [3, 0, 3, 2, 0, 1],
+            [[-1, 2, -3], [-1, 2, 1], [0, -2, 1], [2, -1, 3]],
+        ),
+    ],
+)
+def test_uniqidx_signed_duplicates(dtype, rows, expected_indices, expected_rows):
+    a = np.array(rows, dtype=dtype)
+
+    uidx, values = uniqidx(a)
+
+    assert uidx.shape == (len(a),)
+    assert uidx.dtype == np.dtype(int)
+    assert values.dtype == a.dtype
+    np.testing.assert_array_equal(uidx, expected_indices)
+    np.testing.assert_array_equal(values, expected_rows)
+    np.testing.assert_array_equal(values[uidx], a)
+    np.testing.assert_array_equal(values, unique_rows(a))
 
 
 def test_find_or_add_index():
@@ -55,6 +92,23 @@ def test_uniqidx_neibouring():
     assert np.all(
         multi_index_update[k] == multi_index_update[index_of_uidx] + np.array([1, 1])
     )
+
+
+def test_uniqidx_neibouring_full_map():
+    a = np.array([[0, 0], [-1, 0], [0, 0], [-1, -1], [0, 1]])
+
+    uidx, neighbors, multi_index = uniqidx_neibouring(a)
+
+    np.testing.assert_array_equal(uidx, [2, 1, 2, 0, 3])
+    np.testing.assert_array_equal(
+        neighbors, [[4, 1, 2], [2, 5, 3], [6, 3, 7], [7, 8, 9]]
+    )
+    np.testing.assert_array_equal(
+        multi_index,
+        [[-1, -1], [-1, 0], [0, 0], [0, 1], [0, -1],
+         [-1, 1], [1, 0], [1, 1], [0, 2], [1, 2]],
+    )
+    np.testing.assert_array_equal(multi_index[uidx], a)
 
 
 def test_unique_rows():


### PR DESCRIPTION
PreMODIT broadening-grid setup currently rescans every input row for each unique row when building inverse indices. Use `np.unique(return_inverse=True)` on the existing structured row view to generate the mapping directly, preserving lexicographic row order, one-dimensional native-int indices, and the public APIs.

Regression coverage checks repeated signed rows across one to three columns and multiple dtypes, plus the complete neighboring-index map.

Validation (CPU, NumPy 2.2.6, JAX 0.6.2; `PYTHONPATH=src JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1`):

- `pytest -q -p no:cacheprovider tests/unittests/utils/misc/indexing_test.py`: 17 passed.
- `pytest -q -p no:cacheprovider tests/unittests/opacity/premodit`: 38 passed, 1 pre-existing precision-dependent failure.
- `pytest -q -p no:cacheprovider tests/unittests/opacity/premodit/lbderror_test.py`: 4 passed in isolation.
- `git diff --check`: passed.

The directory-level failure is `test_single_tilde_line_strength`: `optgrid_fast_test.py` disables JAX x64 during collection after `lbderror_test.py` enables it. The same failure and numerical result were reproduced with the unchanged indexing implementation from `bed953ad`; no unrelated precision/test changes are included.

CPU setup benchmark against `bed953ad`, seed 20260905, int64 rows, one warmup and median of five calls:

| Component | Rows / unique pairs | Before | After |
| --- | ---: | ---: | ---: |
| `uniqidx` | 30,000 / 256 | 176.010 ms | 15.788 ms |
| `uniqidx_neibouring` | 30,000 / 256 | 180.608 ms | 27.815 ms |
| `uniqidx` | 100,000 / 1,024 | 2046.349 ms | 58.562 ms |

All returned arrays and dtypes, including neighboring maps, match the baseline exactly. These timings measure the indexing component, not full PreMODIT initialization or spectral evaluation. No timing assertions were added to tests. The full repository suite and GPU performance were not tested.
