### PR TITLE
Unify atomic line parameters and Direct vector/matrix support

### DIFF
--- a/src/exojax/database/core_atom/line_parameters.py
+++ b/src/exojax/database/core_atom/line_parameters.py
@@ -1,0 +1,34 @@
+"""Atomic line parameters shared by direct LPF and MODIT calculations."""
+
+from jax import jit, vmap
+
+from exojax.database.core.broadening import doppler_sigma
+from exojax.database.core.line_strength import line_strength
+from exojax.database.core_atom.broadening import gamma_vald3
+
+
+def line_parameters(
+    T, PH, PHe, PHH, qr, logsij0, nu_lines, dev_nu_lines, elower, eupper,
+    ielem, iion, atomicmass, ionE, gamRad, gamSta, vdWdamp, Tref,
+):
+    """Return line strengths and Lorentz/Doppler widths at one layer.
+
+    Temperatures are in K, partial pressures in bar, line strengths in cm,
+    and line positions and widths in cm-1. ``qr`` is Q(T)/Q(Tref), either
+    per line or shared by all lines of a single species. ``dev_nu_lines``
+    retains the line positions used by the atomic broadening calculation.
+
+    Padding is handled by the caller, after calculating these parameters.
+    """
+    Sij = line_strength(T, logsij0, nu_lines, elower, qr, Tref)
+    gammaL = gamma_vald3(
+        T, PH, PHH, PHe, ielem, iion, dev_nu_lines, elower, eupper,
+        atomicmass, ionE, gamRad, gamSta, vdWdamp,
+    )
+    sigmaD = doppler_sigma(nu_lines, T, atomicmass)
+    return Sij, gammaL, sigmaD
+
+
+line_parameter_matrix = jit(
+    vmap(line_parameters, in_axes=(0, 0, 0, 0, 0) + (None,) * 13)
+)

--- a/src/exojax/database/core_atom/line_strength.py
+++ b/src/exojax/database/core_atom/line_strength.py
@@ -1,6 +1,5 @@
 import numpy as np
-import jax.numpy as jnp
-from exojax.database.core_atom.pf import partfn_Fe
+from exojax.database.core_atom.pf import _FE_I_QT_INDEX, partfn_Fe
 from exojax.utils.constants import Tref_original
 from exojax.utils.constants import ccgs
 from exojax.utils.constants import hcperk
@@ -23,13 +22,12 @@ def line_strength_atom(A, gupper, nu_lines, elower, QTref_284, QTmask, Irwin=Fal
     """
 
     # Assign Q(Tref) for each line
-    QTref = np.zeros_like(QTmask, dtype=float)
-    for i, mask in enumerate(QTmask):
-        QTref[i] = QTref_284[mask]
+    QTref = np.asarray(QTref_284, dtype=float)[np.asarray(QTmask, dtype=int)]
 
-    # Use Irwin_1981 for Fe I (mask==76)  #test211013Tako
-    if Irwin == True:
-        QTref[jnp.where(QTmask == 76)[0]] = partfn_Fe(Tref_original)
+    if Irwin:
+        QTref = np.where(
+            np.asarray(QTmask) == _FE_I_QT_INDEX, partfn_Fe(Tref_original), QTref
+        )
 
     S0 = (
         -A

--- a/src/exojax/database/core_atom/pf.py
+++ b/src/exojax/database/core_atom/pf.py
@@ -1,42 +1,68 @@
+"""Atomic partition functions and line-specific ratios."""
+
 import jax.numpy as jnp
-import numpy as np
-def interp_QT_284(T, T_gQT, gQT_284species):
-    """interpolated partition function of all 284 species.
+from jax import vmap
+
+
+_FE_I_QT_INDEX = 76
+
+
+def interp_QT_284(T, T_gQT, gQT_284species, Irwin=False):
+    """Interpolate partition functions for the tabulated atomic species.
 
     Args:
-        T: temperature
-        T_gQT: temperature in the grid obtained from the adb instance [N_grid(42)]
-        gQT_284species: partition function in the grid from the adb instance [N_species(284) x N_grid(42)]
+        T: Temperature in K.
+        T_gQT: Partition-function temperature grid.
+        gQT_284species: Partition-function grid, shaped (284, N_temperature).
+        Irwin: Use the Irwin (1981) polynomial for Fe I only.
 
     Returns:
-        QT_284: interpolated partition function at T Q(T) for all 284 Atomic Species [284]
+        Partition functions for all tabulated species.
     """
-    list_gQT_eachspecies = gQT_284species.tolist()
-    listofDA_gQT_eachspecies = list(map(lambda x: jnp.array(x), list_gQT_eachspecies))
-    listofQT = list(map(lambda x: jnp.interp(T, T_gQT, x), listofDA_gQT_eachspecies))
-    QT_284 = jnp.array(listofQT)
-    return QT_284
+    qt = vmap(jnp.interp, (None, None, 0))(T, T_gQT, gQT_284species)
+    is_fe_i = (jnp.arange(qt.shape[0]) == _FE_I_QT_INDEX).reshape(
+        (-1,) + (1,) * (qt.ndim - 1)
+    )
+    return jnp.where(is_fe_i & Irwin, partfn_Fe(T), qt)
+
+
+def qr_interp_lines(T, Tref, T_gQT, gQT_284species, QTmask, Irwin=False):
+    """Return Q(T)/Q(Tref) for each selected atomic line.
+
+    Args:
+        T: Temperature in K.
+        Tref: Reference temperature in K.
+        T_gQT: Partition-function temperature grid.
+        gQT_284species: Partition-function grid, shaped (284, N_temperature).
+        QTmask: Partition-function row index for each selected line.
+        Irwin: Use the Irwin (1981) polynomial for Fe I only.
+
+    Returns:
+        Partition-function ratios with one entry per selected line.
+    """
+    qt = interp_QT_284(T, T_gQT, gQT_284species, Irwin)
+    qtref = interp_QT_284(Tref, T_gQT, gQT_284species, Irwin)
+    return qt[QTmask] / qtref[QTmask]
+
 
 def partfn_Fe(T):
-    """Partition function of Fe I from Irwin_1981.
+    """Return the Fe I partition function from Irwin (1981).
 
     Args:
-        T: temperature
+        T: Temperature in K.
 
     Returns:
-        partition function Q
+        Partition function Q(T).
     """
-    # Irwin_1981
-    a = np.zeros(6)
-    a[0] = -1.15609527e3
-    a[1] = 7.46597652e2
-    a[2] = -1.92865672e2
-    a[3] = 2.49658410e1
-    a[4] = -1.61934455e0
-    a[5] = 4.21182087e-2
-
-    Qln = 0.0
-    for i, a in enumerate(a):
-        Qln = Qln + a * np.log(T) ** i
-    Q = np.exp(Qln)
-    return Q
+    # The original polynomial is recentered at log(T) = 8 to reduce cancellation.
+    coefficients = jnp.array(
+        [
+            0.0421182087,
+            0.0653837980,
+            0.1024689680,
+            0.1314333440,
+            0.3516477760,
+            3.0877158816,
+        ]
+    )
+    return jnp.exp(jnp.polyval(coefficients, jnp.log(T) - 8.0))

--- a/src/exojax/database/kurucz/api.py
+++ b/src/exojax/database/kurucz/api.py
@@ -14,6 +14,7 @@ from exojax.database.core_atom._arrays import (
 from exojax.database.core_atom.line_strength import line_strength_atom
 from exojax.database.core_atom.pf import interp_QT_284
 from exojax.database.core_atom.pf import partfn_Fe
+from exojax.database.core_atom.pf import qr_interp_lines
 
 from exojax.database.core_atom.io import read_kurucz
 from exojax.database.core_atom.io import load_pf_Barklem2016
@@ -69,15 +70,16 @@ class AdbKurucz:
             nurange: wavenumber range list (cm-1) or wavenumber array
             margin: margin for nurange (cm-1)
             crit: line strength lower limit for extraction
-            Irwin: if True(1), the partition functions of Irwin1981 is used, otherwise those of Barklem&Collet2016
+            Irwin: Use Irwin (1981) for Fe I; other species use Barklem & Collet (2016).
             gpu_transfer: If True, generate JAX line arrays at initialization.
-            vmr_fraction: list of the vmr fractions of hydrogen, H2 molecule, helium. if None, typical quasi-"solar-fraction" will be applied.
+            vmr_fraction: VMR fractions of H, He, and H2, in that order. Defaults to [0.0, 0.16, 0.84].
 
         Note:
             (written with reference to moldb.py, but without using feather format)
         """
 
         self.dbtype = "kurucz"
+        self.Irwin = Irwin
 
         # load args
         self.kurucz_file = pathlib.Path(path).expanduser()
@@ -118,7 +120,7 @@ class AdbKurucz:
         )  # grid Q vs T vs Species
         self.Tref = Tref_original
         self.QTref_284 = np.array(
-            interp_QT_284(Tref_original, self.T_gQT, self.gQT_284species)
+            interp_QT_284(Tref_original, self.T_gQT, self.gQT_284species, self.Irwin)
         )
         # identify index of QT grid (gQT) for each line
         self._QTmask = self.make_QTmask(self._ielem, self._iion)
