### PR TITLE
Share VALD and Kurucz line array management

### DIFF
--- a/src/exojax/database/core_atom/_arrays.py
+++ b/src/exojax/database/core_atom/_arrays.py
@@ -1,0 +1,68 @@
+"""Shared line-array management for VALD and Kurucz databases."""
+
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.database.core_atom.io import (
+    load_atomicdata,
+    load_ionization_energies,
+    pick_ionE,
+)
+
+
+_LINE_FIELDS = (
+    "A",
+    "elower",
+    "eupper",
+    "gupper",
+    "jlower",
+    "jupper",
+    "QTmask",
+    "ielem",
+    "iion",
+    "gamRad",
+    "gamSta",
+    "vdWdamp",
+)
+_INTEGER_FIELDS = ("QTmask", "ielem", "iion")
+_METADATA_FIELDS = ("solarA", "atomicmass", "ionE")
+
+
+def _set_atomic_metadata(adb):
+    """Build NumPy metadata for the selected host line arrays."""
+    atomic_data = load_atomicdata().set_index("ielem").loc[adb._ielem]
+    adb.solarA = atomic_data["solarA"].to_numpy()
+    adb.atomicmass = atomic_data["mass"].to_numpy()
+    ionization_energies = load_ionization_energies()
+    adb.ionE = np.array(
+        [
+            pick_ionE(ielem, iion, ionization_energies)
+            for ielem, iion in zip(adb._ielem, adb._iion)
+        ],
+        dtype=float,
+    )
+
+
+def _mask_atomic_lines(adb, mask):
+    """Select host lines and metadata, refreshing existing JAX line arrays."""
+    for name in ("nu_lines", "Sij0"):
+        setattr(adb, name, getattr(adb, name)[mask])
+    for name in _LINE_FIELDS:
+        host_name = "_" + name
+        setattr(adb, host_name, getattr(adb, host_name)[mask])
+    for name in _METADATA_FIELDS:
+        if hasattr(adb, name):
+            setattr(adb, name, getattr(adb, name)[mask])
+    if hasattr(adb, "dev_nu_lines"):
+        _generate_atomic_jnp_arrays(adb)
+
+
+def _generate_atomic_jnp_arrays(adb):
+    """Generate JAX arrays from selected lines while preserving fractional J."""
+    adb.dev_nu_lines = jnp.array(adb.nu_lines)
+    adb.logsij0 = jnp.array(np.log(adb.Sij0))
+    for name in _LINE_FIELDS:
+        dtype = int if name in _INTEGER_FIELDS else None
+        setattr(adb, name, jnp.array(getattr(adb, "_" + name), dtype=dtype))
+    for name in _METADATA_FIELDS:
+        setattr(adb, name, jnp.array(getattr(adb, name)))

--- a/src/exojax/database/kurucz/api.py
+++ b/src/exojax/database/kurucz/api.py
@@ -6,17 +6,18 @@ import warnings
 import jax.numpy as jnp
 import numpy as np
 
+from exojax.database.core_atom._arrays import (
+    _generate_atomic_jnp_arrays,
+    _mask_atomic_lines,
+    _set_atomic_metadata,
+)
 from exojax.database.core_atom.line_strength import line_strength_atom
 from exojax.database.core_atom.pf import interp_QT_284
 from exojax.database.core_atom.pf import partfn_Fe
 
 from exojax.database.core_atom.io import read_kurucz
 from exojax.database.core_atom.io import load_pf_Barklem2016
-from exojax.database.core_atom.io import load_atomicdata
-from exojax.database.core_atom.io import load_ionization_energies
-from exojax.database.core_atom.io import pick_ionE
 from exojax.database.core_atom.io import PeriodicTable
-# from exojax.database.core_atom.io import load_ionization_energies  # Duplicate import removed
 from exojax.utils.constants import Tref_original
 
 __all__ = ["AdbKurucz"]
@@ -69,7 +70,7 @@ class AdbKurucz:
             margin: margin for nurange (cm-1)
             crit: line strength lower limit for extraction
             Irwin: if True(1), the partition functions of Irwin1981 is used, otherwise those of Barklem&Collet2016
-            gpu_transfer: tranfer data to jnp.array?
+            gpu_transfer: If True, generate JAX line arrays at initialization.
             vmr_fraction: list of the vmr fractions of hydrogen, H2 molecule, helium. if None, typical quasi-"solar-fraction" will be applied.
 
         Note:
