### PR TITLE
Fix opacity gradients, database masks, radiative transfer and cache identity

### DIFF
--- a/src/exojax/database/_common/commonapi.py
+++ b/src/exojax/database/_common/commonapi.py
@@ -152,6 +152,7 @@ class MdbCommonHitempHitran:
         """
         self.nu_lines = self.nu_lines[mask]
         self.line_strength_ref_original = self.line_strength_ref_original[mask]
+        self.logsij0 = self.logsij0[mask]
         self.delta_air = self.delta_air[mask]
         self.A = self.A[mask]
         self.n_air = self.n_air[mask]
@@ -161,10 +162,24 @@ class MdbCommonHitempHitran:
         self.gpp = self.gpp[mask]
         # isotope
         self.isoid = self.isoid[mask]
+        isotope_mask = np.isin(self.uniqiso, self.isoid)
+        self.gQT = self.gQT[isotope_mask]
+        self.T_gQT = self.T_gQT[isotope_mask]
         self.uniqiso = np.unique(self.isoid)
         if self.with_error:
             # uncertainties
             self.ierr = self.ierr[mask]
+        for attribute in (
+            "dev_nu_lines",
+            "n_h2", "gamma_h2",
+            "n_he", "gamma_he",
+            "n_co2", "gamma_co2",
+            "n_h2o", "gamma_h2o",
+            "nu_lines_err", "line_strength_ref_err",
+            "gamma_air_err", "gamma_self_err", "n_air_err", "delta_air_err",
+        ):
+            if hasattr(self, attribute):
+                setattr(self, attribute, getattr(self, attribute)[mask])
 
     def QT_interp(self, isotope, T):
         """interpolated partition function.

--- a/src/exojax/database/exomol/api.py
+++ b/src/exojax/database/exomol/api.py
@@ -312,7 +312,8 @@ class MdbExomol(CapiMdbExomol):
         self.A = self.A[mask]
         self.logsij0 = self.logsij0[mask]
         self.nu_lines = self.nu_lines[mask]
-        self.dev_nu_lines = self.dev_nu_lines[mask]
+        if hasattr(self, "dev_nu_lines"):
+            self.dev_nu_lines = self.dev_nu_lines[mask]
         self.gamma_natural = self.gamma_natural[mask]
         self.alpha_ref = self.alpha_ref[mask]
         self.n_Texp = self.n_Texp[mask]