@@ -131,7 +133,6 @@ class AdbKurucz:
             self._elower,
             self.QTref_284,
             self._QTmask,
-            Irwin,
         )  # 211013
 
         ### MASKING ###
@@ -164,6 +165,22 @@ class AdbKurucz:
         """Generate JAX line arrays and metadata for the current selection."""
         _generate_atomic_jnp_arrays(self)
 
+    @property
+    def line_masses(self):
+        """Atomic masses for the current line selection, in amu."""
+        return self.atomicmass
+
+    def qr_interp_lines(self, T, Tref):
+        """Return Q(T)/Q(Tref) for the current line selection."""
+        return qr_interp_lines(
+            T,
+            Tref,
+            self.T_gQT,
+            self.gQT_284species,
+            self._QTmask,
+            getattr(self, "Irwin", False),
+        )
+
     def Atomic_gQT(self, atomspecies):
         """Select grid of partition function especially for the species of
         interest.
@@ -181,8 +198,7 @@ class AdbKurucz:
         return gQT
 
     def QT_interp(self, atomspecies, T):
-        """interpolated partition function The partition functions of Barklem &
-        Collet (2016) are adopted.
+        """Interpolate the selected partition function for an atomic species.
 
         Args:
             atomspecies: species e.g., "Fe 1"
@@ -191,6 +207,8 @@ class AdbKurucz:
         Returns:
             Q(T): interpolated in jnp.array for the Atomic Species
         """
+        if getattr(self, "Irwin", False) and atomspecies == "Fe 1":
+            return partfn_Fe(T)
         gQT = self.Atomic_gQT(atomspecies)
         QT = jnp.interp(T, self.T_gQT, gQT)
         return QT
@@ -212,8 +230,7 @@ class AdbKurucz:
         return QT
 
     def qr_interp(self, atomspecies, T):
-        """interpolated partition function ratio The partition functions of
-        Barklem & Collet (2016) are adopted.
+        """Return the selected partition-function ratio for an atomic species.
 
         Args:
             T: temperature
@@ -253,7 +270,9 @@ class AdbKurucz:
         """
         warn_msg = "Deprecated Use `atomll.interp_QT_284` instead"
         warnings.warn(warn_msg, FutureWarning)
-        return interp_QT_284(T, self.T_gQT, self.gQT_284species)
+        return interp_QT_284(
+            T, self.T_gQT, self.gQT_284species, getattr(self, "Irwin", False)
+        )
 
     def make_QTmask(self, ielem, iion):
         """Convert the species identifier to the index for Q(Tref) grid (gQT)

--- a/src/exojax/database/vald/api.py
+++ b/src/exojax/database/vald/api.py
@@ -19,6 +19,7 @@ from exojax.database.core_atom.io import pickup_param
 from exojax.database.core_atom.line_strength import line_strength_atom
 from exojax.database.core_atom.pf import interp_QT_284
 from exojax.database.core_atom.pf import partfn_Fe
