### PR TITLE
opacity: speed up CKD interpolation with four neighboring corners

### DIFF
--- a/src/exojax/opacity/ckd/core.py
+++ b/src/exojax/opacity/ckd/core.py
@@ -233,7 +233,19 @@ def compute_ckd_tables(
     return log_kggrid, ggrid, weights
 
 
-@jit  
+def _interpolation_interval(x, grid):
+    """Return adjacent indices and a weight with jnp.interp boundary behavior."""
+    upper = jnp.clip(jnp.searchsorted(grid, x, side="right"), 1, grid.size - 1)
+    lower = jnp.maximum(upper - 1, 0)
+    # A singleton grid selects its only point twice. Using interp for the
+    # local weight also preserves endpoint derivatives and dtype promotion.
+    weight = jnp.interp(
+        x, grid[jnp.stack((lower, upper))], jnp.array([0, 1], dtype=jnp.int32)
+    )
+    return lower, upper, weight
+
+
+@jit
 def interpolate_log_k_2d(
     log_kggrid: jnp.ndarray,
     T_grid: jnp.ndarray,
@@ -243,8 +255,9 @@ def interpolate_log_k_2d(
 ) -> jnp.ndarray:
     """JAX-compatible 2D interpolation of log_kggrid at given T,P.
     
-    Pure JAX function for interpolating pre-computed CKD tables at a specific
-    temperature and pressure point. Uses vectorized operations for efficiency.
+    Interpolate linearly in temperature and log pressure using the four
+    neighboring table entries. Out-of-range coordinates are clamped to the
+    boundary values, and singleton temperature or pressure grids are supported.
     
     Args:
         log_kggrid: Pre-computed log k-values, shape (nT, nP, Ng, nnu_bands)
@@ -256,35 +269,13 @@ def interpolate_log_k_2d(
     Returns:
         Interpolated log k-values, shape (Ng, nnu_bands)
     """
-    # log_kggrid shape: (nT, nP, Ng, nnu_bands)
-    # Vectorized interpolation approach
-    
-    def interpolate_2d_slice(log_k_2d_slice):
-        """Interpolate single 2D slice (nT, nP) at given T,P."""
-        # log_k_2d_slice shape: (nT, nP)
-        # First interpolate over T dimension for each P
-        def interp_over_T(log_k_column):
-            """Interpolate over T for single P column."""
-            return jnp.interp(T, T_grid, log_k_column)
-        
-        # Apply to each P column: (nT, nP) -> (nP,)
-        log_k_T = vmap(interp_over_T, in_axes=1)(log_k_2d_slice)
-        
-        # Then interpolate over P dimension in log scale: (nP,) -> scalar
-        # Use log scale for pressure due to wide dynamic range
-        log_k_TP = jnp.interp(jnp.log(P), jnp.log(P_grid), log_k_T)
-        
-        return log_k_TP
-    
-    # Apply vectorized interpolation over (Ng, nnu_bands) dimensions
-    # Reshape from (nT, nP, Ng, nnu_bands) to (Ng*nnu_bands, nT, nP)
-    nT, nP, Ng, nnu_bands = log_kggrid.shape
-    log_k_reshaped = log_kggrid.transpose(2, 3, 0, 1).reshape(-1, nT, nP)
-    
-    # Vectorize interpolation over all (g, band) combinations
-    log_k_flat = vmap(interpolate_2d_slice)(log_k_reshaped)  # Shape: (Ng*nnu_bands,)
-    
-    # Reshape back to (Ng, nnu_bands)
-    log_k_interp = log_k_flat.reshape(Ng, nnu_bands)
-    
-    return log_k_interp
+    t_lower, t_upper, t_weight = _interpolation_interval(T, T_grid)
+    p_lower, p_upper, p_weight = _interpolation_interval(jnp.log(P), jnp.log(P_grid))
+
+    lower_pressure = log_kggrid[t_lower, p_lower] + t_weight * (
+        log_kggrid[t_upper, p_lower] - log_kggrid[t_lower, p_lower]
+    )
+    upper_pressure = log_kggrid[t_lower, p_upper] + t_weight * (
+        log_kggrid[t_upper, p_upper] - log_kggrid[t_lower, p_upper]
+    )
+    return lower_pressure + p_weight * (upper_pressure - lower_pressure)

--- a/tests/unittests/opacity/ckd/ckd_interpolation_test.py
+++ b/tests/unittests/opacity/ckd/ckd_interpolation_test.py
@@ -1,0 +1,94 @@
+"""Regression coverage for CKD interpolation values and derivatives."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+try:
+    from jax import enable_x64
+except ImportError:
+    from jax.experimental import enable_x64
+
+from exojax.opacity.ckd.core import interpolate_log_k_2d
+
+
+def _reference_interpolation(table, temperatures, pressures, temperature, pressure):
+    """Interpolate every column using the original two-stage definition."""
+    n_t, n_p, n_g, n_bands = table.shape
+    at_temperature = jax.vmap(
+        lambda column: jnp.interp(temperature, temperatures, column), in_axes=1
+    )(table.reshape(n_t, -1))
+    at_pressure = jax.vmap(
+        lambda column: jnp.interp(jnp.log(pressure), jnp.log(pressures), column),
+        in_axes=1,
+    )(at_temperature.reshape(n_p, -1))
+    return at_pressure.reshape(n_g, n_bands)
+
+
+@pytest.mark.parametrize("use_x64", [False, True])
+@pytest.mark.parametrize("n_t,n_p", [(3, 3), (1, 3), (3, 1), (1, 1)])
+def test_interpolation_matches_reference_values_and_gradients(use_x64, n_t, n_p):
+    """Keep one-sided node slopes, clamping, and singleton behavior under JIT."""
+    with enable_x64(use_x64):
+        dtype = jnp.float64 if use_x64 else jnp.float32
+        temperatures = jnp.array([300.0, 800.0, 1400.0], dtype=dtype)[:n_t]
+        pressures = jnp.array([0.1, 1.0, 100.0], dtype=dtype)[:n_p]
+        table = jnp.asarray(
+            np.random.default_rng(42).normal(-40.0, 5.0, (n_t, n_p, 2, 3)),
+            dtype=dtype,
+        )
+        t_queries, p_queries = jnp.meshgrid(
+            jnp.array([200.0, 300.0, 500.0, 800.0, 1000.0, 1400.0, 1600.0]),
+            jnp.array([0.01, 0.1, 0.3, 1.0, 4.0, 100.0, 200.0]),
+            indexing="ij",
+        )
+        queries = jnp.stack((t_queries.ravel(), p_queries.ravel()), axis=1)
+
+        def actual(query):
+            return interpolate_log_k_2d(table, temperatures, pressures, *query)
+
+        def reference(query):
+            return _reference_interpolation(table, temperatures, pressures, *query)
+
+        tolerance = 2e-6 if not use_x64 else 2e-13
+        values = jax.jit(jax.vmap(actual))(queries)
+        expected_values = jax.jit(jax.vmap(reference))(queries)
+        assert values.dtype == expected_values.dtype == dtype
+        np.testing.assert_allclose(
+            values, expected_values, rtol=tolerance, atol=tolerance
+        )
+
+        derivatives = jax.jit(jax.vmap(jax.jacfwd(actual)))(queries)
+        expected_derivatives = jax.jit(jax.vmap(jax.jacfwd(reference)))(queries)
+        np.testing.assert_allclose(
+            derivatives, expected_derivatives, rtol=tolerance, atol=tolerance
+        )
+        reverse_derivatives = jax.jit(
+            jax.vmap(jax.grad(lambda query: jnp.sum(actual(query))))
+        )(queries)
+        np.testing.assert_allclose(
+            reverse_derivatives,
+            jnp.sum(expected_derivatives, axis=(1, 2)),
+            rtol=tolerance,
+            atol=tolerance,
+        )
+
+
+@pytest.mark.parametrize(
+    "table_dtype,grid_dtype",
+    [("float32", "float64"), ("float64", "float32"), ("float32", "float32")],
+)
+def test_interpolation_preserves_input_precision(table_dtype, grid_dtype):
+    """Coordinate and table precision remain independent as in jnp.interp."""
+    with enable_x64():
+        table = jnp.arange(12.0, dtype=table_dtype).reshape(2, 2, 1, 3)
+        temperatures = jnp.array([300.0, 800.0], dtype=grid_dtype)
+        pressures = jnp.array([0.1, 10.0], dtype=grid_dtype)
+        temperature = jnp.asarray(500.0, dtype=grid_dtype)
+        pressure = jnp.asarray(1.0, dtype=grid_dtype)
+        arguments = (table, temperatures, pressures, temperature, pressure)
+        actual = interpolate_log_k_2d(*arguments)
+        expected = _reference_interpolation(*arguments)
+        assert actual.dtype == expected.dtype
+        np.testing.assert_allclose(actual, expected, rtol=2e-7, atol=2e-7)


### PR DESCRIPTION
CKD interpolation currently interpolates temperature across every pressure column before selecting the requested pressure. Gather only the four neighboring T/P entries, retaining temperature-linear and log-pressure-linear interpolation and the existing public API.

A small local weight calculation uses `jnp.interp` to preserve clamping, one-sided derivatives at grid endpoints, singleton axes, and coordinate precision. Regression coverage compares values and forward/reverse derivatives with the original two-stage definition on nonuniform grids, including grid nodes, out-of-range inputs, singleton axes, float32/float64, and mixed precision.

Validation (CPU, JAX 0.6.2, NumPy 2.2.6; `PYTHONPATH=src JAX_PLATFORMS=cpu PYTHONDONTWRITEBYTECODE=1`):

- `pytest -q -p no:cacheprovider tests/unittests/opacity/ckd`: 116 passed.
- `pytest -q -p no:cacheprovider tests/unittests/opacity/ckd/ckd_interpolation_test.py`: 11 passed, rerun after making the test context-manager import compatible with older/newer JAX releases.
- Independent table-gradient comparisons also matched the baseline at nodes, boundaries, and outside the domain, with and without singleton axes.
- `git diff --check`: passed.

CPU benchmark against `bed953ad`: table `(24 T, 48 P, 16 g, 64 bands)`, 64 paired layer queries, seed 0, warm JIT, median of 30 interleaved synchronized calls:

| Precision | Before | After | Speedup | Max absolute log-k difference |
| --- | ---: | ---: | ---: | ---: |
| float32 | 3.583 ms | 0.217 ms | 16.50x | 0 |
| float64 | 9.420 ms | 0.285 ms | 33.10x | 0 |

These are interpolation-kernel measurements, not whole-model or GPU speedups. No timing assertions were added to tests. The full repository suite and GPU performance were not tested.