--- a/src/exojax/database/hminus.py
+++ b/src/exojax/database/hminus.py
@@ -97,9 +97,9 @@ def bound_free_absorption(wavelength_um, temperature):
     def f(wavelength_um):
         C_n = jnp.stack(
             (
-                jnp.arange(7),
+                jnp.arange(1, 7),
                 jnp.array(
-                    [0.0, 152.519, 49.534, -118.858, 92.536, -34.194, 4.982]
+                    [152.519, 49.534, -118.858, 92.536, -34.194, 4.982]
                 ),
             ),
             axis=1,

--- a/src/exojax/opacity/ckd/api.py
+++ b/src/exojax/opacity/ckd/api.py
@@ -361,14 +361,14 @@ class OpaCKD(OpaCalc):
             if base_opa is not None:
                 actual_fp = _base_fingerprint(base_opa)
                 actual_hash = _hash_json(actual_fp)
-                if expected_hash is not None and expected_hash != actual_hash:
+                if expected_hash != actual_hash:
                     raise ValueError(
                         "Loaded CKD table does not match base_opa fingerprint."
                     )
             else:
                 if expected_hash is None:
                     raise ValueError(
-                        "Loaded CKD table is missing base fingerprint metadata; provide base_opa to validate."
+                        "Loaded CKD table is missing base fingerprint metadata; regenerate the table."
                     )
 
             arrays = dict(
@@ -606,7 +606,12 @@ class OpaCKD(OpaCalc):
             raise ValueError("External CKD xsgrid must be positive")
 
     def attach_base(self, base_opa, *, strict: bool = True) -> None:
-        """attach base opacity calculator after loading tables."""
+        """Attach a base calculator, validating its data and settings by default.
+
+        Legacy tables lack a complete fingerprint and require ``strict=False``
+        to attach a base after loading without one.
+        Custom calculators must describe opaque calculation inputs in ``meta()``.
+        """
         actual = _hash_json(_base_fingerprint(base_opa))
         if strict and getattr(self, "_expected_base_hash", None) not in (None, actual):
             raise ValueError("base_opa fingerprint mismatch with loaded CKD table.")
@@ -619,6 +624,11 @@ class OpaCKD(OpaCalc):
         Supports both ``OpaCKD.from_saved_tables(path, base_opa=...)`` and the legacy
         calling pattern ``OpaCKD.from_saved_tables(base_opa, path)`` used in earlier
         code and tests.
+
+        Base validation checks numerical calculator and database state. Custom
+        calculators must expose opaque inputs through ``meta()`` when saving.
+        Legacy tables can be loaded without a base and attached explicitly with
+        ``attach_base(base_opa, strict=False)``.
         """
         if kwargs:
             raise TypeError(

--- a/src/exojax/opacity/ckd/io.py
+++ b/src/exojax/opacity/ckd/io.py
@@ -5,7 +5,10 @@ import sys
 import platform
 from datetime import datetime, timezone
 import numpy as np
+from jax import Array
 from importlib.metadata import version as _pkg_version
+
+from exojax.opacity.io.serialization import _sha256_array
 
 def _safe_version(pkg: str) -> str:
     try: return _pkg_version(pkg)
@@ -15,19 +18,65 @@ def _hash_json(d: dict) -> str:
     blob = json.dumps(d, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()
 
-def _base_fingerprint(base_opa) -> dict:
+def _fingerprint_value(value):
+    """Represent numerical state without embedding large arrays in metadata."""
+    if isinstance(value, (np.ndarray, Array)):
+        array = np.asarray(value)
+        if array.dtype.hasobject:
+            raise TypeError("Object arrays cannot identify opacity data")
+        return dict(sha256=_sha256_array(array))
+    if isinstance(value, np.generic):
+        return value.item()
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_fingerprint_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _fingerprint_value(item) for key, item in value.items()}
+    raise TypeError("Non-data attribute")
+
+def _state_fingerprint(obj) -> dict:
+    """Capture direct data attributes, excluding opaque runtime objects."""
+    state = {}
+    for name, value in vars(obj).items():
+        if name in ("warning", "ready"):
+            continue
+        try:
+            state[name] = _fingerprint_value(value)
+        except TypeError:
+            # Do not traverse functions, dataframe internals or runtime wrappers.
+            # Custom calculators can describe additional inputs in meta().
+            continue
     return dict(
-        class_name=type(base_opa).__name__,
-        nu_min=float(base_opa.nu_grid[0]),
-        nu_max=float(base_opa.nu_grid[-1]),
-        nu_len=int(len(base_opa.nu_grid)),
-        base_meta=getattr(base_opa, "meta", lambda: {})(),
+        class_name=f"{type(obj).__module__}.{type(obj).__qualname__}",
+        state=state,
     )
 
+def _base_fingerprint(base_opa) -> dict:
+    """Identify full grids, line data, partition functions and calculation settings."""
+    fingerprint = _state_fingerprint(base_opa)
+    fingerprint["fingerprint_version"] = 2
+    fingerprint["nu_grid"] = _fingerprint_value(base_opa.nu_grid)
+    fingerprint["base_meta"] = _fingerprint_value(
+        getattr(base_opa, "meta", lambda: {})()
+    )
+    for name in (
+        "mdb", "pf_provider", "broadening_strategy", "pre_modit_info", "diffgrid_info"
+    ):
+        component = getattr(base_opa, name, None)
+        if component is not None:
+            fingerprint[name] = _state_fingerprint(component)
+    return fingerprint
+
 def _ckd_metadata_dict(self) -> dict:
-    base_fp = _base_fingerprint(self.base_opa)
+    if self.base_opa is None:
+        base_fp = getattr(self, "_expected_base_meta", None)
+        if base_fp is None:
+            raise ValueError("Cannot save CKD table without base fingerprint metadata.")
+    else:
+        base_fp = _base_fingerprint(self.base_opa)
     return dict(
-        schema_version="ckd.v1",
+        schema_version="ckd.v2",
         exojax_version=_safe_version("ExoJAX"),
         jax_version=_safe_version("jax"),
         python_version=sys.version.split()[0],

--- a/src/exojax/opacity/lpf/api.py
+++ b/src/exojax/opacity/lpf/api.py
@@ -193,7 +193,7 @@ class OpaDirect(OpaCalc):
             gammaLM = self._vmap_gamma(
                 Parr,
                 Tarr,
-                np.zeros_like(Parr),
+                jnp.zeros_like(Parr),
                 self.mdb.n_air,
                 self.mdb.gamma_air,
                 self.mdb.gamma_self,

--- a/src/exojax/opacity/modit/api.py
+++ b/src/exojax/opacity/modit/api.py
@@ -237,7 +237,7 @@ class OpaModit(OpaCalc):
         # Compute parameters based on database type
         if dbtype == "hitran":
             SijM, ngammaLM, nsigmaDl = hitran(
-                self.mdb, Tarr, Parr, np.zeros_like(Parr), R, self.mdb.molmass
+                self.mdb, Tarr, Parr, jnp.zeros_like(Parr), R, self.mdb.molmass
             )
         elif dbtype == "exomol":
             SijM, ngammaLM, nsigmaDl = exomol(self.mdb, Tarr, Parr, R, self.mdb.molmass)

--- a/src/exojax/provider/exomolhr.py
+++ b/src/exojax/provider/exomolhr.py
@@ -1,4 +1,6 @@
 import os
+import hashlib
+import json
 import zipfile
 from urllib.parse import urljoin
 import pandas as pd
@@ -29,9 +31,9 @@ def _fetch_opacity_zip(  # noqa: WPS211 (a few branches are fine here)
 ) -> pathlib.Path:
     """Return a local ExoMolHR CSV—downloaded only if necessary.
 
-    The function skips the network step when a file with the same physics
-    (identical *iso* and *T*) is already present in *out_dir*; only the
-    timestamp differs between downloads.
+    The function skips the network step when a file for the identical query
+    is already present in a query-specific subdirectory of *out_dir*.
+    Legacy files without query identity are not reused.
 
     Args:
         wvmin / wvmax : float | None
@@ -59,11 +61,23 @@ def _fetch_opacity_zip(  # noqa: WPS211 (a few branches are fine here)
         RuntimeError
             When the expected download link is missing or HTTP fails.
     """
-    out_dir = pathlib.Path(out_dir)
+    query = {
+        "wvmin": wvmin,
+        **({} if wvmax is None else {"wvmax": wvmax}),
+        "numin": numin,
+        "numax": numax,
+        "T": T,
+        "Smin": Smin,
+        "iso": iso,
+    }
+    query_key = hashlib.sha256(
+        json.dumps(query, sort_keys=True, default=float).encode("utf-8")
+    ).hexdigest()
+    out_dir = pathlib.Path(out_dir) / query_key
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
-    # 0. reuse if the same physics file already exists
+    # 0. reuse only within the matching query directory
     # ------------------------------------------------------------------
     csv_suffix = f"__{iso}__{float(T):.1f}K.csv"  # 1200  -> 1200.0K
     existing = sorted(out_dir.glob(f"*{csv_suffix}"))
@@ -74,15 +88,6 @@ def _fetch_opacity_zip(  # noqa: WPS211 (a few branches are fine here)
     # 1. build query and fetch HTML page
     # ------------------------------------------------------------------
     sess = session or requests.Session()
-    query = {
-        "wvmin": wvmin,
-        **({} if wvmax is None else {"wvmax": wvmax}),
-        "numin": numin,
-        "numax": numax,
-        "T": T,
-        "Smin": Smin,
-        "iso": iso,
-    }
     html_resp = sess.get(EXOMOLHR_API_ROOT, params=query, timeout=120)
     html_resp.raise_for_status()
 

--- a/src/exojax/rt/emis.py
+++ b/src/exojax/rt/emis.py
@@ -115,7 +115,8 @@ class ArtEmisPure(ArtCommon):
 
         Args:
             dtau (2D array): optical depth matrix, dtau  (N_layer, N_nus)
-            temperature (1D array): temperature profile (Nlayer)
+            temperature (1D array): temperature profile (Nlayer, or Nlayer + 1
+                at layer boundaries for ibased_linsap)
             nu_grid (1D array): if nu_grid is not initialized, provide it.
 
         Returns:
@@ -125,6 +126,10 @@ class ArtEmisPure(ArtCommon):
             nu_grid = self.nu_grid
 
         sourcef = piBarr(temperature, nu_grid)
+        return self._run_solver(dtau, sourcef)
+
+    def _run_solver(self, dtau, sourcef):
+        """Run the selected solver with an already evaluated source function."""
         rtfunc = self.rtsolver_dict[self.rtsolver]
 
         if self.rtsolver == "fbased2st":
@@ -177,7 +182,8 @@ class ArtEmisPure(ArtCommon):
 
         Args:
             dtau_ckd (3D array): optical depth matrix, dtau  (N_layer, Ng, Nbands)
-            temperature (1D array): temperature profile (Nlayer,)
+            temperature (1D array): temperature profile (Nlayer, or Nlayer + 1
+                at layer boundaries for ibased_linsap)
             weights (1D array): weights for the Gaussian quadrature (Ng,)
             nu_bands (1D array): wavenumber grid for the CKD, (Nbands)
 
@@ -187,8 +193,8 @@ class ArtEmisPure(ArtCommon):
 
         nlayer, Ng, Nbands = dtau_ckd.shape
         sourcef = jnp.tile(piBarr(temperature, nu_bands), Ng)
-        flux_ckd = rtrun_emis_pureabs_ibased(
-            dtau_ckd.reshape((nlayer, Ng * Nbands)), sourcef, self.mus, self.weights
+        flux_ckd = self._run_solver(
+            dtau_ckd.reshape((nlayer, Ng * Nbands)), sourcef
         )
         flux_ckd = flux_ckd.reshape((Ng, Nbands))
         return jnp.einsum("g,gb->b", weights, flux_ckd)

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -200,9 +200,11 @@ def rtrun_emis_pureabs_ibased_intensity(dtau, source_matrix, mus):
 
     Nnus = jnp.shape(dtau)[1]
     tau = jnp.cumsum(dtau, axis=0)
+    tau_upper = jnp.concatenate((jnp.zeros_like(dtau[:1]), tau[:-1]), axis=0)
 
     def f(carry, mu):
-        dtrans = -jnp.diff(jnp.exp(-tau / mu), prepend=1.0, axis=0)
+        # Preserve absorption in optically thin layers.
+        dtrans = jnp.exp(-tau_upper / mu) * -jnp.expm1(-dtau / mu)
         intensity = jnp.sum(source_matrix * dtrans, axis=0)
         return carry, intensity
 

--- a/tests/unittests/database/api/commonapi_mask_test.py
+++ b/tests/unittests/database/api/commonapi_mask_test.py
@@ -1,0 +1,84 @@
+"""Regression tests for masks shared by HITRAN and HITEMP databases."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.database._common.commonapi import MdbCommonHitempHitran
+
+
+@pytest.mark.parametrize("gpu_transfer", [False, True])
+@pytest.mark.parametrize("optional_fields", [False, True])
+def test_mask_preserves_isotope_partition_functions_and_line_arrays(
+    gpu_transfer, optional_fields
+):
+    mdb = MdbCommonHitempHitran.__new__(MdbCommonHitempHitran)
+    fields = [
+        "nu_lines",
+        "line_strength_ref_original",
+        "delta_air",
+        "A",
+        "n_air",
+        "gamma_air",
+        "gamma_self",
+        "elower",
+        "gpp",
+    ]
+    for field in fields:
+        setattr(mdb, field, np.arange(1.0, 5.0))
+    mdb.logsij0 = np.log(mdb.line_strength_ref_original)
+    fields.append("logsij0")
+    mdb.gpu_transfer = gpu_transfer
+    if gpu_transfer:
+        mdb.dev_nu_lines = jnp.array(mdb.nu_lines)
+        mdb.logsij0 = jnp.array(mdb.logsij0)
+        fields.append("dev_nu_lines")
+    mdb.with_error = optional_fields
+    if optional_fields:
+        for broadener in ("h2", "he", "co2", "h2o"):
+            for parameter in ("n", "gamma"):
+                field = f"{parameter}_{broadener}"
+                setattr(mdb, field, np.arange(1.0, 5.0))
+                fields.append(field)
+        mdb.ierr = np.array([123456, 234567, 345678, 456789])
+        mdb.add_error()
+        fields.extend(
+            [
+                "ierr",
+                "nu_lines_err",
+                "line_strength_ref_err",
+                "gamma_air_err",
+                "gamma_self_err",
+                "n_air_err",
+                "delta_air_err",
+            ]
+        )
+    mdb.isoid = np.array([1, 2, 3, 2])
+    mdb.uniqiso = np.array([1, 2, 3])
+    mdb.T_gQT = jnp.array(
+        [[100.0, 300.0, 900.0], [100.0, 400.0, 1000.0], [100.0, 500.0, 1100.0]]
+    )
+    mdb.gQT = jnp.array([[1.0, 3.0, 9.0], [2.0, 10.0, 40.0], [5.0, 30.0, 120.0]])
+
+    mask = mdb.isoid != 1
+    expected = {field: np.asarray(getattr(mdb, field))[mask] for field in fields}
+    expected_qr = np.asarray(mdb.qr_interp_lines(800.0, 296.0))[mask]
+    expected_qt = np.asarray(mdb.QT_interp(2, 800.0))
+    expected_gqt = np.asarray(mdb.gQT)[1:]
+    expected_temperatures = np.asarray(mdb.T_gQT)[1:]
+
+    mdb.apply_mask_mdb(mask)
+
+    for field, values in expected.items():
+        np.testing.assert_array_equal(getattr(mdb, field), values)
+    np.testing.assert_array_equal(mdb.isoid, [2, 3, 2])
+    np.testing.assert_array_equal(mdb.uniqiso, [2, 3])
+    np.testing.assert_array_equal(mdb.gQT, expected_gqt)
+    np.testing.assert_array_equal(mdb.T_gQT, expected_temperatures)
+    np.testing.assert_allclose(mdb.qr_interp_lines(800.0, 296.0), expected_qr)
+    np.testing.assert_allclose(mdb.QT_interp(2, 800.0), expected_qt)
+    assert hasattr(mdb, "dev_nu_lines") == gpu_transfer
+
+    mdb.apply_mask_mdb(mdb.isoid == 3)
+    np.testing.assert_array_equal(mdb.uniqiso, [3])
+    np.testing.assert_allclose(mdb.qr_interp_lines(800.0, 296.0), expected_qr[1:2])

--- a/tests/unittests/database/api/exomol_mask_test.py
+++ b/tests/unittests/database/api/exomol_mask_test.py
@@ -1,0 +1,45 @@
+"""Regression tests for ExoMol masks with and without device arrays."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.database.exomol.api import MdbExomol
+
+
+@pytest.mark.parametrize("gpu_transfer", [False, True])
+def test_apply_mask_keeps_exomol_line_arrays_aligned(gpu_transfer):
+    mdb = MdbExomol.__new__(MdbExomol)
+    mdb.gpu_transfer = gpu_transfer
+    fields = [
+        "A",
+        "nu_lines",
+        "gamma_natural",
+        "alpha_ref",
+        "n_Texp",
+        "elower",
+        "jlower",
+        "jupper",
+        "line_strength_ref_original",
+        "gpp",
+    ]
+    for field in fields:
+        setattr(mdb, field, np.arange(1.0, 5.0))
+    mdb.logsij0 = np.log(mdb.line_strength_ref_original)
+    mdb.gamma_natural = jnp.array(mdb.gamma_natural)
+    fields.append("logsij0")
+    if gpu_transfer:
+        mdb.generate_jnp_arrays()
+        fields.append("dev_nu_lines")
+
+    mask = np.array([False, True, False, True])
+    expected = {field: np.asarray(getattr(mdb, field))[mask] for field in fields}
+    mdb.apply_mask_mdb(mask)
+
+    for field, values in expected.items():
+        np.testing.assert_array_equal(getattr(mdb, field), values)
+    assert hasattr(mdb, "dev_nu_lines") == gpu_transfer
+
+    mdb.apply_mask_mdb(np.array([False, True]))
+    for field, values in expected.items():
+        np.testing.assert_array_equal(getattr(mdb, field), values[1:])

--- a/tests/unittests/database/exomolhr/exomolhr_cache_test.py
+++ b/tests/unittests/database/exomolhr/exomolhr_cache_test.py
@@ -1,0 +1,85 @@
+"""ExoMolHR downloads are reusable only for identical queries."""
+
+import io
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from exojax.provider.exomolhr import _fetch_opacity_zip
+
+
+def _query():
+    return dict(
+        wvmin=0,
+        wvmax=None,
+        numin=1000.0,
+        numax=2000.0,
+        T=1200,
+        Smin=1.0e-30,
+        iso="12C-16O",
+    )
+
+
+@pytest.fixture
+def session():
+    session = MagicMock()
+    archive = None
+
+    def get(url, *, params=None, **kwargs):
+        nonlocal archive
+        response = MagicMock()
+        if params is not None:
+            csv_name = f"timestamp__{params['iso']}__{float(params['T']):.1f}K.csv"
+            buffer = io.BytesIO()
+            with zipfile.ZipFile(buffer, "w") as zf:
+                zf.writestr(csv_name, repr(params))
+            archive = buffer.getvalue()
+            response.text = '<a href="/download/?archive_name=opacity.zip">Download</a>'
+        else:
+            response.__enter__.return_value = response
+            response.iter_content.return_value = [archive]
+        return response
+
+    session.get.side_effect = get
+    return session
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"wvmin": 100},
+        {"wvmax": 5000},
+        {"numin": 1500.0},
+        {"numax": 2500.0},
+        {"T": 1400},
+        {"Smin": 1.0e-25},
+        {"iso": "13C-16O"},
+    ],
+)
+def test_cache_matches_every_query_parameter(tmp_path, session, changed):
+    first = _fetch_opacity_zip(**_query(), out_dir=tmp_path, session=session)
+    first_contents = first.read_text()
+    assert session.get.call_count == 2
+    assert _fetch_opacity_zip(**_query(), out_dir=tmp_path, session=session) == first
+    assert session.get.call_count == 2
+
+    second_query = dict(_query(), **changed)
+    second = _fetch_opacity_zip(**second_query, out_dir=tmp_path, session=session)
+    assert session.get.call_count == 4
+    assert first != second
+    assert first.read_text() == first_contents
+    assert second.read_text() != first_contents
+    assert (
+        _fetch_opacity_zip(**second_query, out_dir=tmp_path, session=session) == second
+    )
+    assert session.get.call_count == 4
+
+
+def test_legacy_cache_without_query_identity_is_not_reused(tmp_path, session):
+    legacy = tmp_path / "timestamp__12C-16O__1200.0K.csv"
+    legacy.write_text("unknown query")
+    downloaded = _fetch_opacity_zip(**_query(), out_dir=tmp_path, session=session)
+    assert session.get.call_count == 2
+    assert downloaded != legacy
+    assert legacy.read_text() == "unknown query"

--- a/tests/unittests/opacity/ckd/ckd_io_test.py
+++ b/tests/unittests/opacity/ckd/ckd_io_test.py
@@ -1,9 +1,12 @@
+import json
+from types import SimpleNamespace
+
 import numpy as np
 import jax.numpy as jnp
 import pytest
 
 from exojax.opacity.ckd.api import OpaCKD, CKDTableInfo
-from exojax.opacity.ckd.io import _ckd_save_as_npz
+from exojax.opacity.ckd.io import _ckd_save_as_npz, _hash_json
 
 
 class _DummyBaseOpa:
@@ -12,6 +15,102 @@ class _DummyBaseOpa:
 
     def meta(self):
         return {"tag": "dummy"}
+
+
+class _ScaledBaseOpa(_DummyBaseOpa):
+    def __init__(self, scale=1.0):
+        super().__init__(jnp.linspace(100.0, 200.0, 5))
+        self.scale = scale
+        self._scale = 1.0
+        self.alias = "close"
+        self.opainfo = (np.asarray([1.0, 2.0]), [np.asarray([3.0])])
+        self.mdb = SimpleNamespace(
+            line_strength_ref_original=np.asarray([1.0e-20]),
+            gQT=np.asarray([1.0, 2.0]),
+        )
+
+    def xsmatrix(self, temperatures, pressures):
+        return jnp.full(
+            (len(temperatures), len(self.nu_grid)),
+            self.scale * self._scale * self.mdb.line_strength_ref_original[0],
+        )
+
+
+@pytest.mark.parametrize(
+    "difference", ["scale", "private_scale", "grid", "lines", "partition", "alias", "opainfo"]
+)
+def test_ckd_rejects_different_base_opacity(tmp_path, difference):
+    base = _ScaledBaseOpa()
+    opa = OpaCKD(base, Ng=2, band_width=100.0, band_spacing="linear")
+    path = tmp_path / "ckd.npz"
+    opa.precompute_tables(jnp.asarray([800.0]), jnp.asarray([0.1]), to_path=path)
+
+    other = _ScaledBaseOpa()
+    if difference == "scale":
+        other.scale = 100.0
+        np.testing.assert_allclose(
+            other.xsmatrix([800.0], [0.1]) / base.xsmatrix([800.0], [0.1]),
+            100.0,
+        )
+    elif difference == "private_scale":
+        other._scale = 100.0
+    elif difference == "grid":
+        other.nu_grid = other.nu_grid.at[2].add(1.0)
+    elif difference == "lines":
+        other.mdb.line_strength_ref_original *= 100.0
+    elif difference == "partition":
+        other.mdb.gQT *= 2.0
+    elif difference == "alias":
+        other.alias = "open"
+    else:
+        other.opainfo[1][0][0] = 4.0
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        OpaCKD.from_saved_tables(other, path)
+    loaded = OpaCKD.from_saved_tables(path)
+    with pytest.raises(ValueError, match="fingerprint"):
+        loaded.attach_base(other)
+    loaded.attach_base(_ScaledBaseOpa())
+
+
+def test_ckd_headless_resave_preserves_base_fingerprint(tmp_path):
+    base = _ScaledBaseOpa()
+    opa = OpaCKD(base, Ng=2, band_width=100.0, band_spacing="linear")
+    path = tmp_path / "ckd.npz"
+    opa.precompute_tables(jnp.asarray([800.0]), jnp.asarray([0.1]), to_path=path)
+
+    loaded = OpaCKD.from_saved_tables(path)
+    second_path = tmp_path / "ckd_copy.npz"
+    loaded.save_tables(second_path)
+    restored = OpaCKD.from_saved_tables(_ScaledBaseOpa(), second_path)
+    np.testing.assert_array_equal(restored.ckd_info.log_kggrid, opa.ckd_info.log_kggrid)
+    with pytest.raises(ValueError, match="fingerprint"):
+        OpaCKD.from_saved_tables(_ScaledBaseOpa(scale=100.0), second_path)
+
+
+def test_ckd_legacy_fingerprint_requires_explicit_base_override(tmp_path):
+    base = _DummyBaseOpa(jnp.linspace(100.0, 200.0, 5))
+    legacy_fingerprint = dict(
+        class_name=type(base).__name__, nu_min=100.0, nu_max=200.0,
+        nu_len=5, base_meta=base.meta(),
+    )
+    path = tmp_path / "legacy.npz"
+    _write_ckd_npz(
+        path,
+        meta=json.dumps(dict(
+            Ng=2, band_width=40.0, band_spacing="linear",
+            base_fingerprint=legacy_fingerprint,
+            base_fingerprint_hash=_hash_json(legacy_fingerprint),
+        )),
+    )
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        OpaCKD.from_saved_tables(base, path)
+    loaded = OpaCKD.from_saved_tables(path)
+    with pytest.raises(ValueError, match="fingerprint"):
+        loaded.attach_base(base)
+    loaded.attach_base(base, strict=False)
+    assert loaded.base_opa is base
 
 
 def _write_ckd_npz(path, **overrides):

--- a/tests/unittests/opacity/opa/hitran_pressure_autodiff_test.py
+++ b/tests/unittests/opacity/opa/hitran_pressure_autodiff_test.py
@@ -1,0 +1,56 @@
+"""Pressure tracing must work for both HITRAN opacity matrix APIs."""
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.opacity import OpaDirect, OpaModit
+
+
+@pytest.mark.parametrize("calculator", [OpaDirect, OpaModit])
+def test_hitran_xsmatrix_pressure_jit_and_gradient(calculator):
+    with jax.experimental.enable_x64():
+        nu_lines = np.array([1000.3, 1000.7])
+        mdb = SimpleNamespace(
+            dbtype="hitran",
+            gpu_transfer=True,
+            nu_lines=nu_lines,
+            dev_nu_lines=jnp.asarray(nu_lines),
+            logsij0=jnp.log(jnp.array([1.0e-20, 2.0e-20])),
+            elower=jnp.array([0.0, 100.0]),
+            n_air=jnp.array([0.5, 0.7]),
+            gamma_air=jnp.array([0.05, 0.08]),
+            gamma_self=jnp.array([0.1, 0.2]),
+            A=jnp.array([1.0, 2.0]),
+            molmass=28.0,
+            qr_interp_lines=lambda temperature, reference: jnp.full(
+                2, temperature / reference
+            ),
+        )
+        nu_grid = np.geomspace(1000.0, 1001.0, 64)
+        temperatures = jnp.array([800.0, 1000.0])
+        pressures = jnp.array([0.3, 1.0])
+        kwargs = {}
+        if calculator is OpaModit:
+            kwargs = dict(
+                Tarr_list=[temperatures * 0.8, temperatures * 1.2], Parr=pressures
+            )
+        opa = calculator(mdb, nu_grid, **kwargs)
+
+        expected = opa.xsmatrix(temperatures, pressures)
+        actual = jax.jit(opa.xsmatrix)(temperatures, pressures)
+        np.testing.assert_allclose(actual, expected, rtol=1.0e-10, atol=0.0)
+
+        def signal(pressure_scale):
+            return (
+                jnp.sum(opa.xsmatrix(temperatures, pressures * pressure_scale)) * 1.0e20
+            )
+
+        derivative = jax.jit(jax.grad(signal))(1.0)
+        step = 1.0e-5
+        finite_difference = (signal(1.0 + step) - signal(1.0 - step)) / (2.0 * step)
+        assert np.isfinite(derivative)
+        np.testing.assert_allclose(derivative, finite_difference, rtol=1.0e-5)

--- a/tests/unittests/opacity/opa/hitran_pressure_autodiff_test.py
+++ b/tests/unittests/opacity/opa/hitran_pressure_autodiff_test.py
@@ -12,7 +12,9 @@ from exojax.opacity import OpaDirect, OpaModit
 
 @pytest.mark.parametrize("calculator", [OpaDirect, OpaModit])
 def test_hitran_xsmatrix_pressure_jit_and_gradient(calculator):
-    with jax.experimental.enable_x64():
+    previous_x64 = jax.config.jax_enable_x64
+    try:
+        jax.config.update("jax_enable_x64", True)
         nu_lines = np.array([1000.3, 1000.7])
         mdb = SimpleNamespace(
             dbtype="hitran",
@@ -54,3 +56,5 @@ def test_hitran_xsmatrix_pressure_jit_and_gradient(calculator):
         finite_difference = (signal(1.0 + step) - signal(1.0 - step)) / (2.0 * step)
         assert np.isfinite(derivative)
         np.testing.assert_allclose(derivative, finite_difference, rtol=1.0e-5)
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)

--- a/tests/unittests/opacity/xs/hminus_test.py
+++ b/tests/unittests/opacity/xs/hminus_test.py
@@ -39,9 +39,11 @@ def test_hminus_bf():
 
 @pytest.mark.parametrize("wavelength", [1.4, 1.6419, 2.0])
 def test_hminus_continuum_temperature_gradient(wavelength):
-    from jax.experimental import enable_x64
+    from jax import config
 
-    with enable_x64():
+    previous_x64 = config.jax_enable_x64
+    try:
+        config.update("jax_enable_x64", True)
         nu_grid = jnp.array([1.0e4 / wavelength])
 
         def continuum(temperature):
@@ -60,6 +62,8 @@ def test_hminus_continuum_temperature_gradient(wavelength):
             ))(3000.0)
             assert bf_value == 0.0
             assert bf_derivative == 0.0
+    finally:
+        config.update("jax_enable_x64", previous_x64)
 
 
 def _setting_test_hminus():

--- a/tests/unittests/opacity/xs/hminus_test.py
+++ b/tests/unittests/opacity/xs/hminus_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import jax.numpy as jnp
 import pytest
+from jax import jit, value_and_grad
 from exojax.database.hminus  import free_free_absorption
 from exojax.database.hminus  import bound_free_absorption
 from exojax.database.hminus  import log_hminus_continuum
@@ -34,6 +35,31 @@ def test_hminus_bf():
     diff = np.abs(ref - val)
     print(diff)
     assert diff < 1.0e-30
+
+
+@pytest.mark.parametrize("wavelength", [1.4, 1.6419, 2.0])
+def test_hminus_continuum_temperature_gradient(wavelength):
+    from jax.experimental import enable_x64
+
+    with enable_x64():
+        nu_grid = jnp.array([1.0e4 / wavelength])
+
+        def continuum(temperature):
+            return log_hminus_continuum_single(
+                nu_grid, temperature, 1.0, 1.0
+            )[0]
+
+        value, derivative = jit(value_and_grad(continuum))(3000.0)
+        finite_difference = (continuum(3000.1) - continuum(2999.9)) / 0.2
+        assert np.isfinite(value)
+        assert np.isfinite(derivative)
+        np.testing.assert_allclose(derivative, finite_difference, rtol=1.0e-7)
+        if wavelength >= 1.6419:
+            bf_value, bf_derivative = jit(value_and_grad(
+                lambda temperature: bound_free_absorption(wavelength, temperature)
+            ))(3000.0)
+            assert bf_value == 0.0
+            assert bf_derivative == 0.0
 
 
 def _setting_test_hminus():

--- a/tests/unittests/rt/atmrt/emispure_ckd_solver_test.py
+++ b/tests/unittests/rt/atmrt/emispure_ckd_solver_test.py
@@ -1,0 +1,26 @@
+import jax.numpy as jnp
+import pytest
+
+from exojax.rt import ArtEmisPure
+
+
+@pytest.mark.parametrize(
+    "rtsolver,nstream", [("ibased", 8), ("fbased2st", 2), ("ibased_linsap", 8)]
+)
+@pytest.mark.parametrize("ng", [1, 3])
+def test_ckd_matches_weighted_monochromatic_solver(rtsolver, nstream, ng):
+    nu_bands = jnp.array([1000.0, 1500.0])
+    ntemperature = 3 if rtsolver == "ibased_linsap" else 2
+    temperature = jnp.linspace(500.0, 1000.0, ntemperature)
+    art = ArtEmisPure(nlayer=2, nu_grid=nu_bands, rtsolver=rtsolver, nstream=nstream)
+    dtau = jnp.array([[0.1, 0.3], [1.0, 3.0]])
+    dtau_ckd = dtau[:, None, :] * jnp.arange(1, ng + 1)[None, :, None]
+    weights = jnp.arange(1, ng + 1, dtype=float)
+    weights = weights / weights.sum()
+    expected = sum(
+        weights[g] * art.run(dtau_ckd[:, g, :], temperature) for g in range(ng)
+    )
+
+    actual = art.run_ckd(dtau_ckd, temperature, weights, nu_bands)
+
+    assert actual == pytest.approx(expected, rel=1.0e-6)

--- a/tests/unittests/rt/atmrt/emispure_intensity_test.py
+++ b/tests/unittests/rt/atmrt/emispure_intensity_test.py
@@ -1,16 +1,51 @@
 import jax.numpy as jnp
+import numpy as np
 import pytest
-from jax import jacfwd, jit
+from jax import grad, jacfwd, jit
 
 from exojax.rt import ArtEmisPure
 from exojax.rt.planck import piBarr
 from exojax.rt.rtransfer import (
     coeffs_linsap,
+    initialize_gaussian_quadrature,
     rtrun_emis_pureabs_ibased,
     rtrun_emis_pureabs_ibased_flux_from_intensity,
     rtrun_emis_pureabs_ibased_intensity,
     rtrun_emis_pureabs_ibased_intensity_surface,
 )
+
+
+@pytest.mark.parametrize("optical_depth", [0.0, 1.0e-9, 1.0e-3, 1.0])
+def test_ibased_float32_slab_flux_and_gradient(optical_depth):
+    mus, weights = initialize_gaussian_quadrature(8)
+    mus = jnp.asarray(mus, dtype=jnp.float32)
+    weights = jnp.asarray(weights, dtype=jnp.float32)
+
+    def flux(depth):
+        dtau = depth.reshape((1, 1))
+        return rtrun_emis_pureabs_ibased(
+            dtau, jnp.ones_like(dtau), mus, weights
+        )[0]
+
+    depth = jnp.float32(optical_depth)
+    mu64 = np.asarray(mus, dtype=np.float64)
+    weight64 = np.asarray(weights, dtype=np.float64)
+    expected = np.sum(2.0 * mu64 * weight64 * -np.expm1(-float(depth) / mu64))
+    expected_gradient = np.sum(2.0 * weight64 * np.exp(-float(depth) / mu64))
+
+    assert flux(depth) == pytest.approx(expected, rel=1.0e-6, abs=0.0)
+    assert grad(flux)(depth) == pytest.approx(expected_gradient, rel=1.0e-6)
+
+
+def test_ibased_thin_float32_layer_below_absorbing_layer():
+    dtau = jnp.array([[1.0], [1.0e-9]], dtype=jnp.float32)
+    source = jnp.array([[0.0], [1.0]], dtype=jnp.float32)
+    mus = jnp.array([0.5], dtype=jnp.float32)
+
+    intensity = rtrun_emis_pureabs_ibased_intensity(dtau, source, mus)
+    expected = np.exp(-2.0) * -np.expm1(-2.0e-9)
+
+    assert intensity == pytest.approx(np.array([[expected]]), rel=1.0e-6, abs=0.0)
 
 
 def test_linsap_coefficients_at_small_optical_depth():

--- a/tests/unittests/rt/atmrt/opart_emispure_intensity_test.py
+++ b/tests/unittests/rt/atmrt/opart_emispure_intensity_test.py
@@ -66,7 +66,8 @@ def test_opart_run_with_limb_darkening_matches_artemispure():
 
     assert flux == pytest.approx(expected_flux)
     assert u1 == pytest.approx(expected_u1, rel=1.0e-5, abs=1.0e-6)
-    assert u2 == pytest.approx(expected_u2, rel=1.0e-5, abs=1.0e-6)
+    # The float32 least-squares fit amplifies sub-ppm intensity differences.
+    assert u2 == pytest.approx(expected_u2, rel=2.0e-5, abs=1.0e-6)
 
 
 def test_opart_run_with_reduced_limb_darkening():


### PR DESCRIPTION
Eight independently reproduced bugs caused invalid opacity gradients, inconsistent database masks, lost thin-layer emission, ignored solver choices, or reuse of incompatible cached data. Each fix is isolated in its own commit with regression coverage.

| Area | Reproduced problem | Change |
| --- | --- | --- |
| H-minus continuum | At 2 microns the value was finite but the temperature gradient was NaN; at 1.6419 microns both were NaN. | Remove the zero coefficient term that evaluated as `0 * inf`. |
| HITRAN/HITEMP masks | Removing an entire isotope reassigned partition functions and left some line arrays unmasked. | Subset the corresponding partition rows and synchronize line strengths, device arrays, optional broadening coefficients and uncertainties. |
| Direct/MODIT | Passing HITRAN pressure through JIT raised `TracerArrayConversionError`. | Use `jnp.zeros_like` for self-pressure; verify JIT and pressure derivatives against finite differences. |
| Intensity-based RT | A float32 layer with source=1 and dtau=1e-9 emitted zero instead of approximately 2e-9. | Evaluate each layer's transmission difference with `expm1` and its upper-boundary optical depth. |
| CKD emission | `run_ckd` always used ibased, including when fbased2st was selected. | Share solver dispatch with the monochromatic path; cover all three solvers with Ng=1 and Ng=3. |
| CKD saved tables | A base producing 100 times the opacity, or with different interior grid points or database inputs, passed compatibility checks. | Hash complete numerical state and grids, database arrays, partition providers and calculation settings using the existing array hash helper. |
| ExoMolHR cache | Changed wavenumber limits or line-strength thresholds reused an earlier CSV. | Put ZIP/CSV files in directories keyed by every query parameter, including when server filenames coincide. |
| ExoMol masks | With gpu_transfer=False, masking raised after partially updating line arrays. | Mask the device wavenumber array only when it exists. |

Validation: 321 related tests passed on CPU across database/api, database/exomolhr, opacity/opa, opacity/ckd, H-minus and rt. The focused RT checks also passed in both default float32 and x64 modes (29 tests each). Existing dependency/deprecation warnings remain. `git diff --check` is clean.

```bash
JAX_PLATFORMS=cpu NUMBA_CACHE_DIR=/tmp/exojax-numba-cache \
MPLCONFIGDIR=/tmp/exojax-mpl-cache python -m pytest -q \
  tests/unittests/database/api tests/unittests/database/exomolhr \
  tests/unittests/opacity/opa tests/unittests/opacity/ckd \
  tests/unittests/opacity/xs/hminus_test.py tests/unittests/rt
```

Tests were run from a temporary working directory with absolute test paths to keep generated database fixtures separate from existing workspace data.

Compatibility details: legacy CKD tables remain readable without a base, and attaching a base to them requires an explicit `attach_base(base, strict=False)`. Custom calculators must include opaque calculation inputs in `meta()`. Legacy ExoMolHR files are preserved but fetched again into query-specific directories. One existing Opart limb-darkening comparison tolerance changes from 1e-5 to 2e-5 because the float32 fit amplifies sub-2.4e-7 relative intensity differences.