@@ -141,54 +142,17 @@ class AdbKurucz:
         )
 
         self.masking(mask)
+        _set_atomic_metadata(self)
         if gpu_transfer:
             self.generate_jnp_arrays()
 
-        # Compile atomic-specific data for each absorption line of interest
-        ipccd = load_atomicdata()
-        self.solarA = jnp.array(
-            list(map(lambda x: ipccd[ipccd["ielem"] == x].iat[0, 4], self.ielem))
-        )
-        self.atomicmass = jnp.array(
-            list(map(lambda x: ipccd[ipccd["ielem"] == x].iat[0, 5], self.ielem))
-        )
-        df_ionE = load_ionization_energies()
-        self.ionE = jnp.array(
-            list(
-                map(
-                    pick_ionE,
-                    self.ielem,
-                    self.iion,
-                    [
-                        df_ionE,
-                    ]
-                    * len(self.ielem),
-                )
-            )
-        )
-
     def masking(self, mask):
-        """applying mask
+        """Select lines and metadata, refreshing existing JAX arrays.
 
         Args:
-            mask: mask to be applied. self.mask is updated.
-
+            mask: Boolean mask for the current lines.
         """
-        # numpy float 64 Do not convert them jnp array
-        self.nu_lines = self.nu_lines[mask]
-        self.Sij0 = self.Sij0[mask]
-        self._A = self._A[mask]
-        self._elower = self._elower[mask]
-        self._eupper = self._eupper[mask]
-        self._gupper = self._gupper[mask]
-        self._jlower = self._jlower[mask]
-        self._jupper = self._jupper[mask]
-        self._QTmask = self._QTmask[mask]
-        self._ielem = self._ielem[mask]
-        self._iion = self._iion[mask]
-        self._gamRad = self._gamRad[mask]
-        self._gamSta = self._gamSta[mask]
-        self._vdWdamp = self._vdWdamp[mask]
+        _mask_atomic_lines(self, mask)
 
         if len(self.nu_lines) < 1:
             warn_msg = (
@@ -197,28 +161,8 @@ class AdbKurucz:
             warnings.warn(warn_msg, UserWarning)
 
     def generate_jnp_arrays(self):
-        """(re)generate jnp.arrays.
-
-        Note:
-            We have nd arrays and jnp arrays. We usually apply the mask to nd arrays and then generate jnp array from the corresponding nd array. For instance, self._A is nd array and self.A is jnp array.
-
-        """
-        # jnp arrays
-        self.dev_nu_lines = jnp.array(self.nu_lines)
-        self.logsij0 = jnp.array(np.log(self.Sij0))
-        self.A = jnp.array(self._A)
-        self.elower = jnp.array(self._elower)
-        self.eupper = jnp.array(self._eupper)
-        self.gupper = jnp.array(self._gupper)
-        self.jlower = jnp.array(self._jlower, dtype=int)
-        self.jupper = jnp.array(self._jupper, dtype=int)
-
-        self.QTmask = jnp.array(self._QTmask, dtype=int)
-        self.ielem = jnp.array(self._ielem, dtype=int)
-        self.iion = jnp.array(self._iion, dtype=int)
-        self.gamRad = jnp.array(self._gamRad)
-        self.gamSta = jnp.array(self._gamSta)
-        self.vdWdamp = jnp.array(self._vdWdamp)
+        """Generate JAX line arrays and metadata for the current selection."""
+        _generate_atomic_jnp_arrays(self)
 
     def Atomic_gQT(self, atomspecies):
         """Select grid of partition function especially for the species of

--- a/src/exojax/database/vald/api.py
+++ b/src/exojax/database/vald/api.py
@@ -4,10 +4,12 @@ import pathlib
 import warnings
 import jax.numpy as jnp
 import numpy as np
+from exojax.database.core_atom._arrays import (
+    _generate_atomic_jnp_arrays,
+    _mask_atomic_lines,
+    _set_atomic_metadata,
+)
 from exojax.database.core_atom.io import load_pf_Barklem2016