+from exojax.database.core_atom.pf import qr_interp_lines
 from exojax.database.core_atom.misc import get_unique_species
 from exojax.database.core_atom.misc import sep_arr_of_sp
 
@@ -110,9 +111,9 @@ class AdbVald:
             nurange: wavenumber range list (cm-1) or wavenumber array
             margin: margin for nurange (cm-1)
             crit: line strength lower limit for extraction
-            Irwin: if True(1), the partition functions of Irwin1981 is used, otherwise those of Barklem&Collet2016
+            Irwin: Use Irwin (1981) for Fe I; other species use Barklem & Collet (2016).
             gpu_transfer: If True, generate JAX line arrays at initialization.
-            vmr_fraction: list of the vmr fractions of hydrogen, H2 molecule, helium. if None, typical quasi-"solar-fraction" will be applied.
+            vmr_fraction: VMR fractions of H, He, and H2, in that order. Defaults to [0.0, 0.16, 0.84].
             engine: ``"pytables"`` (default), its legacy alias ``"pandas"``,
                 or the optional ``"vaex"`` backend.
 
@@ -121,6 +122,7 @@ class AdbVald:
         """
 
         self.dbtype = "vald"
+        self.Irwin = Irwin
 
         # load args
         self.vald3_file = pathlib.Path(path).expanduser()  # VALD3 output
@@ -165,7 +167,7 @@ class AdbVald:
         )  # grid Q vs T vs Species
         self.Tref = Tref_original
         self.QTref_284 = np.array(
-            interp_QT_284(Tref_original, self.T_gQT, self.gQT_284species)
+            interp_QT_284(Tref_original, self.T_gQT, self.gQT_284species, self.Irwin)
         )
         # identify index of QT grid (gQT) for each line
         self._QTmask = self.make_QTmask(self._ielem, self._iion)
@@ -178,7 +180,6 @@ class AdbVald:
             self._elower,
             self.QTref_284,
             self._QTmask,
-            Irwin,
         )  # 211013
 
         ### MASKING ###
@@ -211,6 +212,22 @@ class AdbVald:
         """Generate JAX line arrays and metadata for the current selection."""
         _generate_atomic_jnp_arrays(self)
 
+    @property
+    def line_masses(self):
+        """Atomic masses for the current line selection, in amu."""
+        return self.atomicmass
+
+    def qr_interp_lines(self, T, Tref):
+        """Return Q(T)/Q(Tref) for the current line selection."""
+        return qr_interp_lines(
+            T,
+            Tref,
+            self.T_gQT,
+            self.gQT_284species,
+            self._QTmask,
+            getattr(self, "Irwin", False),
+        )
+
     def Atomic_gQT(self, atomspecies):
         """Select grid of partition function especially for the species of
         interest.
@@ -228,8 +245,7 @@ class AdbVald:
         return gQT
 
     def QT_interp(self, atomspecies, T):
-        """interpolated partition function The partition functions of Barklem &
-        Collet (2016) are adopted.
+        """Interpolate the selected partition function for an atomic species.
 
         Args:
             atomspecies: species e.g., "Fe 1"
@@ -238,6 +254,8 @@ class AdbVald:
         Returns:
             Q(T): interpolated in jnp.array for the Atomic Species
         """
+        if getattr(self, "Irwin", False) and atomspecies == "Fe 1":
+            return partfn_Fe(T)
         gQT = self.Atomic_gQT(atomspecies)
         QT = jnp.interp(T, self.T_gQT, gQT)
         return QT
@@ -259,8 +277,7 @@ class AdbVald:
         return QT
 
     def qr_interp(self, atomspecies, T):
-        """interpolated partition function ratio The partition functions of
-        Barklem & Collet (2016) are adopted.
+        """Return the selected partition-function ratio for an atomic species.
 
         Args:
             T: temperature
@@ -300,7 +317,9 @@ class AdbVald:
         """
         warn_msg = "Deprecated Use `atomll.interp_QT_284` instead"
         warnings.warn(warn_msg, FutureWarning)
-        return interp_QT_284(T, self.T_gQT, self.gQT_284species)
+        return interp_QT_284(
+            T, self.T_gQT, self.gQT_284species, getattr(self, "Irwin", False)
+        )
 
     def make_QTmask(self, ielem, iion):
         """Convert the species identifier to the index for Q(Tref) grid (gQT)
@@ -383,3 +402,4 @@ class AdbSepVald:
         self.T_gQT = adb.T_gQT
         self.QTref_284 = adb.QTref_284
         self.Tref = adb.Tref
+        self.Irwin = getattr(adb, "Irwin", False)

--- a/src/exojax/opacity/lpf/api.py
+++ b/src/exojax/opacity/lpf/api.py
@@ -25,9 +25,15 @@ class OpaDirect(OpaCalc):
 
     Attributes:
         method: Always "lpf" for this calculator
-        mdb: Molecular database instance
+        mdb: Molecular or atomic line database instance
         wavelength_order: Order of wavelength grid
         opainfo: Opacity information from initialization
+
+    Notes:
+        VALD and Kurucz support both ``xsvector`` and ``xsmatrix``. Their
+        H, He, and H2 partial pressures use the database's ``vmr_fraction``
+        in that order. Select a single atomic species before applying its
+        abundance to the cross section.
     """
 
     def __init__(
@@ -39,7 +45,7 @@ class OpaDirect(OpaCalc):
         """Initialize OpaDirect (LPF) opacity calculator.
 
         Args:
-            mdb: Molecular database (mdbExomol, mdbHitemp, mdbHitran, etc.)
+            mdb: Molecular or atomic line database
             nu_grid: Wavenumber grid in cm⁻¹
             wavelength_order: Order of wavelength grid
         """
@@ -110,6 +116,17 @@ class OpaDirect(OpaCalc):
             self._vmap_qt = None
             self._vmap_gamma = None
 
+    def _atomic_line_parameters(self, T, P):
+        """Use the same atomic parameter calculation for vectors and matrices."""
+        from exojax.opacity.lpf.lpf import vald
+
+        Tarr = jnp.atleast_1d(T)
+        Parr = jnp.atleast_1d(P)
+        return vald(
+            self.mdb, Tarr, Parr * self.mdb.vmrH,
+            Parr * self.mdb.vmrHe, Parr * self.mdb.vmrHH,
+        )
+
     def xsvector(self, T: float, P: float, Pself: float = 0.0) -> jnp.ndarray:
         """Compute cross section vector for given temperature and pressure.
 
@@ -149,10 +166,13 @@ class OpaDirect(OpaCalc):
             qt = self.mdb.qr_interp_lines(T, Tref_original)
             gammaL = gamma_natural(self.mdb.A)
             line_masses = self.mdb.line_masses
+        elif dbtype in ("kurucz", "vald"):
+            SijM, gammaLM, sigmaDM = self._atomic_line_parameters(T, P)
+            return xsvector_lpf(numatrix, sigmaDM[0], gammaLM[0], SijM[0])
         else:
             raise ValueError(
                 f"Unsupported database type for xsvector: '{dbtype}'. "
-                "Supported types: hitran, exomol, hydrogen"
+                "Supported types: hitran, exomol, hydrogen, kurucz, vald"
             )
 
         sigmaD = doppler_sigma(self.mdb.nu_lines, T, line_masses)
@@ -181,8 +201,6 @@ class OpaDirect(OpaCalc):
             ValueError: If database type is not supported
         """
         from exojax.database.core.broadening import gamma_natural
-        from exojax.database.core_atom.broadening import gamma_vald3
-        from exojax.database.core_atom.pf import interp_QT_284
         from exojax.opacity.lpf.lpf import xsmatrix as xsmatrix_lpf
 
         numatrix = self.opainfo
@@ -242,66 +260,7 @@ class OpaDirect(OpaCalc):
                 self.mdb.nu_lines, Tarr, self.mdb.line_masses
             )
         elif dbtype in ("kurucz", "vald"):
