### PR TITLE
Add RADIS-backed Kurucz database loading

### DIFF
--- a/documents/userguide.rst
+++ b/documents/userguide.rst
@@ -8,6 +8,7 @@ Databases
    userguide/mdb.rst
    userguide/moldb.rst
    userguide/exomol.rst
+   userguide/kurucz.rst
    userguide/hitran.rst
    userguide/api.rst
    userguide/nonair.rst

--- a/documents/userguide/kurucz.rst
+++ b/documents/userguide/kurucz.rst
@@ -1,0 +1,49 @@
+Kurucz atomic lines
+==================
+
+Load an existing Kurucz line list with ``AdbKurucz(path, nurange=nu_grid)``.
+To let RADIS download and cache one atomic species, use the explicit
+``from_radis`` constructor:
+
+.. code-block:: python
+
+    import numpy as np
+    from exojax.database import AdbKurucz
+    from exojax.opacity import OpaDirect
+
+    nu_grid = np.linspace(19950.0, 20050.0, 2000)  # vacuum cm-1
+    adb = AdbKurucz.from_radis(
+        "Fe_I", nu_grid,
+        local_databases=".database/radis-kurucz",
+        margin=10.0,
+        gpu_transfer=False,
+    )
+    # Select lines on the host before generating JAX line arrays if needed.
+    adb.generate_jnp_arrays()
+    opa = OpaDirect(adb, nu_grid)
+    cross_section = opa.xsvector(3000.0, 0.1)  # K, bar; output in cm2
+    print(adb.provenance)
+
+``from_radis`` requires a finite positive wavenumber interval or grid. Its
+``margin`` expands the fetch interval as well as the ExoJAX selection interval.
+Supported species must have ExoJAX partition functions and atomic metadata;
+examples are ``Fe_I`` and ``Fe_II``. Unsupported species are rejected before
+downloading. Missing or nonfinite line parameters are reported as errors.
+
+RADIS manages downloads, cache registration, and cache policies. ``cache`` is
+passed to RADIS, and the default ``True`` reuses registered cache files when
+available. The initial download covers the species line list; the requested
+wavenumber interval filters the cached data loaded into ExoJAX.
+``databank_name`` defaults to ``"ExoJAX-Kurucz-{molecule}"``; choose
+a different name when maintaining a separate cache for the same species.
+``engine="pytables"`` is the default, and ``"vaex"`` requires that optional
+backend. ``adb.provenance`` records the species, RADIS version, and cache paths;
+download URLs and dates remain in RADIS cache metadata.
+
+Line positions and Einstein A coefficients come from RADIS. Its air/vacuum
+conversion can produce small differences from the existing local-file reader.
+ExoJAX continues to compute the reference line strengths, partition functions,
+and broadening. ``Irwin=True`` selects the Irwin polynomial for Fe I consistently
+at the reference and evaluation temperatures; other species retain the
+Barklem and Collet partition functions. ``gpu_transfer=False`` delays line-array
+transfer; partition-function calculations still use JAX.

--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -83,6 +83,28 @@ def get_auto_memory_mapping_engine():
     return get_auto_MEMORY_MAPPING_ENGINE()
 
 