-from exojax.database.core_atom.io import load_atomicdata
-from exojax.database.core_atom.io import load_ionization_energies
-from exojax.database.core_atom.io import pick_ionE
 from exojax.database.core_atom.io import PeriodicTable
 from exojax.database.core_atom.io import _normalize_vald_engine
 from exojax.database.core_atom.io import _vald_cache_path
@@ -109,7 +111,7 @@ class AdbVald:
             margin: margin for nurange (cm-1)
             crit: line strength lower limit for extraction
             Irwin: if True(1), the partition functions of Irwin1981 is used, otherwise those of Barklem&Collet2016
-            gpu_transfer: tranfer data to jnp.array?
+            gpu_transfer: If True, generate JAX line arrays at initialization.
             vmr_fraction: list of the vmr fractions of hydrogen, H2 molecule, helium. if None, typical quasi-"solar-fraction" will be applied.
             engine: ``"pytables"`` (default), its legacy alias ``"pandas"``,
                 or the optional ``"vaex"`` backend.
@@ -187,54 +189,17 @@ class AdbVald:
         )
 
         self.masking(mask)
+        _set_atomic_metadata(self)
         if gpu_transfer:
             self.generate_jnp_arrays()
 
-        # Compile atomic-specific data for each absorption line of interest
-        ipccd = load_atomicdata()
-        self.solarA = jnp.array(
-            list(map(lambda x: ipccd[ipccd["ielem"] == x].iat[0, 4], self.ielem))
-        )
-        self.atomicmass = jnp.array(
-            list(map(lambda x: ipccd[ipccd["ielem"] == x].iat[0, 5], self.ielem))
-        )
-        df_ionE = load_ionization_energies()
-        self.ionE = jnp.array(
-            list(
-                map(
-                    pick_ionE,
-                    self.ielem,
-                    self.iion,
-                    [
-                        df_ionE,
-                    ]
-                    * len(self.ielem),
-                )
-            )
-        )
-
     def masking(self, mask):
-        """applying mask.
+        """Select lines and metadata, refreshing existing JAX arrays.
 
         Args:
-            mask: mask to be applied. self.mask is updated.
-
+            mask: Boolean mask for the current lines.
         """
-        # numpy float 64 Do not convert them jnp array
-        self.nu_lines = self.nu_lines[mask]
-        self.Sij0 = self.Sij0[mask]
-        self._A = self._A[mask]
-        self._elower = self._elower[mask]
-        self._eupper = self._eupper[mask]
-        self._gupper = self._gupper[mask]
-        self._jlower = self._jlower[mask]
-        self._jupper = self._jupper[mask]
-        self._QTmask = self._QTmask[mask]
-        self._ielem = self._ielem[mask]
-        self._iion = self._iion[mask]
-        self._gamRad = self._gamRad[mask]
-        self._gamSta = self._gamSta[mask]
-        self._vdWdamp = self._vdWdamp[mask]
+        _mask_atomic_lines(self, mask)
 
         if len(self.nu_lines) < 1:
             warn_msg = (
@@ -243,28 +208,8 @@ class AdbVald:
             warnings.warn(warn_msg, UserWarning)
 
     def generate_jnp_arrays(self):
-        """(re)generate jnp.arrays.
-
-        Note:
-            We have nd arrays and jnp arrays. We usually apply the mask to nd arrays and then generate jnp array from the corresponding nd array. For instance, self._A is nd array and self.A is jnp array.
-
-        """
-        # jnp arrays
-        self.dev_nu_lines = jnp.array(self.nu_lines)
-        self.logsij0 = jnp.array(np.log(self.Sij0))
-        self.A = jnp.array(self._A)
-        self.elower = jnp.array(self._elower)
-        self.eupper = jnp.array(self._eupper)
-        self.gupper = jnp.array(self._gupper)
-        self.jlower = jnp.array(self._jlower, dtype=int)
-        self.jupper = jnp.array(self._jupper, dtype=int)
-
-        self.QTmask = jnp.array(self._QTmask, dtype=int)
-        self.ielem = jnp.array(self._ielem, dtype=int)
-        self.iion = jnp.array(self._iion, dtype=int)
-        self.gamRad = jnp.array(self._gamRad)
-        self.gamSta = jnp.array(self._gamSta)
-        self.vdWdamp = jnp.array(self._vdWdamp)
+        """Generate JAX line arrays and metadata for the current selection."""
+        _generate_atomic_jnp_arrays(self)
 
     def Atomic_gQT(self, atomspecies):
         """Select grid of partition function especially for the species of