-            qt_284 = vmap(interp_QT_284, (0, None, None))(
-                Tarr, self.mdb.T_gQT, self.mdb.gQT_284species
-            )
-            qt_K = qt_284[:, self.mdb.QTmask]
-            qr_K = qt_K / self.mdb.QTref_284[self.mdb.QTmask]
-            vmapvald3 = jit(
-                vmap(
-                    gamma_vald3,
-                    (
-                        0,
-                        0,
-                        0,
-                        0,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                    ),
-                )
-            )
-            PH, PHe, PHH = (
-                Parr * self.mdb.vmrH,
-                Parr * self.mdb.vmrHe,
-                Parr * self.mdb.vmrHH,
-            )
-            gammaLM = vmapvald3(
-                Tarr,
-                PH,
-                PHH,
-                PHe,
-                self.mdb.ielem,
-                self.mdb.iion,
-                self.mdb.dev_nu_lines,
-                self.mdb.elower,
-                self.mdb.eupper,
-                self.mdb.atomicmass,
-                self.mdb.ionE,
-                self.mdb.gamRad,
-                self.mdb.gamSta,
-                self.mdb.vdWdamp,
-                1.0,
-            )
-            SijM = self._vmap_line_strength(
-                Tarr,
-                self.mdb.logsij0,
-                self.mdb.nu_lines,
-                self.mdb.elower,
-                qr_K,
-                Tref_original,
-            )
-            sigmaDM = self._vmap_doppler_sigma(
-                self.mdb.nu_lines, Tarr, self.mdb.atomicmass
-            )
+            SijM, gammaLM, sigmaDM = self._atomic_line_parameters(Tarr, Parr)
         else:
             raise ValueError(
                 f"Unsupported database type for xsmatrix: '{dbtype}'. "

--- a/src/exojax/opacity/lpf/lpf.py
+++ b/src/exojax/opacity/lpf/lpf.py
@@ -4,8 +4,7 @@ import jax.numpy as jnp
 from jax import custom_jvp, jit, vmap
 
 # vald
-from exojax.database.core_atom.broadening import gamma_vald3
-from exojax.database.core_atom.pf import interp_QT_284
+from exojax.database.core_atom.line_parameters import line_parameter_matrix
 from exojax.database.core.broadening  import gamma_exomol
 from exojax.database.core.broadening  import doppler_sigma
 from exojax.database.core.broadening  import gamma_natural
@@ -57,60 +56,12 @@ def vald(adb, Tarr, PH, PHe, PHH):
         sigmaDM: sigmaD matrix
 
     """
-    # Compute normalized partition function for each species
-    qt_284 = vmap(interp_QT_284, (0, None, None))(Tarr, adb.T_gQT, adb.gQT_284species)
-    qt = qt_284[:, adb.QTmask]
-    qr = qt / adb.QTref_284[adb.QTmask]
-    
-    # Compute line strength matrix
-    SijM = jit(vmap(line_strength,(0,None,None,None,0,None)))\
-        (Tarr, adb.logsij0, adb.nu_lines, adb.elower, qr, adb.Tref)
-    # Compute gamma parameters for the pressure and natural broadenings
-    gammaLM = jit(
-        vmap(
-            gamma_vald3,
-            (
-                0,
-                0,
-                0,
-                0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ),
-        )
-    )(
-        Tarr,
-        PH,
-        PHH,
-        PHe,
-        adb.ielem,
-        adb.iion,
-        adb.dev_nu_lines,
-        adb.elower,
-        adb.eupper,
-        adb.atomicmass,
-        adb.ionE,
-        adb.gamRad,
-        adb.gamSta,
-        adb.vdWdamp,
-        1.0,
+    qr = vmap(adb.qr_interp_lines, (0, None))(Tarr, adb.Tref)
+    return line_parameter_matrix(
+        Tarr, PH, PHe, PHH, qr, adb.logsij0, adb.nu_lines, adb.dev_nu_lines,
+        adb.elower, adb.eupper, adb.ielem, adb.iion, adb.line_masses, adb.ionE,
+        adb.gamRad, adb.gamSta, adb.vdWdamp, adb.Tref,
     )
-
-    # Compute doppler broadening
-    sigmaDM = jit(vmap(doppler_sigma, (None, 0, None)))(
-        adb.nu_lines, Tarr, adb.atomicmass
-    )
-
-    return SijM, gammaLM, sigmaDM
 
 
 
@@ -146,62 +97,17 @@ def vald_each(Tarr, PH, PHe, PHH, \
         sigmaDM: sigmaD matrix [N_layer x N_line]
 
     """
-    # Compute normalized partition function for each species
-    qt = qt_284_T[:, QTmask]
-    qr = qt / QTref_284[QTmask]
-
-    # Compute line strength matrix
-
-    SijM = jit(vmap(line_strength,(0,None,None,None,0,None)))\
-        (Tarr, logsij0, nu_lines, elower, qr, Tref)
-
-    SijM = jnp.nan_to_num(SijM, nan=0.0)
-
-    # Compute gamma parameters for the pressure and natural broadenings
-    gammaLM = jit(
-        vmap(
-            gamma_vald3,
-            (
-                0,
-                0,
-                0,
-                0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ),
-        )
-    )(
-        Tarr,
-        PH,
-        PHH,
-        PHe,
-        ielem,
-        iion,
-        dev_nu_lines,
-        elower,
-        eupper,
-        atomicmass,
-        ionE,
-        gamRad,
-        gamSta,
-        vdWdamp,
-        1.0,
+    qr = qt_284_T[:, QTmask] / QTref_284[QTmask]
+    SijM, gammaLM, sigmaDM = line_parameter_matrix(
+        Tarr, PH, PHe, PHH, qr, logsij0, nu_lines, dev_nu_lines,
+        elower, eupper, ielem, iion, atomicmass, ionE,
+        gamRad, gamSta, vdWdamp, Tref,
     )
-
-    # Compute doppler broadening
-    sigmaDMn = jit(vmap(doppler_sigma, (None, 0, None)))(nu_lines, Tarr, atomicmass)
-    sigmaDM = jnp.where(sigmaDMn != 0, sigmaDMn, 1.0)
-
-    return SijM, gammaLM, sigmaDM
+    return (
+        jnp.nan_to_num(SijM, nan=0.0),
+        gammaLM,
+        jnp.where(sigmaDM != 0, sigmaDM, 1.0),
+    )
 
 
 @jit

--- a/src/exojax/opacity/modit/modit.py
+++ b/src/exojax/opacity/modit/modit.py
@@ -19,7 +19,7 @@ from exojax.database.core.broadening import gamma_natural
 from exojax.database.core.broadening import normalized_doppler_sigma
 
 # vald
-from exojax.database.core_atom.broadening import gamma_vald3
+from exojax.database.core_atom.line_parameters import line_parameter_matrix
 from exojax.database.core_atom.pf import interp_QT_284
 
 # exomol
@@ -531,53 +531,11 @@ def vald_each(
         ngammaLM:  normalized gammaL matrix [N_layer x N_line]
         nsigmaDl:  normalized sigmaD matrix [N_layer x 1]
     """
-    # Compute normalized partition function for each species
-    qt = qt_284_T[:, QTmask]
-    qr = qt / QTref_284[QTmask]
-
-    # Compute line strength matrix
-    SijM = VMAP_LINE_STRENGTH(
-        Tarr, logsij0, dev_nu_lines, elower, qr, Tref
-    )
-
-    # Compute gamma parameters for the pressure and natural broadenings
-    gammaLM = jit(
-        vmap(
-            gamma_vald3,
-            (
-                0,
-                0,
-                0,
-                0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ),
-        )
-    )(
-        Tarr,
-        PH,
-        PHH,
-        PHe,
-        ielem,
-        iion,
-        dev_nu_lines,
-        elower,
-        eupper,
-        atomicmass,
-        ionE,
-        gamRad,
-        gamSta,
-        vdWdamp,
-        1.0,
+    qr = qt_284_T[:, QTmask] / QTref_284[QTmask]
+    SijM, gammaLM, _ = line_parameter_matrix(
+        Tarr, PH, PHe, PHH, qr, logsij0, dev_nu_lines, dev_nu_lines,
+        elower, eupper, ielem, iion, atomicmass, ionE,
+        gamRad, gamSta, vdWdamp, Tref,
     )
     ngammaLM = gammaLM / (dev_nu_lines / R)
     # Do NOT remove NaN because "set_ditgrid_matrix_vald_each" makes good use of them. # ngammaLM = jnp.nan_to_num(ngammaLM, nan = 0.0)
@@ -605,7 +563,9 @@ def vald_all(asdb, Tarr, PH, PHe, PHH, R):
     """
     gQT_284species = asdb.gQT_284species
     T_gQT = asdb.T_gQT
-    qt_284_T = vmap(interp_QT_284, (0, None, None))(Tarr, T_gQT, gQT_284species)
+    qt_284_T = vmap(interp_QT_284, (0, None, None, None))(
+        Tarr, T_gQT, gQT_284species, getattr(asdb, "Irwin", False)
+    )
 
     SijMS, ngammaLMS, nsigmaDlS = jit(
         vmap(
@@ -733,7 +693,8 @@ def set_ditgrid_matrix_vald_each(
     R,
     fT,
     dit_grid_resolution,
-    *kargs
+    *kargs,
+    Irwin=False,
 ):
     """Easy Setting of DIT Grid Matrix (dgm) using VALD.
 
@@ -760,6 +721,7 @@ def set_ditgrid_matrix_vald_each(
         fT:  function of temperature array
         dit_grid_resolution:  resolution of dgm
         *kargs:  arguments for fT
+        Irwin: Use the Irwin partition function for Fe I.
 
     Returns:
         dgm_ngammaL:  DIT Grid Matrix (dgm) of normalized gammaL [N_layer x N_DITgrid]
@@ -767,8 +729,10 @@ def set_ditgrid_matrix_vald_each(
     set_dgm_minmax = []
     Tarr_list = fT(*kargs)
     for Tarr in Tarr_list:
-        qt_284_T = vmap(interp_QT_284, (0, None, None))(Tarr, T_gQT, gQT_284species)
-        QTref_284 = jnp.array(interp_QT_284(Tref, T_gQT, gQT_284species))
+        qt_284_T = vmap(interp_QT_284, (0, None, None, None))(
+            Tarr, T_gQT, gQT_284species, Irwin
+        )
+        QTref_284 = interp_QT_284(Tref, T_gQT, gQT_284species, Irwin)
 
         SijM, ngammaLM, nsigmaDl = vald_each(
             Tarr,
@@ -865,7 +829,8 @@ def set_ditgrid_matrix_vald_all(asdb, PH, PHe, PHH, R, fT, dit_grid_resolution, 
             R,
             fT,
             dit_grid_resolution,
-            *kargs
+            *kargs,
+            Irwin=getattr(asdb, "Irwin", False),
         )
         dgm_ngammaLS_BeforePadding.append(dgm_ngammaL_sp)
         lendgm.append(dgm_ngammaL_sp.shape[1])

--- a/tests/unittests/database/core_atom/test_partfn.py
+++ b/tests/unittests/database/core_atom/test_partfn.py
@@ -3,8 +3,10 @@
 - Test polynomial expansion of the partition function of iron by Irwin1981
 """
 
-import pytest
+import jax
+import jax.numpy as jnp
 import numpy as np
+import pytest
 from exojax.database.core_atom.pf import partfn_Fe
 
 
@@ -12,3 +14,21 @@ def test_partfn_Fe():
     tabulated = 5.62138956e0  # Table 1 of Irwin (1981)
     diff = np.log(partfn_Fe(16000)) - tabulated
     assert diff < 1e-8
+
+
+@pytest.mark.parametrize("enable_x64,rtol", [(False, 3.0e-6), (True, 1.0e-11)])
+def test_partfn_fe_matches_original_polynomial(enable_x64, rtol):
+    jax.config.update("jax_enable_x64", enable_x64)
+    temperatures = np.array([296.0, 1000.0, 3000.0, 6000.0, 10000.0, 16000.0])
+    # Original Irwin coefficients in ascending powers of log(T).
+    coefficients = [-1.15609527e3, 7.46597652e2, -1.92865672e2,
+                    2.49658410e1, -1.61934455, 4.21182087e-2]
+    expected = np.exp(sum(
+        coefficient * np.log(temperatures) ** power
+        for power, coefficient in enumerate(coefficients)
+    ))
+    dtype = np.float64 if enable_x64 else np.float32
+    actual = jax.jit(partfn_Fe)(jnp.asarray(temperatures, dtype=dtype))
+
+    assert actual.dtype == dtype
+    np.testing.assert_allclose(actual, expected, rtol=rtol, atol=0.0)

--- a/tests/unittests/database/core_atom/test_partition_lines.py
+++ b/tests/unittests/database/core_atom/test_partition_lines.py
@@ -1,0 +1,81 @@
+"""Atomic partition functions must match line strengths and selected species."""
+
+import importlib
+
+import jax
+import numpy as np
+import pytest
+
+from exojax.database.core.line_strength import line_strength
+from exojax.database.core_atom.pf import partfn_Fe
+from exojax.utils.constants import ccgs, hcperk
+
+
+@pytest.fixture(params=["vald", "kurucz"])
+def make_adb(request, monkeypatch, tmp_path):
+    api = importlib.import_module(f"exojax.database.{request.param}.api")
+    transitions = (
+        [1.0e6, 2.0e6, 3.0e6], [1000.0, 1001.0, 1002.0],
+        [0.0, 10.0, 20.0], [1000.0, 1011.0, 1022.0],
+        [3.0, 4.0, 4.0], [0.0, 0.5, 0.5], [1.0, 1.5, 1.5],
+        [26, 26, 11], [1, 2, 1],
+        [8.0, 8.1, 8.2], [-6.0, -6.1, -6.2], [-7.0, -7.1, -7.2],
+    )
+
+    def read_transitions(_):
+        return tuple(np.array(values) for values in transitions)
+
+    if request.param == "vald":
+        monkeypatch.setattr(api, "_load_vald_dataframe", lambda *args: None)
+        monkeypatch.setattr(api, "pickup_param", read_transitions)
+        adb_class = api.AdbVald
+    else:
+        monkeypatch.setattr(api, "read_kurucz", read_transitions)
+        adb_class = api.AdbKurucz
+    return lambda **kwargs: adb_class(tmp_path / "synthetic.lines", **kwargs)
+
+
+@pytest.mark.parametrize("irwin", [False, True])
+def test_atomic_partition_ratio_reference_and_masking(make_adb, irwin):
+    adb = make_adb(Irwin=irwin)
+    for reference in (adb.Tref, 1100.0):
+        np.testing.assert_array_equal(adb.qr_interp_lines(reference, reference), np.ones(3))
+    ratios = jax.jit(adb.qr_interp_lines)(1800.0, adb.Tref)
+    assert ratios.shape == (3,)
+    assert np.all(np.isfinite(ratios))
+    np.testing.assert_array_equal(adb.line_masses, [55.847, 55.847, 22.98981])
+
+    mask = np.array([False, True, True])
+    adb.masking(mask)
+    np.testing.assert_array_equal(adb.line_masses, [55.847, 22.98981])
+    np.testing.assert_allclose(adb.qr_interp_lines(1800.0, adb.Tref), ratios[mask])
+
+
+def test_atomic_irwin_line_strength_uses_consistent_partition_function(make_adb):
+    barklem = make_adb()
+    irwin = make_adb(Irwin=True)
+    np.testing.assert_array_equal(irwin.Sij0[1:], barklem.Sij0[1:])
+
+    for temperature in (irwin.Tref, 1800.0):
+        partition = np.array([
+            np.interp(temperature, barklem.T_gQT, barklem.gQT_284species[index])
+            for index in np.asarray(barklem.QTmask)
+        ])
+        partition[0] = float(partfn_Fe(temperature))
+        expected = (
+            -np.asarray(irwin.A) * np.asarray(irwin.gupper)
+            * np.exp(-hcperk * np.asarray(irwin.elower) / temperature)
+            * np.expm1(-hcperk * irwin.nu_lines / temperature)
+            / (8.0 * np.pi * ccgs * irwin.nu_lines**2 * partition)
+        )
+        actual = line_strength(
+            temperature, irwin.logsij0, irwin.nu_lines, irwin.elower,
+            irwin.qr_interp_lines(temperature, irwin.Tref), irwin.Tref,
+        )
+        baseline = line_strength(
+            temperature, barklem.logsij0, barklem.nu_lines, barklem.elower,
+            barklem.qr_interp_lines(temperature, barklem.Tref), barklem.Tref,
+        )
+        np.testing.assert_allclose(actual, expected, rtol=1.0e-11, atol=0.0)
+        np.testing.assert_array_equal(actual[1:], baseline[1:])
+    assert not np.isclose(actual[0] / baseline[0], 1.0, rtol=1.0e-3)

--- a/tests/unittests/opacity/lpf/test_api_xsmatrix.py
+++ b/tests/unittests/opacity/lpf/test_api_xsmatrix.py
@@ -1,41 +1,149 @@
-from types import SimpleNamespace
+import importlib
 
+import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from exojax.opacity import OpaDirect
+from exojax.opacity.lpf.lpf import vald, xsmatrix
 
 
-def test_opadirect_atomic_xsmatrix_with_different_line_and_layer_counts():
-    nline = 3
-    mdb = SimpleNamespace(
-        dbtype="vald",
-        nu_lines=np.array([1000.0, 1001.0, 1002.0]),
-        T_gQT=jnp.array([300.0, 3000.0]),
-        gQT_284species=jnp.array([[1.0, 2.0], [2.0, 4.0]]),
-        QTmask=jnp.array([0, 1, 0]),
-        QTref_284=jnp.array([1.0, 2.0]),
-        vmrH=0.0,
-        vmrHe=0.16,
-        vmrHH=0.84,
-        ielem=jnp.full(nline, 26),
-        iion=jnp.ones(nline),
-        dev_nu_lines=jnp.array([1000.0, 1001.0, 1002.0]),
-        elower=jnp.array([0.0, 10.0, 20.0]),
-        eupper=jnp.array([1000.0, 1011.0, 1022.0]),
-        atomicmass=jnp.full(nline, 55.845),
-        ionE=jnp.full(nline, 7.9),
-        gamRad=jnp.full(nline, 8.0),
-        gamSta=jnp.zeros(nline),
-        vdWdamp=jnp.full(nline, -7.0),
-        logsij0=jnp.log(jnp.array([1.0e-20, 2.0e-20, 3.0e-20])),
-    )
-    nu_grid = np.linspace(999.0, 1003.0, 5)
-    opa = OpaDirect(mdb, nu_grid=nu_grid)
-
-    xsmatrix = opa.xsmatrix(
-        jnp.array([1000.0, 1500.0]), jnp.array([0.1, 0.01])
+@pytest.fixture(params=["vald", "kurucz"])
+def make_adb(request, monkeypatch, tmp_path):
+    """Construct real adapters for Fe I, Fe II, and Na I transitions."""
+    api = importlib.import_module(f"exojax.database.{request.param}.api")
+    transitions = (
+        [1.0e6, 2.0e6, 3.0e6, 4.0e6], [1000.0, 1001.0, 1002.0, 1003.0],
+        [0.0, 10.0, 20.0, 30.0], [1000.0, 1011.0, 1022.0, 1033.0],
+        [3.0, 4.0, 4.0, 7.0], [0.0, 0.5, 0.5, 2.0], [1.0, 1.5, 1.5, 3.0],
+        [26, 26, 11, 26], [1, 2, 1, 1],
+        [8.0, 8.1, 8.2, 8.3], [-6.0, -6.1, -6.2, -6.3],
+        [-7.0, -7.1, -7.2, -7.3],
     )
 
-    assert xsmatrix.shape == (2, len(nu_grid))
-    assert jnp.all(jnp.isfinite(xsmatrix))
+    def read_transitions(_):
+        return tuple(np.array(values) for values in transitions)
+
+    if request.param == "vald":
+        monkeypatch.setattr(api, "_load_vald_dataframe", lambda *args: None)
+        monkeypatch.setattr(api, "pickup_param", read_transitions)
+        adb_class = api.AdbVald
+    else:
+        monkeypatch.setattr(api, "read_kurucz", read_transitions)
+        adb_class = api.AdbKurucz
+    return lambda **kwargs: adb_class(tmp_path / "synthetic.lines", **kwargs)
+
+
+@pytest.mark.parametrize("irwin", [False, True])
+def test_opadirect_atomic_vectors_match_matrix_and_lowlevel_lpf(make_adb, irwin):
+    adb = make_adb(Irwin=irwin, vmr_fraction=[0.1, 0.2, 0.7])
+    nu_grid = np.linspace(999.8, 1003.2, 86)
+    opa = OpaDirect(adb, nu_grid=nu_grid)
+    temperatures = jnp.array([1300.0, 1800.0])
+    pressures = jnp.array([0.01, 0.1])
+
+    actual = opa.xsmatrix(temperatures, pressures)
+    vectors = jnp.stack([
+        opa.xsvector(temperature, pressure)
+        for temperature, pressure in zip(temperatures, pressures)
+    ])
+    strengths, gammas, sigmas = vald(
+        adb, temperatures, pressures * adb.vmrH,
+        pressures * adb.vmrHe, pressures * adb.vmrHH,
+    )
+    expected = xsmatrix(opa.opainfo, sigmas, gammas, strengths)
+
+    assert len(adb.nu_lines) != len(temperatures)
+    assert actual.shape == (2, len(nu_grid))
+    assert np.all(np.isfinite(actual))
+    assert np.all(actual > 0.0)
+    np.testing.assert_allclose(actual, vectors, rtol=1.0e-12, atol=0.0)
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-12, atol=0.0)
+
+
+def test_opadirect_atomic_temperature_and_pressure_gradients(make_adb):
+    adb = make_adb(Irwin=True, vmr_fraction=[0.1, 0.2, 0.7])
+    nu_grid = np.linspace(999.8, 1003.2, 86)
+    opa = OpaDirect(adb, nu_grid=nu_grid)
+    line_center = np.argmin(np.abs(nu_grid - adb.nu_lines[0]))
+
+    def log_opacity(temperature, pressure):
+        return jnp.log(opa.xsvector(temperature, pressure)[line_center])
+
+    def log_matrix_opacity(temperature, pressure):
+        matrix = opa.xsmatrix(
+            jnp.array([temperature, 1300.0]), jnp.array([pressure, 0.01])
+        )
+        return jnp.log(matrix[0, line_center])
+
+    compiled = jax.jit(log_opacity)
+    temperature, pressure = 1800.0, 0.1
+    np.testing.assert_allclose(
+        compiled(temperature, pressure), log_opacity(temperature, pressure),
+        rtol=1.0e-12,
+    )
+    actual = jax.jit(jax.grad(log_opacity, argnums=(0, 1)))(temperature, pressure)
+    matrix_value, matrix_grad = jax.jit(
+        jax.value_and_grad(log_matrix_opacity, argnums=(0, 1))
+    )(temperature, pressure)
+    np.testing.assert_allclose(matrix_value, compiled(temperature, pressure), rtol=1.0e-12)
+    np.testing.assert_allclose(matrix_grad, actual, rtol=1.0e-10, atol=1.0e-12)
+    temperature_step, pressure_step = 0.1, 1.0e-5
+    expected = (
+        (compiled(temperature + temperature_step, pressure)
+         - compiled(temperature - temperature_step, pressure)) / (2 * temperature_step),
+        (compiled(temperature, pressure + pressure_step)
+         - compiled(temperature, pressure - pressure_step)) / (2 * pressure_step),
+    )
+
+    assert np.all(np.isfinite(actual))
+    assert np.all(np.abs(actual) > 1.0e-8)
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-4, atol=1.0e-9)
+
+
+@pytest.mark.parametrize("irwin", [False, True])
+def test_separated_atomic_line_parameters_preserve_values_and_padding(make_adb, irwin):
+    from exojax.database import AdbSepVald
+    from exojax.database.core_atom.pf import interp_QT_284
+    from exojax.opacity.lpf.lpf import vald_each
+    from exojax.opacity.modit.modit import vald_all
+
+    adb = make_adb(Irwin=irwin)
+    asdb = AdbSepVald(adb)
+    temperatures = jnp.array([1300.0, 1800.0, 2300.0])
+    pressures = jnp.array([0.01, 0.1, 1.0])
+    ph, phe, phh = pressures * 0.1, pressures * 0.2, pressures * 0.7
+    resolution = 1.0e5
+    expected = vald(adb, temperatures, ph, phe, phh)
+    strengths, ngamma, nsigma = vald_all(asdb, temperatures, ph, phe, phh, resolution)
+    partition = jax.vmap(interp_QT_284, (0, None, None, None))(
+        temperatures, adb.T_gQT, adb.gQT_284species, irwin,
+    )
+
+    assert asdb.L_max == 2
+    assert np.any(asdb.nu_lines == 0.0)
+    for index, (element, ion) in enumerate(np.asarray(asdb.uspecies)):
+        selected = np.asarray((adb.ielem == element) & (adb.iion == ion))
+        valid = asdb.nu_lines[index] != 0.0
+        widths = asdb.nu_lines[index, valid] / resolution
+        actual = (
+            strengths[index][:, valid],
+            ngamma[index][:, valid] * widths,
+            nsigma[index] * widths,
+        )
+        for values, reference in zip(actual, expected):
+            np.testing.assert_allclose(values, reference[:, selected], rtol=1.0e-12, atol=0.0)
+
+        padded = vald_each(
+            temperatures, ph, phe, phh, partition, asdb.QTmask[index], asdb.QTref_284,
+            asdb.logsij0[index], asdb.nu_lines[index], element, ion,
+            asdb.dev_nu_lines[index], asdb.elower[index], asdb.eupper[index],
+            asdb.atomicmass[index], asdb.ionE[index], asdb.gamRad[index],
+            asdb.gamSta[index], asdb.vdWdamp[index], asdb.Tref,
+        )
+        for values, reference in zip(padded, expected):
+            np.testing.assert_allclose(values[:, valid], reference[:, selected], rtol=1.0e-12, atol=0.0)
+        assert np.all(~np.isfinite(ngamma[index][:, ~valid]))
+        assert np.all(np.asarray(padded[0])[:, ~valid] == 0.0)
+        assert np.all(np.asarray(padded[2])[:, ~valid] == 1.0)


### PR DESCRIPTION
`OpaDirect.xsvector` rejected VALD and Kurucz databases even though `xsmatrix` supported them, and their line-strength and broadening calculations were duplicated across Direct, LPF, and MODIT. Both Direct entry points now use the same atomic line-parameter calculation, also shared by the low-level LPF/MODIT paths.

Add `line_masses` and `qr_interp_lines(T, Tref)` to both atomic databases. The selected Fe I partition function now consistently determines reference line strengths and temperature-dependent ratios, including species-separated MODIT. Irwin's existing polynomial is evaluated in a numerically stable, differentiable JAX form.

Validation: **53 focused tests passed**, covering both databases, vector/matrix agreement, temperature/pressure gradients against finite differences, partition-function normalization, Irwin line strengths against the Einstein-A expression, and LPF/MODIT padding behavior. Small default-setting Direct/LPF/MODIT results matched their pre-refactor values; the legacy VALD pickle remained usable.

```sh
JAX_PLATFORMS=cpu NUMBA_CACHE_DIR=/tmp/exojax-atomic-numba-cache \
python -m pytest -q \
  tests/unittests/database/core_atom \
  tests/unittests/database/vald \
  tests/unittests/opacity/lpf \
  tests/unittests/opacity/modit/test_vald_all.py \
  tests/unittests/opacity/modit/test_xsmatrix_vald.py \
  tests/unittests/opacity/test_hitran_pressure_autodiff.py
```

Related to #539. This completes the Direct vector/matrix API work covered here. The issue also discusses adoption of RADIS atomic common APIs, and atomic `OpaModit`/`OpaPremodit` class support remains outside this change, so this PR does not close it.