+def fetch_kurucz_dataframe(
+    species, *, nurange, local_databases, databank_name, engine, cache
+):
+    """Fetch Kurucz lines as pandas data, retaining RADIS cache paths."""
+    fetch = _import_attr(
+        "radis.io.kurucz", "fetch_kurucz", "Kurucz database download"
+    )
+    return fetch(
+        molecule=species,
+        local_databases=local_databases,
+        databank_name=databank_name,
+        load_wavenum_min=nurange[0],
+        load_wavenum_max=nurange[1],
+        cache=cache,
+        engine=engine,
+        output="pandas",
+        return_local_path=True,
+        verbose=False,
+        parallel=False,
+    )
+
+
 def get_exomol_mdb_class():
     """Return RADIS common-API ExoMol MDB class."""
     return _import_attr(

--- a/src/exojax/database/kurucz/_radis.py
+++ b/src/exojax/database/kurucz/_radis.py
@@ -1,0 +1,88 @@
+"""Validation and host-array conversion for the optional RADIS Kurucz reader."""
+
+import numpy as np
+
+from exojax.database.core_atom.io import (
+    PeriodicTable,
+    load_atomicdata,
+    load_ionization_energies,
+    load_pf_Barklem2016,
+    pick_ionE,
+)
+
+
+def validate_species(species):
+    """Resolve a supported spectroscopic species before downloading lines."""
+    if not isinstance(species, str) or species.count("_") != 1:
+        raise ValueError("Use an atomic species such as 'Fe_I' or 'Fe_II'.")
+    symbol, stage = species.split("_")
+    if symbol not in PeriodicTable or stage not in ("I", "II", "III"):
+        raise ValueError(f"Unsupported atomic species {species!r}.")
+    ielem = int(np.flatnonzero(PeriodicTable == symbol)[0])
+    iion = len(stage)
+    _, partition_functions = load_pf_Barklem2016()
+    if species not in partition_functions["T[K]"].values:
+        raise ValueError(f"No ExoJAX partition function is available for {species}.")
+    if ielem not in load_atomicdata()["ielem"].values:
+        raise ValueError(f"No ExoJAX atomic metadata is available for {species}.")
+    try:
+        ion_energy = pick_ionE(ielem, iion, load_ionization_energies())
+    except (ValueError, IndexError) as exc:
+        raise ValueError(f"No ionization energy is available for {species}.") from exc
+    if not np.isfinite(ion_energy) or ion_energy <= 0.0:
+        raise ValueError(f"No positive ionization energy is available for {species}.")
+    return ielem, iion
+
+
+def validate_options(nurange, margin, crit, vmr_fraction):
+    """Validate the finite spectral interval and optional selection settings."""
+    nu = np.asarray(nurange, dtype=float)
+    if nu.ndim != 1 or nu.size < 2 or not np.all(np.isfinite(nu)) or np.any(nu <= 0):
+        raise ValueError("nurange must contain at least two finite positive wavenumbers.")
+    if np.min(nu) == np.max(nu):
+        raise ValueError("nurange must span a nonzero interval.")
+    for name, value in (("margin", margin), ("crit", crit)):
+        if not np.isscalar(value) or not np.isfinite(value) or value < 0:
+            raise ValueError(f"{name} must be finite and nonnegative.")
+    if vmr_fraction is not None:
+        fractions = np.asarray(vmr_fraction, dtype=float)
+        if fractions.shape != (3,) or not np.all(np.isfinite(fractions)) or np.any(
+            (fractions < 0.0) | (fractions > 1.0)
+        ):
+            raise ValueError("vmr_fraction must contain three finite fractions for H, He, H2.")
+    return [float(np.min(nu)), float(np.max(nu))]
+
+
+def transitions_from_dataframe(dataframe, ielem, iion):
+    """Convert one RADIS species into sorted, aligned NumPy line arrays.
+
+    RADIS supplies vacuum wavenumbers and level energies in cm-1, Einstein A
+    in s-1, and the original logarithmic damping coefficients. Signed Kurucz
+    level energies are retained. No air/vacuum conversion is repeated here.
+    """
+    columns = ("A", "wav", "El", "Eu", "gu", "jl", "ju", "gamRad", "gamSta", "gamvdW")
+    missing = set(columns + ("species",)) - set(dataframe.columns)
+    if missing:
+        raise ValueError(f"RADIS Kurucz data are missing columns: {', '.join(sorted(missing))}.")
+    arrays = [dataframe[column].to_numpy(dtype=float) for column in columns]
+    for name, values in zip(columns, arrays):
+        if not np.all(np.isfinite(values)):
+            raise ValueError(f"RADIS Kurucz column {name!r} contains missing or nonfinite values.")
+    for name in ("A", "wav", "gu"):
+        if np.any(arrays[columns.index(name)] <= 0.0):
+            raise ValueError(f"RADIS Kurucz column {name!r} must be positive.")
+    if np.any(arrays[5] < 0.0) or np.any(arrays[6] < 0.0):
+        raise ValueError("RADIS Kurucz angular momenta must be nonnegative.")
+    for code in dataframe["species"].unique():
+        try:
+            element, charge = (int(part) for part in str(code).split("."))
+        except ValueError as exc:
+            raise ValueError(f"Invalid RADIS Kurucz species code {code!r}.") from exc
+        if (element, charge + 1) != (ielem, iion):
+            raise ValueError("RADIS Kurucz data do not match the requested species.")
+    order = np.argsort(arrays[1], kind="stable")
+    arrays = [values[order] for values in arrays]
+    size = len(order)
+    return tuple(arrays[:7]) + (
+        np.full(size, ielem, dtype=int), np.full(size, iion, dtype=int)
+    ) + tuple(arrays[7:])

--- a/src/exojax/database/kurucz/api.py
+++ b/src/exojax/database/kurucz/api.py
@@ -19,6 +19,10 @@ from exojax.database.core_atom.pf import qr_interp_lines
 from exojax.database.core_atom.io import read_kurucz
 from exojax.database.core_atom.io import load_pf_Barklem2016
 from exojax.database.core_atom.io import PeriodicTable
+from exojax.database._common.radis_adapter import (
+    fetch_kurucz_dataframe,
+    get_radis_version,
+)
 from exojax.utils.constants import Tref_original
 
 __all__ = ["AdbKurucz"]
@@ -78,11 +82,79 @@ class AdbKurucz:
             (written with reference to moldb.py, but without using feather format)
         """
 
+        self.kurucz_file = pathlib.Path(path).expanduser()
+        print("Reading Kurucz file")
+        self._initialize(
+            read_kurucz(self.kurucz_file), nurange, margin, crit, Irwin,
+            gpu_transfer, vmr_fraction,
+        )
+
+    @classmethod
+    def from_radis(
+        cls, species, nurange, *, local_databases=None, cache=True,
+        databank_name="ExoJAX-Kurucz-{molecule}", engine="pytables", margin=0.0,
+        crit=0.0, Irwin=False, gpu_transfer=True, vmr_fraction=None,
+    ):
+        """Download or reuse one Kurucz species through RADIS.
+
+        Args:
+            species: Spectroscopic species, for example ``"Fe_I"`` or ``"Fe_II"``.
+            nurange: Finite positive wavenumber interval or grid in cm-1.
+            local_databases: RADIS cache directory, or its configured default.
+            cache: RADIS cache policy; True reuses cached data.
+            databank_name: RADIS registration name; ``{molecule}`` is replaced
+                with the species. Use a distinct name for a separate cache.
+            engine: RADIS cache engine, ``"pytables"`` or ``"vaex"``.
+            margin: Extra wavenumber coverage in cm-1.
+            crit: Nonnegative reference line-strength cutoff in cm.
+            Irwin: Use Irwin (1981) for Fe I only.
+            gpu_transfer: Generate JAX line arrays immediately if True.
+            vmr_fraction: VMR fractions of H, He, and H2, in that order.
+
+        Returns:
+            An AdbKurucz with ExoJAX partition functions and broadening.
+
+        Notes:
+            RADIS controls downloads and cache registration. ``provenance``
+            records the species, RADIS version, and returned cache paths.
+            RADIS line positions and A coefficients are retained; its air/vacuum
+            conversion can differ from the local-file constructor.
+        """
+        from exojax.database.kurucz._radis import (
+            transitions_from_dataframe, validate_options, validate_species,
+        )
+
+        nurange = validate_options(nurange, margin, crit, vmr_fraction)
+        ielem, iion = validate_species(species)
+        if engine not in ("pytables", "vaex"):
+            raise ValueError("engine must be 'pytables' or 'vaex'.")
+        dataframe, local_paths = fetch_kurucz_dataframe(
+            species,
+            nurange=[max(0.0, nurange[0] - margin), nurange[1] + margin],
+            local_databases=local_databases,
+            databank_name=databank_name,
+            engine=engine,
+            cache=cache,
+        )
+        instance = cls.__new__(cls)
+        instance.kurucz_file = None
+        instance.provenance = {
+            "backend": "radis",
+            "radis_version": get_radis_version(),
+            "species": species,
+            "local_paths": [str(path) for path in local_paths],
+        }
+        instance._initialize(
+            transitions_from_dataframe(dataframe, ielem, iion), nurange, margin,
+            crit, Irwin, gpu_transfer, vmr_fraction,
+        )
+        return instance
+
+    def _initialize(self, transitions, nurange, margin, crit, Irwin,
+                    gpu_transfer, vmr_fraction):
+        """Initialize either reader's normalized host transitions."""
         self.dbtype = "kurucz"
         self.Irwin = Irwin
-
-        # load args
-        self.kurucz_file = pathlib.Path(path).expanduser()
         self.nurange = [np.min(nurange), np.max(nurange)]
         self.margin = margin
         self.crit = crit
@@ -95,8 +167,6 @@ class AdbKurucz:
         else:
             self.vmrH, self.vmrHe, self.vmrHH = vmr_fraction
 
-        # load kurucz file
-        print("Reading Kurucz file")
         (
             self._A,
             self.nu_lines,
@@ -110,7 +180,7 @@ class AdbKurucz:
             self._gamRad,
             self._gamSta,
             self._vdWdamp,
-        ) = read_kurucz(self.kurucz_file)
+        ) = transitions
 
         # load the partition functions (for 284 atomic species)
         pfTdat, self.pfdat = load_pf_Barklem2016()  # Barklem & Collet (2016)

