### PR TITLE
Fix VALD species decoding for single-digit atomic numbers

### DIFF
--- a/src/exojax/database/core_atom/io.py
+++ b/src/exojax/database/core_atom/io.py
@@ -491,12 +491,10 @@ def pickup_param(ExAll):
     gamSta = ExAll["stark_damping"].to_numpy()
     vdWdamp = ExAll["waals_damping"].to_numpy()
 
-    ielem = np.zeros(len(ExAll), dtype="int")  # atomic number (e.g., Fe=26)
-    # e.g., neutral=1, singly ionized=2, ...
-    iion = np.zeros(len(ExAll), dtype="int")
-    for i, sp in enumerate(ExAll["species"]):
-        ielem[i] = int(str(int(sp))[:2])
-        iion[i] = int(str(int(sp))[2:]) + 1
+    # Species codes store 100 * atomic number + ion charge.
+    species = ExAll["species"].to_numpy(dtype=int)
+    ielem = species // 100
+    iion = species % 100 + 1
 
     return (
         A,

--- a/tests/unittests/database/vald/test_pytables.py
+++ b/tests/unittests/database/vald/test_pytables.py
@@ -3,6 +3,7 @@
 import gzip
 import inspect
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -12,7 +13,9 @@ from exojax.database.vald.api import AdbVald, _load_vald_dataframe
 
 _VALD_FIXTURE = """                                                                    Lande factors       Damping parameters
 Elm Ion      WL_vac(A)   log gf* E_low(eV) J lo E_up(eV)  J up  lower   upper    mean    Rad.  Stark  Waals
+'Li 1',      4999.0000,  -1.000,  1.0000,  1.0,  3.0000,  2.0,  0.000,  0.000,  0.000,  8.000, -6.000, -7.000,
 'Fe 1',      5000.0000,  -1.000,  1.0000,  1.0,  3.0000,  2.0,  0.000,  0.000,  0.000,  8.000, -6.000, -7.000,
+'Fe 2',      5001.0000,  -1.000,  1.0000,  1.0,  3.0000,  2.0,  0.000,  0.000,  0.000,  8.000, -6.000, -7.000,
 """
 
 
@@ -26,15 +29,29 @@ def test_adbvald_defaults_to_pytables():
     assert signature.parameters["engine"].default == "pytables"
 
 
-def test_adbvald_loads_default_pytables_cache(tmp_path):
+@pytest.mark.parametrize("use_cache", [False, True], ids=["raw", "cache"])
+def test_adbvald_preserves_species(tmp_path, use_cache):
     vald_path = tmp_path / "vald_fixture.gz"
     _write_vald_fixture(vald_path)
 
-    adb = AdbVald(vald_path, nurange=[19999.0, 20001.0])
+    if use_cache:
+        _load_vald_dataframe(vald_path, engine="pytables")
+        vald_path.unlink()
+
+    adb = AdbVald(vald_path, nurange=[19990.0, 20010.0])
 
     assert adb.engine == "pytables"
-    assert len(adb.nu_lines) == 1
     assert vald_path.with_suffix(".h5").is_file()
+    np.testing.assert_allclose(
+        adb.nu_lines, 1.0e8 / np.array([5001.0, 5000.0, 4999.0])
+    )
+    np.testing.assert_array_equal(adb.ielem, [26, 26, 3])
+    np.testing.assert_array_equal(adb.iion, [2, 1, 1])
+    assert adb.pfdat.iloc[np.asarray(adb.QTmask)]["T[K]"].tolist() == [
+        "Fe_II",
+        "Fe_I",
+        "Li_I",
+    ]
 
 
 def test_pandas_alias_creates_and_reuses_pytables_cache(tmp_path):
@@ -45,8 +62,8 @@ def test_pandas_alias_creates_and_reuses_pytables_cache(tmp_path):
     cache_path = vald_path.with_suffix(".h5")
 
     assert cache_path.is_file()
-    assert initial["species"].tolist() == [2600.0]
-    assert initial["wav_lines"].tolist() == [5000.0]
+    assert initial["species"].tolist() == [300.0, 2600.0, 2601.0]
+    assert initial["wav_lines"].tolist() == [4999.0, 5000.0, 5001.0]
 
     vald_path.unlink()
     cached = _load_vald_dataframe(vald_path, engine="pytables")


### PR DESCRIPTION
VALD species codes for single-digit atomic numbers were decoded using a fixed two-character prefix, so Li I (code `300`) was read as Zn I. Decode the atomic number and ion stage using integer division and remainder, preserving the existing cache format.

Expand the small VALD fixture to include Li I, Fe I, and Fe II. Verify their identities, wavenumber ordering, and partition-function rows through both raw-file loading and cache-only loading.

Validation: both regression cases failed before the fix; all 13 focused tests passed after the fix.

```sh
JAX_PLATFORMS=cpu python -m pytest \
  tests/unittests/database/core_atom \
  tests/unittests/database/vald \
  tests/unittests/opacity/lpf/test_api_xsmatrix.py \
  tests/unittests/opacity/modit/test_vald_all.py \
  tests/unittests/opacity/modit/test_xsmatrix_vald.py -q
```