--- a/tests/unittests/database/core_atom/test_arrays.py
+++ b/tests/unittests/database/core_atom/test_arrays.py
@@ -1,0 +1,146 @@
+"""Regression tests for atomic line arrays across selection and transfer."""
+
+import importlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+_LINE_FIELDS = (
+    "A", "elower", "eupper", "gupper", "jlower", "jupper", "QTmask",
+    "ielem", "iion", "gamRad", "gamSta", "vdWdamp",
+)
+_METADATA = ("solarA", "atomicmass", "ionE")
+_HOST_FIELDS = ("nu_lines", "Sij0") + tuple("_" + name for name in _LINE_FIELDS)
+
+
+@pytest.fixture(params=["vald", "kurucz"])
+def make_adb(request, monkeypatch, tmp_path):
+    """Supply normalized transitions while retaining real atomic metadata."""
+    api = importlib.import_module(f"exojax.database.{request.param}.api")
+    transitions = (
+        np.array([1.0e6, 2.0e6, 3.0e6, 4.0e6]),
+        np.array([1000.0, 1001.0, 1002.0, 1003.0]),
+        np.array([0.0, 10.0, 20.0, 30.0]),
+        np.array([1000.0, 1011.0, 1022.0, 1033.0]),
+        np.array([3.0, 4.0, 6.0, 3.0]),
+        np.array([0.0, 0.5, 1.5, 0.0]),
+        np.array([1.0, 1.5, 2.5, 1.0]),
+        np.array([26, 11, 26, 12]),
+        np.array([1, 1, 2, 1]),
+        np.array([8.0, 8.1, 8.2, 8.3]),
+        np.array([-6.0, -6.1, -6.2, -6.3]),
+        np.array([-7.0, -7.1, -7.2, -7.3]),
+    )
+
+    def read_transitions(_):
+        return tuple(array.copy() for array in transitions)
+
+    if request.param == "vald":
+        monkeypatch.setattr(api, "_load_vald_dataframe", lambda *args: None)
+        monkeypatch.setattr(api, "pickup_param", read_transitions)
+        adb_class = api.AdbVald
+    else:
+        monkeypatch.setattr(api, "read_kurucz", read_transitions)
+        adb_class = api.AdbKurucz
+
+    def create(**kwargs):
+        return adb_class(tmp_path / "synthetic.lines", **kwargs)
+
+    return create
+
+
+def _assert_arrays(adb, expected, transferred):
+    for name in _HOST_FIELDS:
+        actual = getattr(adb, name)
+        assert isinstance(actual, np.ndarray), name
+        np.testing.assert_array_equal(actual, expected[name], err_msg=name)
+    for name in _METADATA:
+        actual = getattr(adb, name)
+        assert isinstance(actual, jax.Array if transferred else np.ndarray), name
+        np.testing.assert_array_equal(actual, expected[name], err_msg=name)
+
+    assert hasattr(adb, "dev_nu_lines") == transferred
+    if transferred:
+        for name in _LINE_FIELDS:
+            actual = getattr(adb, name)
+            assert isinstance(actual, jax.Array), name
+            np.testing.assert_array_equal(actual, expected["_" + name], err_msg=name)
+        np.testing.assert_array_equal(adb.dev_nu_lines, expected["nu_lines"])
+        np.testing.assert_allclose(adb.logsij0, np.log(expected["Sij0"]), atol=0.0)
+        for name in ("QTmask", "ielem", "iion"):
+            assert np.issubdtype(getattr(adb, name).dtype, np.integer)
+        for name in ("jlower", "jupper"):
+            assert np.issubdtype(getattr(adb, name).dtype, np.floating)
+
+
+def _snapshot(adb):
+    return {
+        name: np.array(getattr(adb, name), copy=True)
+        for name in _HOST_FIELDS + _METADATA
+    }
+
+
+def test_atomic_host_construction_and_delayed_transfer(make_adb):
+    adb = make_adb(nurange=[999.5, 1002.5], gpu_transfer=False)
+    np.testing.assert_array_equal(adb.nu_lines, [1000.0, 1001.0, 1002.0])
+    np.testing.assert_array_equal(adb._ielem, [26, 11, 26])
+    np.testing.assert_array_equal(adb._iion, [1, 1, 2])
+    np.testing.assert_allclose(adb.solarA, [-4.5, -5.76, -4.5])
+    np.testing.assert_allclose(adb.atomicmass, [55.847, 22.98981, 55.847])
+    np.testing.assert_allclose(adb.ionE, [7.9024681, 5.13907696, 16.19921])
+    expected = _snapshot(adb)
+    _assert_arrays(adb, expected, transferred=False)
+
+    adb.generate_jnp_arrays()
+    _assert_arrays(adb, expected, transferred=True)
+    np.testing.assert_array_equal(adb.jlower, [0.0, 0.5, 1.5])
+    np.testing.assert_array_equal(adb.jupper, [1.0, 1.5, 2.5])
+
+
+@pytest.mark.parametrize("transfer", ["host", "eager", "delayed"])
+def test_atomic_repeated_masking_preserves_line_alignment(make_adb, transfer):
+    adb = make_adb(nurange=[999.5, 1002.5], gpu_transfer=transfer == "eager")
+    if transfer == "delayed":
+        adb.generate_jnp_arrays()
+    expected = _snapshot(adb)
+    for mask in (np.array([False, True, True]), np.array([True, False])):
+        expected = {name: values[mask] for name, values in expected.items()}
+        adb.masking(mask)
+        _assert_arrays(adb, expected, transferred=transfer != "host")
+
+    adb.generate_jnp_arrays()
+    _assert_arrays(adb, expected, transferred=True)
+
+
+@pytest.mark.parametrize("gpu_transfer", [False, True])
+def test_atomic_empty_selection_remains_consistent(make_adb, gpu_transfer):
+    adb = make_adb(gpu_transfer=gpu_transfer)
+    expected = {name: values[:0] for name, values in _snapshot(adb).items()}
+    with pytest.warns(UserWarning, match="no lines are selected"):
+        adb.masking(np.zeros(len(adb.nu_lines), dtype=bool))
+    _assert_arrays(adb, expected, transferred=gpu_transfer)
+
+    with pytest.warns(UserWarning, match="no lines are selected"):
+        empty = make_adb(nurange=[2000.0, 2001.0], gpu_transfer=gpu_transfer)
+    _assert_arrays(empty, expected, transferred=gpu_transfer)
+
+
+def test_atomic_masked_opacity_matches_constructor_selection(make_adb):
+    from exojax.opacity import OpaDirect
+
+    adb = make_adb()
+    adb.masking(np.array([False, True, True, False]))
+    selected = make_adb(nurange=[1000.5, 1002.5])
+    nu_grid = np.linspace(1000.5, 1002.5, 33)
+    temperatures = jnp.array([1500.0, 2000.0, 2500.0])
+    pressures = jnp.array([0.01, 0.1, 1.0])
+    actual = OpaDirect(adb, nu_grid).xsmatrix(temperatures, pressures)
+    expected = OpaDirect(selected, nu_grid).xsmatrix(temperatures, pressures)
+
+    assert actual.shape == (3, len(nu_grid))
+    assert np.all(np.isfinite(actual))
+    assert np.all(actual > 0.0)
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-12, atol=0.0)


### PR DESCRIPTION
VALD and Kurucz could not initialize with `gpu_transfer=False`, and masking lines left atomic metadata and existing JAX arrays aligned with the previous selection. Share small internal helpers for metadata construction, masking, and JAX array generation so all line properties follow the current selection. Deferred transfer now works, and `jlower`/`jupper` preserve half-integer values.

Add regressions for both database classes covering deferred transfer, repeated masks, empty selections, metadata alignment, fractional J, and agreement between opacity from a masked database and one initialized with the same selection.

Validation:

- All 14 new regression cases failed before the change; all 27 focused tests passed afterward.
- A small VALD spectrum and its atomic metadata exactly matched their pre-refactor values.
- The bundled legacy VALD pickle still supports masking, JAX array regeneration, and `AdbSepVald` construction.

```sh
JAX_PLATFORMS=cpu python -m pytest -q \
  tests/unittests/database/core_atom \
  tests/unittests/database/vald \
  tests/unittests/opacity/lpf/test_api_xsmatrix.py \
  tests/unittests/opacity/modit/test_vald_all.py \
  tests/unittests/opacity/modit/test_xsmatrix_vald.py
```