--- a/tests/unittests/database/kurucz/test_radis.py
+++ b/tests/unittests/database/kurucz/test_radis.py
@@ -1,0 +1,166 @@
+"""Exercise the RADIS reader, cache, and ExoJAX activation without networking."""
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import jax
+import numpy as np
+import pandas as pd
+import pytest
+
+from exojax.database.core_atom.io import read_kurucz
+from exojax.database.kurucz import api
+from exojax.database.kurucz._radis import transitions_from_dataframe
+from exojax.opacity import OpaDirect
+
+
+def _line(wavelength, lower, upper, jl, ju, species="26.00"):
+    row = [" "] * 160
+    fields = (
+        (0, 11, f"{wavelength:11.4f}"), (11, 18, f"{-1.0:7.3f}"),
+        (18, 24, f"{species:>6}"), (24, 36, f"{lower:12.3f}"),
+        (36, 41, f"{jl:5.1f}"), (42, 52, "lower     "),
+        (52, 64, f"{upper:12.3f}"), (64, 69, f"{ju:5.1f}"),
+        (70, 80, "upper     "), (80, 86, "  8.00"),
+        (86, 92, " -6.00"), (92, 98, " -7.00"), (106, 109, " 56"),
+    )
+    for start, stop, value in fields:
+        row[start:stop] = value
+    return "".join(row) + "\n"
+
+
+@pytest.fixture
+def offline_kurucz(monkeypatch, tmp_path, request):
+    """Keep the real RADIS parser/cache while replacing transport and registry."""
+    from radis.api import dbmanager
+    from radis.api.kuruczapi import KuruczDatabaseManager
+
+    fetch_module = importlib.import_module("radis.io.kurucz")
+    species = getattr(request, "param", "Fe_I")
+    code = {"Fe_I": "26.00", "Fe_II": "26.01"}[species]
+    source = tmp_path / "gf2600.all"
+    source.write_text(
+        _line(500.0, 100.0, 20100.0, 0.5, 1.5, code)
+        + _line(600.0, 22000.0, 5000.0, 2.5, 1.5, code)
+        + _line(550.0, 0.0, 18181.0, 0.5, 1.5, code)
+    )
+    state = SimpleNamespace(source=source, downloads=0, registry={}, species=species,
+                            local_databases=str(tmp_path / "cache"))
+
+    def download(manager, urls, targets, total=None):
+        state.downloads += 1
+        opener = SimpleNamespace(abspath=lambda url: str(source))
+        return manager.parse_to_local_file(opener, urls[0], targets[0], pbar_active=False)
+
+    def register(manager, get_main_files):
+        state.registry[manager.name] = {
+            "path": [manager.actual_file], "download_url": [manager.actual_url],
+        }
+
+    monkeypatch.setattr(dbmanager.DatabaseManager, "is_registered",
+                        lambda manager: manager.name in state.registry)
+    monkeypatch.setattr(dbmanager, "getDatabankEntries", state.registry.__getitem__)
+    monkeypatch.setattr(fetch_module, "getDatabankEntries", state.registry.__getitem__)
+    monkeypatch.setattr(KuruczDatabaseManager, "download_and_parse", download)
+    monkeypatch.setattr(KuruczDatabaseManager, "register", register)
+    state.create = lambda **kwargs: api.AdbKurucz.from_radis(
+        species, [17000.0, 19000.0], local_databases=state.local_databases, **kwargs
+    )
+    return state
+
+
+@pytest.mark.parametrize("offline_kurucz,irwin", [
+    ("Fe_I", False), ("Fe_I", True), ("Fe_II", False),
+], indirect=["offline_kurucz"])
+def test_radis_parser_cache_selection_and_opacity(offline_kurucz, irwin):
+    from radis.api.kuruczapi import read_kurucz as radis_read_kurucz
+
+    original = radis_read_kurucz(offline_kurucz.source).sort_values("wav")
+    adb = offline_kurucz.create(margin=2000.0, Irwin=irwin, gpu_transfer=False)
+    assert isinstance(adb, api.AdbKurucz)
+    assert isinstance(adb.nu_lines, np.ndarray)
+    assert not hasattr(adb, "dev_nu_lines")
+    np.testing.assert_array_equal(adb.nu_lines, original.wav)
+    np.testing.assert_array_equal(adb._jlower, original.jl)
+    np.testing.assert_array_equal(adb._jupper, original.ju)
+    np.testing.assert_array_equal(adb._A, original.A)
+    np.testing.assert_array_equal(adb._ielem, [26, 26, 26])
+    iion = 1 if offline_kurucz.species == "Fe_I" else 2
+    np.testing.assert_array_equal(adb._iion, [iion, iion, iion])
+    assert adb.provenance["backend"] == "radis"
+    assert adb.provenance["species"] == offline_kurucz.species
+    assert adb.provenance["radis_version"]
+    assert all(Path(path).is_file() for path in adb.provenance["local_paths"])
+
+    offline_kurucz.source.unlink()
+    cached = offline_kurucz.create(Irwin=irwin)
+    assert offline_kurucz.downloads == 1
+    assert len(cached.nu_lines) == 1
+    assert cached.provenance == adb.provenance
+    mask = (adb.nu_lines > 17000.0) & (adb.nu_lines < 19000.0)
+    adb.masking(mask)
+    assert isinstance(adb.atomicmass, np.ndarray)
+    adb.generate_jnp_arrays()
+    assert isinstance(adb.jlower, jax.Array)
+    np.testing.assert_array_equal(adb.jlower, [0.5])
+    np.testing.assert_array_equal(adb.Sij0, cached.Sij0)
+    np.testing.assert_array_equal(adb.qr_interp_lines(1800.0, adb.Tref),
+                                  cached.qr_interp_lines(1800.0, cached.Tref))
+    grid = np.linspace(18170.0, 18190.0, 33)
+    actual = OpaDirect(adb, grid).xsvector(1800.0, 0.1)
+    expected = OpaDirect(cached, grid).xsvector(1800.0, 0.1)
+    assert np.all(np.isfinite(actual)) and np.all(actual > 0)
+    np.testing.assert_array_equal(actual, expected)
+
+    with pytest.warns(UserWarning, match="no lines are selected"):
+        empty = api.AdbKurucz.from_radis(
+            offline_kurucz.species, [1000.0, 2000.0],
+            local_databases=offline_kurucz.local_databases, gpu_transfer=False,
+        )
+    assert len(empty.nu_lines) == len(empty.atomicmass) == len(empty.ionE) == 0
+    assert offline_kurucz.downloads == 1
+
+
+def test_local_constructor_preserves_reader_values(offline_kurucz):
+    expected = read_kurucz(offline_kurucz.source)
+    adb = api.AdbKurucz(offline_kurucz.source, gpu_transfer=False)
+    fields = ("_A", "nu_lines", "_elower", "_eupper", "_gupper", "_jlower",
+              "_jupper", "_ielem", "_iion", "_gamRad", "_gamSta", "_vdWdamp")
+    for field, values in zip(fields, expected):
+        np.testing.assert_array_equal(getattr(adb, field), values)
+    assert offline_kurucz.downloads == 0
+
+
+@pytest.mark.parametrize("species,kwargs,message", [
+    ("Fe", {}, "such as"), ("Fe_IV", {}, "Unsupported"),
+    ("Cs_I", {}, "atomic metadata"), ("Fe_I", {"nurange": [0.0, 1.0]}, "positive"),
+    ("Fe_I", {"nurange": [1.0, np.inf]}, "finite"),
+    ("Fe_I", {"margin": -1.0}, "margin"),
+    ("Fe_I", {"crit": np.nan}, "crit"),
+    ("Fe_I", {"vmr_fraction": [0.0, np.nan, 1.0]}, "vmr_fraction"),
+])
+def test_invalid_requests_fail_before_fetch(monkeypatch, species, kwargs, message):
+    def unexpected_fetch(*args, **kwargs):
+        pytest.fail("Invalid requests must be rejected before RADIS fetch.")
+
+    monkeypatch.setattr(api, "fetch_kurucz_dataframe", unexpected_fetch)
+    options = {"nurange": [1000.0, 2000.0], **kwargs}
+    with pytest.raises(ValueError, match=message):
+        api.AdbKurucz.from_radis(species, **options)
+
+
+@pytest.mark.parametrize("column,value,message", [
+    ("A", 0.0, "positive"), ("wav", np.inf, "nonfinite"),
+    ("gamvdW", np.nan, "missing or nonfinite"),
+    ("species", "26.01", "requested species"),
+])
+def test_converter_rejects_invalid_source_data(column, value, message):
+    frame = pd.DataFrame({
+        "A": [1.0e6], "wav": [20000.0], "El": [0.0], "Eu": [20000.0],
+        "gu": [4.0], "jl": [0.5], "ju": [1.5], "gamRad": [8.0],
+        "gamSta": [-6.0], "gamvdW": [-7.0], "species": ["26.00"],
+    })
+    frame[column] = value
+    with pytest.raises(ValueError, match=message):
+        transitions_from_dataframe(frame, 26, 1)


### PR DESCRIPTION
Add `AdbKurucz.from_radis("Fe_I", nurange=...)` to download and reuse a single atomic species through RADIS. The new reader converts validated, aligned line arrays into the existing ExoJAX initialization, retaining Barklem/Irwin partition functions, masking, delayed JAX transfer, and Direct opacity calculations.

The local-file constructor keeps its existing reader and values. The explicit RADIS path retains RADIS line positions and Einstein A values, including its air/vacuum conversion, and records the species, RADIS version, and cache paths. An English guide documents the API and cache behavior.

Validation with RADIS 0.17.1 and NumPy 2.0.2:

- 90 focused tests passed across the new Kurucz tests and existing atomic database, RADIS adapter, LPF, MODIT, and HITRAN pressure-gradient checks.
- Offline tests exercise the real RADIS parser and HDF5 cache for Fe I/Fe II, with only transport and registration replaced; they cover cache reuse, missing parameters, empty selection, Irwin, and delayed transfer.
- A live O I download produced four lines in 12850-12875 cm^-1. JIT `xsvector` matched the first row of `xsmatrix`, and reconstructing the database reused its cache with downloads disabled.

Related to #539. This PR is based directly on `develop` and can be merged independently of the NIST integration.
