### PR TITLE
Add NIST atomic database and explicit Direct broadening

### DIFF
--- a/documents/userguide.rst
+++ b/documents/userguide.rst
@@ -6,6 +6,7 @@ Databases
    :maxdepth: 1
 
    userguide/mdb.rst
+   userguide/nist.rst
    userguide/moldb.rst
    userguide/exomol.rst
    userguide/hitran.rst

--- a/documents/userguide/nist.rst
+++ b/documents/userguide/nist.rst
@@ -1,0 +1,70 @@
+NIST atomic lines
+=================
+
+``AdbNist`` retrieves one atomic species through RADIS and supplies line
+strengths, masses, and partition-function ratios to ``OpaDirect``. Species
+names use spectroscopic notation, such as ``Fe_II`` or ``Fe II``. The
+partition function must be available in the bundled Barklem & Collet (2016)
+table. ``Irwin=True`` selects Irwin (1981) for Fe I only.
+
+NIST does not supply a complete set of damping parameters. An explicit
+``atomic_broadening(T, P)`` callback is therefore required. It returns the
+**total Lorentzian HWHM in cm-1** for each selected line, with shape
+``(Nline,)``. Temperature is in K and pressure in bar. Values must be finite
+and nonnegative. Use JAX operations inside the callback to retain temperature
+and pressure derivatives. No other Lorentzian width is added automatically.
+
+The example below uses a specified constant width to demonstrate the API;
+it is not a pressure-broadening prescription for O I.
+
+.. code:: python
+
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+    from exojax.database import AdbNist
+    from exojax.opacity import OpaDirect
+
+    jax.config.update("jax_enable_x64", True)
+    nu_grid = np.linspace(12850.0, 12870.0, 2001)
+    adb = AdbNist("O_I", nu_grid, local_databases=".database/nist")
+
+    def broadening(T, P):
+        return jnp.full_like(adb.A, 0.01)
+
+    opa = OpaDirect(adb, nu_grid, atomic_broadening=broadening)
+    xs = opa.xsvector(5000.0, 0.1)
+    xsm = jax.jit(opa.xsmatrix)(
+        jnp.array([5000.0, 6000.0]), jnp.array([0.1, 0.01])
+    )
+
+Select lines with ``adb.masking(boolean_mask)`` before constructing the
+opacity calculator and its callback. Host and existing JAX arrays stay
+aligned. With ``gpu_transfer=False``, call ``adb.generate_jnp_arrays()``
+before creating ``OpaDirect``. The adapter discards lines with missing or
+invalid required parameters and applies the reference-strength cutoff.
+
+RADIS handles download and local caching. ``engine`` defaults to
+``"pytables"`` and ``cache`` is passed to RADIS unchanged. The registry name
+defaults to ``ExoJAX-NIST-{molecule}``; supply a different ``databank_name``
+when storing the same species in another directory. The initial fetch
+downloads the species line list before applying the wavenumber-range filter.
+The selected
+wavenumbers are vacuum values calculated by RADIS from the level-energy
+differences. No damping constants or ionization energies are synthesized.
+
+The Einstein coefficient of a single transition does not generally determine
+its natural width. In the usual radiative model,
+``gamma_rad = (Gamma_upper + Gamma_lower) / (4*pi*c)``, where each level's
+decay rate is the sum of its downward transition probabilities. Using
+``A_ul / (4*pi*c)`` assumes a stable lower level and negligible competing
+upper-level branches. NIST lines in a selected wavelength range need not
+contain every branch; an automatic sum over those lines is insufficient.
+See the `NIST atomic-lifetime reference
+<https://physics.nist.gov/Pubs/AtSpec/node18.html>`_.
+
+The same callback can override total Lorentzian widths for VALD or Kurucz.
+Their existing broadening calculations remain the default when no callback
+is provided. ``OpaModit`` and ``OpaPremodit`` do not accept ``AdbNist``.
+Atomic abundances and ionization fractions remain inputs to the optical-depth
+calculation, separate from the cross section.

--- a/src/exojax/database/__init__.py
+++ b/src/exojax/database/__init__.py
@@ -25,6 +25,7 @@ _ALIAS: Final[dict[str, str]] = {
     "AdbSepVald": "exojax.database.vald.api:AdbSepVald",
     "AdbKurucz": "exojax.database.kurucz.api:AdbKurucz",
     "AdbHydrogen": "exojax.database.hydrogen.api:AdbHydrogen",
+    "AdbNist": "exojax.database.nist.api:AdbNist",
     "PdbCloud": "exojax.database.pardb:PdbCloud",
     "CdbCIA": "exojax.database.cia.api:CdbCIA",
 }

--- a/src/exojax/database/__init__.pyi
+++ b/src/exojax/database/__init__.pyi
@@ -7,6 +7,7 @@ from exojax.database.vald.api import AdbVald as AdbVald
 from exojax.database.vald.api import AdbSepVald as AdbSepVald
 from exojax.database.kurucz.api import AdbKurucz as AdbKurucz
 from exojax.database.hydrogen.api import AdbHydrogen as AdbHydrogen
+from exojax.database.nist.api import AdbNist as AdbNist
 from exojax.database.exomolhr.api import XdbExomolHR as XdbExomolHR
 from exojax.database.pardb import PdbCloud as PdbCloud
 from exojax.database.cia.api import CdbCIA as CdbCIA

--- a/src/exojax/database/_common/radis_adapter.py
+++ b/src/exojax/database/_common/radis_adapter.py
@@ -322,3 +322,23 @@ def get_isotope_name_dict():
         "isotope_name_dict",
         "isotope-name table lookup",
     )
+
+
+def fetch_nist_lines(
+    species, *, nurange, local_databases, databank_name, engine, cache
+):
+    """Fetch NIST lines through RADIS, returning a Pandas frame and paths."""
+    fetch_nist = _import_attr("radis.io.nist", "fetch_nist", "NIST line retrieval")
+    return fetch_nist(
+        species,
+        local_databases=local_databases,
+        databank_name=databank_name,
+        load_wavenum_min=nurange[0],
+        load_wavenum_max=nurange[1],
+        engine=engine,
+        cache=cache,
+        output="pandas",
+        return_local_path=True,
+        verbose=False,
+        parallel=False,
+    )

--- a/src/exojax/database/core_atom/_arrays.py
+++ b/src/exojax/database/core_atom/_arrays.py
@@ -1,4 +1,4 @@
-"""Shared line-array management for VALD and Kurucz databases."""
+"""Shared line-array management for atomic databases."""
 
 import jax.numpy as jnp
 import numpy as np
@@ -43,26 +43,32 @@ def _set_atomic_metadata(adb):
     )
 
 
-def _mask_atomic_lines(adb, mask):
+def _mask_atomic_lines(
+    adb, mask, *, line_fields=_LINE_FIELDS, metadata_fields=_METADATA_FIELDS
+):
     """Select host lines and metadata, refreshing existing JAX line arrays."""
     for name in ("nu_lines", "Sij0"):
         setattr(adb, name, getattr(adb, name)[mask])
-    for name in _LINE_FIELDS:
+    for name in line_fields:
         host_name = "_" + name
         setattr(adb, host_name, getattr(adb, host_name)[mask])
-    for name in _METADATA_FIELDS:
+    for name in metadata_fields:
         if hasattr(adb, name):
             setattr(adb, name, getattr(adb, name)[mask])
     if hasattr(adb, "dev_nu_lines"):
-        _generate_atomic_jnp_arrays(adb)
+        _generate_atomic_jnp_arrays(
+            adb, line_fields=line_fields, metadata_fields=metadata_fields
+        )
 
 
-def _generate_atomic_jnp_arrays(adb):
+def _generate_atomic_jnp_arrays(
+    adb, *, line_fields=_LINE_FIELDS, metadata_fields=_METADATA_FIELDS
+):
     """Generate JAX arrays from selected lines while preserving fractional J."""
     adb.dev_nu_lines = jnp.array(adb.nu_lines)
     adb.logsij0 = jnp.array(np.log(adb.Sij0))
-    for name in _LINE_FIELDS:
+    for name in line_fields:
         dtype = int if name in _INTEGER_FIELDS else None
         setattr(adb, name, jnp.array(getattr(adb, "_" + name), dtype=dtype))
-    for name in _METADATA_FIELDS:
+    for name in metadata_fields:
         setattr(adb, name, jnp.array(getattr(adb, name)))

--- a/src/exojax/database/nist/__init__.py
+++ b/src/exojax/database/nist/__init__.py
@@ -1,0 +1,5 @@
+"""NIST atomic line database."""
+
+from exojax.database.nist.api import AdbNist
+
+__all__ = ["AdbNist"]

--- a/src/exojax/database/nist/_convert.py
+++ b/src/exojax/database/nist/_convert.py
@@ -1,0 +1,57 @@
+"""Normalize RADIS NIST species and line columns."""
+
+import re
+import warnings
+
+import numpy as np
+
+from exojax.database.core_atom.io import PeriodicTable
+
+
+_COLUMNS = {
+    "nu_lines": "wav", "A": "A", "elower": "El", "eupper": "Eu",
+    "glower": "gl", "gupper": "gu", "jlower": "jl", "jupper": "ju",
+}
+
+
+def parse_species(species):
+    """Return canonical RADIS notation, atomic number, and ion stage."""
+    if not isinstance(species, str):
+        raise ValueError("species must be an atom and ion stage, such as 'Fe_II'.")
+    canonical = "_".join(species.split())
+    match = re.fullmatch(r"([A-Z][a-z]?)_([IVXLC]+)", canonical)
+    if match is None or match[1] not in PeriodicTable:
+        raise ValueError("species must be an atom and ion stage, such as 'Fe_II'.")
+    symbol, roman = match.groups()
+    if roman not in ("I", "II", "III"):
+        raise ValueError("Only ion stages I, II, and III have supported partition functions.")
+    stage = len(roman)
+    ielem = int(np.flatnonzero(PeriodicTable == symbol)[0])
+    if stage > ielem + 1:
+        raise ValueError(f"Invalid ion stage in species '{species}'.")
+    return canonical, ielem, stage
+
+
+def line_arrays(dataframe, species):
+    """Select finite, physical line records and sort their aligned columns."""
+    missing = (set(_COLUMNS.values()) | {"species"}) - set(dataframe.columns)
+    if missing:
+        raise ValueError(f"NIST data are missing required columns: {', '.join(sorted(missing))}.")
+    if not np.all(dataframe["species"].to_numpy() == species):
+        raise ValueError(f"NIST data contain species other than the requested '{species}'.")
+    arrays = {name: dataframe[column].to_numpy(dtype=float)
+              for name, column in _COLUMNS.items()}
+    valid = np.isfinite(np.stack(list(arrays.values()))).all(axis=0)
+    for name in ("nu_lines", "A", "glower", "gupper"):
+        valid &= arrays[name] > 0
+    for name in ("elower", "jlower", "jupper"):
+        valid &= arrays[name] >= 0
+    valid &= arrays["eupper"] > arrays["elower"]
+    if not np.all(valid):
+        warnings.warn(
+            f"Discarded {np.count_nonzero(~valid)} NIST lines with missing or invalid parameters.",
+            UserWarning,
+            stacklevel=2,
+        )
+    order = np.argsort(arrays["nu_lines"][valid], kind="stable")
+    return {name: values[valid][order] for name, values in arrays.items()}

--- a/src/exojax/database/nist/api.py
+++ b/src/exojax/database/nist/api.py
@@ -1,0 +1,143 @@
+"""NIST atomic transitions fetched through the RADIS database API."""
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+
+from exojax.database._common.radis_adapter import fetch_nist_lines
+from exojax.database.core_atom._arrays import (
+    _generate_atomic_jnp_arrays,
+    _mask_atomic_lines,
+)
+from exojax.database.core_atom.io import load_atomicdata, load_pf_Barklem2016
+from exojax.database.core_atom.line_strength import line_strength_atom
+from exojax.database.core_atom.pf import interp_QT_284, qr_interp_lines
+from exojax.database.nist._convert import line_arrays, parse_species
+from exojax.utils.constants import Tref_original
+
+__all__ = ["AdbNist"]
+
+_LINE_FIELDS = (
+    "A", "elower", "eupper", "glower", "gupper", "jlower", "jupper",
+    "QTmask", "ielem", "iion",
+)
+
+
+class AdbNist:
+    """NIST lines for one atomic species, without assumed damping parameters.
+
+    NIST supplies transition probabilities, not a complete broadening model.
+    Use ``OpaDirect(..., atomic_broadening=...)`` to specify total Lorentzian
+    half widths. Partition functions use Barklem & Collet (2016), optionally
+    replacing Fe I with Irwin (1981).
+    """
+
+    def __init__(
+        self, species, nurange=(-np.inf, np.inf), *, local_databases=None,
+        databank_name="ExoJAX-NIST-{molecule}",
+        margin=0.0, crit=0.0, Irwin=False, gpu_transfer=True,
+        engine="pytables", cache=True,
+    ):
+        """Load and select NIST atomic lines.
+
+        Args:
+            species: One species in ``'Fe_II'`` or ``'Fe II'`` notation.
+            nurange: Wavenumber bounds or grid in cm-1.
+            local_databases: RADIS cache directory; None uses its default.
+            databank_name: RADIS registry name. Use a different name when
+                storing the same species in another cache directory.
+            margin: Nonnegative wavenumber margin in cm-1.
+            crit: Nonnegative reference line-strength cutoff in cm.
+            Irwin: Use Irwin (1981) for Fe I only.
+            gpu_transfer: Generate JAX arrays at initialization when True.
+            engine: RADIS cache engine, defaulting to PyTables.
+            cache: Cache option passed to RADIS without modification.
+
+        Raises:
+            ValueError: If the species, partition function, or selection is invalid.
+        """
+        self.species, ielem, iion = parse_species(species)
+        self.dbtype = "nist"
+        self.Tref = Tref_original
+        self.Irwin = Irwin
+        self.gpu_transfer = gpu_transfer
+        bounds = np.asarray(nurange, dtype=float)
+        if bounds.ndim != 1 or bounds.size < 2 or np.any(np.isnan(bounds)):
+            raise ValueError("nurange must contain at least two wavenumbers without NaN.")
+        self.nurange = [float(np.min(bounds)), float(np.max(bounds))]
+        if self.nurange[0] >= self.nurange[1] or self.nurange[1] <= 0:
+            raise ValueError("nurange must span a positive wavenumber interval.")
+        if not np.isfinite(margin) or margin < 0 or not np.isfinite(crit) or crit < 0:
+            raise ValueError("margin and crit must be finite and nonnegative.")
+        self.margin, self.crit = margin, crit
+        self.engine = engine
+
+        pf_temperature, self.pfdat = load_pf_Barklem2016()
+        matches = np.flatnonzero(self.pfdat["T[K]"].to_numpy() == self.species)
+        if matches.size != 1:
+            raise ValueError(f"No Barklem partition function is available for '{self.species}'.")
+        atomic_data = load_atomicdata().set_index("ielem")
+        if ielem not in atomic_data.index:
+            raise ValueError(f"No atomic mass is available for '{self.species}'.")
+        mass = float(atomic_data.loc[ielem, "mass"])
+        self.T_gQT = jnp.asarray(pf_temperature.columns[1:], dtype=float)
+        self.gQT_284species = jnp.asarray(self.pfdat.iloc[:, 1:].to_numpy(dtype=float))
+        self.QTref_284 = np.asarray(interp_QT_284(
+            self.Tref, self.T_gQT, self.gQT_284species, self.Irwin
+        ))
+
+        expanded = [self.nurange[0] - margin, self.nurange[1] + margin]
+        fetch_bounds = [value if np.isfinite(value) else None for value in expanded]
+        frame, self.local_paths = fetch_nist_lines(
+            self.species, nurange=fetch_bounds, local_databases=local_databases,
+            databank_name=databank_name,
+            engine=engine, cache=cache,
+        )
+        arrays = line_arrays(frame, self.species)
+        self.nu_lines = arrays.pop("nu_lines")
+        for name, values in arrays.items():
+            setattr(self, "_" + name, values)
+        nline = len(self.nu_lines)
+        self._ielem = np.full(nline, ielem, dtype=int)
+        self._iion = np.full(nline, iion, dtype=int)
+        self._QTmask = np.full(nline, matches[0], dtype=int)
+        self.atomicmass = np.full(nline, mass)
+        self.Sij0 = line_strength_atom(
+            self._A, self._gupper, self.nu_lines, self._elower,
+            self.QTref_284, self._QTmask,
+        )
+        self.masking(
+            (self.nu_lines > expanded[0]) & (self.nu_lines < expanded[1])
+            & np.isfinite(self.Sij0) & (self.Sij0 > crit)
+        )
+        if gpu_transfer:
+            self.generate_jnp_arrays()
+
+    def masking(self, mask):
+        """Select current lines and refresh any existing JAX arrays."""
+        mask = np.asarray(mask)
+        if mask.dtype != bool or mask.shape != self.nu_lines.shape:
+            raise ValueError("mask must be a Boolean array with one entry per current line.")
+        _mask_atomic_lines(
+            self, mask, line_fields=_LINE_FIELDS, metadata_fields=("atomicmass",)
+        )
+        if self.nu_lines.size == 0:
+            warnings.warn("No NIST lines are selected.", UserWarning, stacklevel=2)
+
+    def generate_jnp_arrays(self):
+        """Generate JAX arrays while retaining host line data."""
+        _generate_atomic_jnp_arrays(
+            self, line_fields=_LINE_FIELDS, metadata_fields=("atomicmass",)
+        )
+
+    @property
+    def line_masses(self):
+        """Atomic masses for the current line selection, in amu."""
+        return self.atomicmass
+
+    def qr_interp_lines(self, T, Tref):
+        """Return the partition-function ratio for every selected line."""
+        return qr_interp_lines(
+            T, Tref, self.T_gQT, self.gQT_284species, self._QTmask, self.Irwin
+        )

--- a/src/exojax/opacity/lpf/api.py
+++ b/src/exojax/opacity/lpf/api.py
@@ -4,7 +4,7 @@ This module provides the OpaDirect class for direct line-by-line opacity
 calculations using the LPF method.
 """
 
-from typing import Literal, Union
+from typing import Callable, Literal, Optional, Union
 
 import jax.numpy as jnp
 import numpy as np
@@ -34,6 +34,10 @@ class OpaDirect(OpaCalc):
         H, He, and H2 partial pressures use the database's ``vmr_fraction``
         in that order. Select a single atomic species before applying its
         abundance to the cross section.
+
+        NIST requires ``atomic_broadening`` because its line list does not
+        provide damping parameters. A supplied callback replaces the total
+        Lorentzian width for NIST, VALD, or Kurucz.
     """
 
     def __init__(
@@ -41,6 +45,8 @@ class OpaDirect(OpaCalc):
         mdb,
         nu_grid: np.ndarray,
         wavelength_order: Literal["ascending", "descending"] = "descending",
+        *,
+        atomic_broadening: Optional[Callable] = None,
     ) -> None:
         """Initialize OpaDirect (LPF) opacity calculator.
 
@@ -48,7 +54,19 @@ class OpaDirect(OpaCalc):
             mdb: Molecular or atomic line database
             nu_grid: Wavenumber grid in cm⁻¹
             wavelength_order: Order of wavelength grid
+            atomic_broadening: JAX-compatible callable ``(T, P) -> gammaL``
+                for NIST, VALD, or Kurucz. T is in K and P in bar. Return
+                the total Lorentzian HWHM in cm-1, shaped ``(Nline,)``.
+                Include every desired broadening contribution; no natural
+                or pressure width is added automatically. Required for NIST.
         """
+        if atomic_broadening is not None:
+            if mdb.dbtype not in ("nist", "vald", "kurucz"):
+                raise ValueError("atomic_broadening supports only NIST, VALD, and Kurucz.")
+            if not callable(atomic_broadening):
+                raise TypeError("atomic_broadening must be callable.")
+        if mdb.dbtype == "nist" and atomic_broadening is None:
+            raise ValueError("NIST requires an explicit atomic_broadening(T, P) callable.")
         super().__init__(nu_grid)
 
         self.method = "lpf"
@@ -58,6 +76,7 @@ class OpaDirect(OpaCalc):
             self.nu_grid, wavelength_order=self.wavelength_order, unit="AA"
         )
         self.mdb = mdb
+        self.atomic_broadening = atomic_broadening
         self.apply_params()
 
     def __eq__(self, other: object) -> bool:
@@ -74,6 +93,10 @@ class OpaDirect(OpaCalc):
 
         return (
             (self.mdb == other.mdb)
+            and (
+                getattr(self, "atomic_broadening", None)
+                is getattr(other, "atomic_broadening", None)
+            )
             and (self.wavelength_order == other.wavelength_order)
             and np.array_equal(self.nu_grid, other.nu_grid)
         )
@@ -112,9 +135,23 @@ class OpaDirect(OpaCalc):
         elif self.dbtype == "exomol":
             self._vmap_qt = vmap(self.mdb.qr_interp, (0, None))
             self._vmap_gamma = jit(vmap(gamma_exomol, (0, 0, None, None)))
+        elif getattr(self, "atomic_broadening", None) is not None:
+            self._vmap_qt = vmap(self.mdb.qr_interp_lines, (0, None))
+            self._vmap_gamma = jit(vmap(self._atomic_gamma, (0, 0)))
         else:
             self._vmap_qt = None
             self._vmap_gamma = None
+
+    def _atomic_gamma(self, T, P):
+        """Check the static shape of a user-supplied atomic Lorentz width."""
+        gammaL = jnp.asarray(self.atomic_broadening(T, P))
+        expected_shape = (len(self.mdb.nu_lines),)
+        if gammaL.shape != expected_shape:
+            raise ValueError(
+                f"atomic_broadening must return shape {expected_shape}, "
+                f"but returned {gammaL.shape}."
+            )
+        return gammaL
 
     def _atomic_line_parameters(self, T, P):
         """Use the same atomic parameter calculation for vectors and matrices."""
@@ -122,6 +159,17 @@ class OpaDirect(OpaCalc):
 
         Tarr = jnp.atleast_1d(T)
         Parr = jnp.atleast_1d(P)
+        if getattr(self, "atomic_broadening", None) is not None:
+            qr = self._vmap_qt(Tarr, self.mdb.Tref)
+            SijM = self._vmap_line_strength(
+                Tarr, self.mdb.logsij0, self.mdb.nu_lines, self.mdb.elower,
+                qr, self.mdb.Tref,
+            )
+            gammaLM = self._vmap_gamma(Tarr, Parr)
+            sigmaDM = self._vmap_doppler_sigma(
+                self.mdb.nu_lines, Tarr, self.mdb.line_masses
+            )
+            return SijM, gammaLM, sigmaDM
         return vald(
             self.mdb, Tarr, Parr * self.mdb.vmrH,
             Parr * self.mdb.vmrHe, Parr * self.mdb.vmrHH,
@@ -166,13 +214,13 @@ class OpaDirect(OpaCalc):
             qt = self.mdb.qr_interp_lines(T, Tref_original)
             gammaL = gamma_natural(self.mdb.A)
             line_masses = self.mdb.line_masses
-        elif dbtype in ("kurucz", "vald"):
+        elif dbtype in ("kurucz", "vald", "nist"):
             SijM, gammaLM, sigmaDM = self._atomic_line_parameters(T, P)
             return xsvector_lpf(numatrix, sigmaDM[0], gammaLM[0], SijM[0])
         else:
             raise ValueError(
                 f"Unsupported database type for xsvector: '{dbtype}'. "
-                "Supported types: hitran, exomol, hydrogen, kurucz, vald"
+                "Supported types: hitran, exomol, hydrogen, kurucz, vald, nist"
             )
 
         sigmaD = doppler_sigma(self.mdb.nu_lines, T, line_masses)
@@ -259,12 +307,12 @@ class OpaDirect(OpaCalc):
             sigmaDM = self._vmap_doppler_sigma(
                 self.mdb.nu_lines, Tarr, self.mdb.line_masses
             )
-        elif dbtype in ("kurucz", "vald"):
+        elif dbtype in ("kurucz", "vald", "nist"):
             SijM, gammaLM, sigmaDM = self._atomic_line_parameters(Tarr, Parr)
         else:
             raise ValueError(
                 f"Unsupported database type for xsmatrix: '{dbtype}'. "
-                "Supported types: hitran, exomol, hydrogen, kurucz, vald"
+                "Supported types: hitran, exomol, hydrogen, kurucz, vald, nist"
             )
 
         return xsmatrix_lpf(numatrix, sigmaDM, gammaLM, SijM)

--- a/tests/unittests/database/nist/test_api.py
+++ b/tests/unittests/database/nist/test_api.py
@@ -1,0 +1,261 @@
+"""NIST adapters and explicit atomic broadening, without network access."""
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pandas as pd
+import pytest
+
+from exojax.database import AdbNist
+from exojax.database.nist import api
+from exojax.database.core.broadening import doppler_sigma
+from exojax.database.core.line_strength import line_strength
+from exojax.opacity import OpaDirect
+from exojax.opacity.lpf.lpf import xsvector
+
+
+@pytest.fixture
+def make_adb(monkeypatch):
+    frame = pd.DataFrame({
+        "wav": [1002.0, 1000.0, 1001.0], "A": [3e6, 1e6, 2e6],
+        "El": [20.0, 0.0, 10.0], "Eu": [1022.0, 1000.0, 1011.0],
+        "gl": [6.0, 2.0, 4.0], "gu": [8.0, 4.0, 6.0],
+        "jl": [2.5, 0.5, 1.5], "ju": [3.5, 1.5, 2.5],
+        "species": ["Fe_II"] * 3,
+    })
+    calls = []
+
+    def fetch(species, **kwargs):
+        calls.append((species, kwargs))
+        return frame.copy(), ["offline-nist.h5"]
+
+    monkeypatch.setattr(api, "fetch_nist_lines", fetch)
+    return SimpleNamespace(
+        create=lambda **kwargs: AdbNist("Fe II", **kwargs), frame=frame, calls=calls
+    )
+
+
+@pytest.mark.parametrize("gpu_transfer", [False, True])
+def test_nist_sorted_arrays_fractional_j_and_mask_alignment(make_adb, gpu_transfer):
+    adb = make_adb.create(gpu_transfer=gpu_transfer)
+    assert adb.species == "Fe_II"
+    assert adb.local_paths == ["offline-nist.h5"]
+    np.testing.assert_array_equal(adb.nu_lines, [1000.0, 1001.0, 1002.0])
+    np.testing.assert_array_equal(adb._A, [1e6, 2e6, 3e6])
+    np.testing.assert_array_equal(adb._jlower, [0.5, 1.5, 2.5])
+    assert np.all(np.isfinite(adb.Sij0)) and np.all(adb.Sij0 > 0)
+    assert not any(hasattr(adb, name) for name in ("gamRad", "gamSta", "vdWdamp", "ionE"))
+    assert hasattr(adb, "logsij0") == gpu_transfer
+    old_ratios = np.asarray(adb.qr_interp_lines(1800.0, adb.Tref))
+    np.testing.assert_array_equal(adb.qr_interp_lines(adb.Tref, adb.Tref), np.ones(3))
+    adb.masking(np.array([False, True, True]))
+    adb.generate_jnp_arrays()
+    np.testing.assert_array_equal(adb.A, [2e6, 3e6])
+    np.testing.assert_array_equal(adb.jlower, [1.5, 2.5])
+    np.testing.assert_array_equal(adb.jupper, [2.5, 3.5])
+    np.testing.assert_array_equal(adb.iion, [2, 2])
+    np.testing.assert_allclose(adb.qr_interp_lines(1800.0, adb.Tref), old_ratios[1:])
+    np.testing.assert_array_equal(adb.line_masses, np.full(2, 55.847))
+    adb.masking(np.array([False, True]))
+    np.testing.assert_array_equal(adb.dev_nu_lines, adb.nu_lines)
+    np.testing.assert_array_equal(adb.elower, adb._elower)
+    np.testing.assert_allclose(adb.logsij0, np.log(adb.Sij0))
+
+
+def test_nist_range_margin_and_strength_cutoff(make_adb, tmp_path):
+    full = make_adb.create()
+    cutoff = np.min(full.Sij0)
+    adb = make_adb.create(
+        nurange=[1000.0, 1001.0], margin=0.5, crit=cutoff,
+        local_databases=tmp_path, engine="pytables", cache="force",
+    )
+    expected = (full.nu_lines > 999.5) & (full.nu_lines < 1001.5) & (full.Sij0 > cutoff)
+    np.testing.assert_array_equal(adb.nu_lines, full.nu_lines[expected])
+    assert make_adb.calls[-1] == ("Fe_II", dict(
+        nurange=[999.5, 1001.5], local_databases=tmp_path, engine="pytables", cache="force",
+        databank_name="ExoJAX-NIST-{molecule}",
+    ))
+
+
+@pytest.mark.parametrize("column,value", [
+    ("A", np.nan), ("A", 0.0), ("wav", -1.0), ("gu", 0.0),
+    ("El", np.inf), ("El", -1.0), ("jl", -0.5), ("Eu", 0.0),
+])
+def test_nist_discards_invalid_line_parameters(make_adb, column, value):
+    make_adb.frame.loc[0, column] = value
+    with pytest.warns(UserWarning, match="Discarded 1 NIST lines"):
+        adb = make_adb.create()
+    np.testing.assert_array_equal(adb.nu_lines, [1000.0, 1001.0])
+
+
+def test_nist_missing_columns_and_empty_selection(make_adb):
+    make_adb.frame.drop(columns="A", inplace=True)
+    with pytest.raises(ValueError, match="missing required columns: A"):
+        make_adb.create()
+    make_adb.frame["A"] = 1e6
+    with pytest.warns(UserWarning, match="No NIST lines"):
+        adb = make_adb.create(nurange=[1100.0, 1200.0])
+    assert adb.nu_lines.size == 0
+
+
+@pytest.mark.parametrize("species", ["Fe", "CO_I", "Fe_IIII", "Xx_I", "H_III", 26])
+def test_nist_rejects_invalid_species_before_fetch(make_adb, species):
+    with pytest.raises(ValueError, match="species|ion stage"):
+        AdbNist(species)
+    assert not make_adb.calls
+
+
+def test_nist_rejects_missing_partition_function_before_fetch(make_adb):
+    with pytest.raises(ValueError, match="supported partition functions"):
+        AdbNist("Fe_IV")
+    assert not make_adb.calls
+
+
+def test_nist_missing_partition_table_entry(make_adb, monkeypatch):
+    temperatures, partition = api.load_pf_Barklem2016()
+    partition = partition.loc[partition["T[K]"] != "Fe_II"]
+    monkeypatch.setattr(api, "load_pf_Barklem2016", lambda: (temperatures, partition))
+    with pytest.raises(ValueError, match="No Barklem partition function.*Fe_II"):
+        make_adb.create()
+    assert not make_adb.calls
+
+
+def test_nist_rejects_mismatched_cache_species(make_adb):
+    make_adb.frame.loc[0, "species"] = "Fe_I"
+    with pytest.raises(ValueError, match="other than the requested 'Fe_II'"):
+        make_adb.create()
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"nurange": []}, {"nurange": [np.nan, 1000]}, {"nurange": [1000, 1000]},
+    {"margin": -1}, {"crit": np.inf},
+])
+def test_nist_rejects_invalid_selection(make_adb, kwargs):
+    with pytest.raises(ValueError):
+        make_adb.create(**kwargs)
+    assert not make_adb.calls
+
+
+def test_nist_irwin_reference_and_runtime_partition_are_consistent(make_adb):
+    from exojax.database.core_atom.pf import partfn_Fe
+    from exojax.utils.constants import ccgs, hcperk
+
+    make_adb.frame["species"] = "Fe_I"
+    adb = AdbNist("Fe_I", Irwin=True)
+    temperature = 1800.0
+    expected = (
+        -np.asarray(adb.A) * np.asarray(adb.gupper)
+        * np.exp(-hcperk * np.asarray(adb.elower) / temperature)
+        * np.expm1(-hcperk * adb.nu_lines / temperature)
+        / (8 * np.pi * ccgs * adb.nu_lines**2 * float(partfn_Fe(temperature)))
+    )
+    actual = line_strength(
+        temperature, adb.logsij0, adb.nu_lines, adb.elower,
+        adb.qr_interp_lines(temperature, adb.Tref), adb.Tref,
+    )
+    np.testing.assert_allclose(actual, expected, rtol=1e-11, atol=0.0)
+
+
+def test_nist_direct_requires_broadening_and_checks_callback_shape(make_adb):
+    adb = make_adb.create()
+    grid = np.linspace(999.8, 1002.2, 61)
+    with pytest.raises(ValueError, match="NIST requires an explicit atomic_broadening"):
+        OpaDirect(adb, grid)
+    with pytest.raises(TypeError, match="must be callable"):
+        OpaDirect(adb, grid, atomic_broadening=0.1)
+    with pytest.raises(ValueError, match="only NIST, VALD, and Kurucz"):
+        OpaDirect(SimpleNamespace(dbtype="exomol"), grid, atomic_broadening=lambda T, P: 0.1)
+    for width in (0.1, jnp.ones(2), jnp.ones((1, 3))):
+        opa = OpaDirect(adb, grid, atomic_broadening=lambda T, P: width)
+        with pytest.raises(ValueError, match="atomic_broadening must return shape"):
+            jax.jit(opa.xsvector)(1800.0, 0.1)
+
+
+def test_nist_direct_values_and_gradients_with_explicit_broadening(make_adb):
+    adb = make_adb.create()
+    grid = np.linspace(999.8, 1002.2, 61)
+
+    def broadening(T, P):
+        return jnp.array([0.1, 0.2, 0.3]) * P * (296.0 / T)**0.7 + 0.002
+
+    opa = OpaDirect(adb, grid, atomic_broadening=broadening)
+    temperatures, pressures = jnp.array([1300.0, 1800.0]), jnp.array([0.01, 0.1])
+    matrix = jax.jit(opa.xsmatrix)(temperatures, pressures)
+    vectors = jnp.stack([opa.xsvector(T, P) for T, P in zip(temperatures, pressures)])
+    np.testing.assert_allclose(matrix, vectors, rtol=1e-12, atol=0.0)
+    assert np.all(np.isfinite(matrix)) and np.all(matrix > 0)
+    strengths = line_strength(
+        1800.0, adb.logsij0, adb.nu_lines, adb.elower,
+        adb.qr_interp_lines(1800.0, adb.Tref), adb.Tref,
+    )
+    expected = xsvector(
+        opa.opainfo, doppler_sigma(adb.nu_lines, 1800.0, adb.line_masses),
+        broadening(1800.0, 0.1), strengths,
+    )
+    np.testing.assert_allclose(matrix[1], expected, rtol=1e-12, atol=0.0)
+    index = np.argmin(np.abs(grid - 1000.0))
+    fn = jax.jit(lambda T, P: jnp.log(opa.xsvector(T, P)[index]))
+    actual = jax.jit(jax.grad(fn, argnums=(0, 1)))(1800.0, 0.1)
+    matrix_fn = lambda T, P: jnp.log(opa.xsmatrix(
+        jnp.array([T, 1300.0]), jnp.array([P, 0.01])
+    )[0, index])
+    matrix_gradient = jax.jit(jax.grad(matrix_fn, argnums=(0, 1)))(1800.0, 0.1)
+    expected_gradient = (
+        (fn(1800.1, 0.1) - fn(1799.9, 0.1)) / 0.2,
+        (fn(1800.0, 0.10001) - fn(1800.0, 0.09999)) / 0.00002,
+    )
+    assert np.all(np.isfinite(actual)) and np.all(np.abs(actual) > 1e-8)
+    np.testing.assert_allclose(actual, expected_gradient, rtol=1e-4, atol=1e-9)
+    np.testing.assert_allclose(matrix_gradient, actual, rtol=1e-12, atol=0.0)
+    assert opa == OpaDirect(adb, grid, atomic_broadening=broadening)
+    assert opa != OpaDirect(adb, grid, atomic_broadening=lambda T, P: broadening(T, P))
+
+
+def test_nist_direct_accepts_explicit_doppler_only_model(make_adb):
+    adb = make_adb.create()
+    opa = OpaDirect(
+        adb, np.linspace(999.8, 1002.2, 61),
+        atomic_broadening=lambda T, P: jnp.zeros_like(adb.A),
+    )
+    opacity = jax.jit(opa.xsvector)(1800.0, 0.1)
+    assert np.all(np.isfinite(opacity)) and np.all(opacity >= 0)
+    assert np.any(opacity > 0)
+
+
+def test_nist_radis_parser_fetch_and_cache_roundtrip(monkeypatch, tmp_path):
+    radis_api = pytest.importorskip("radis.api.nistapi")
+    from radis.api.dbmanager import DatabaseManager
+
+    source = tmp_path / "nist_OI.tsv"
+    source.write_text(
+        "ritz_wl_air(nm)\tAki(s^-1)\tAcc\tEi(cm-1)\tEk(cm-1)\tg_i\tg_k\n"
+        "777.1944\t3.69e7\tA\t73768.200\t86631.454\t5\t7\n"
+        "777.4166\t3.69e7\tA\t73768.200\t86627.778\t5\t5\n"
+        "777.5388\t3.69e7\tA\t73768.200\t86625.757\t5\t3\n"
+    )
+    downloads = []
+
+    def download(manager, urls, targets, total):
+        downloads.append(urls)
+        opener = SimpleNamespace(open=lambda: source.open("rb"))
+        return manager.parse_to_local_file(opener, urls[0], targets[0], pbar_active=False)
+
+    monkeypatch.setattr(DatabaseManager, "is_registered", lambda self: False)
+    monkeypatch.setattr(radis_api.NISTDatabaseManager, "download_and_parse", download)
+    monkeypatch.setattr(radis_api.NISTDatabaseManager, "register", lambda *args: None)
+    kwargs = dict(nurange=[12850, 12870], local_databases=str(tmp_path / "cache"))
+    first = AdbNist("O_I", **kwargs)
+    second = AdbNist("O_I", **kwargs)
+    assert len(downloads) == 1
+    np.testing.assert_allclose(first.nu_lines, [12857.557, 12859.578, 12863.254])
+    np.testing.assert_array_equal(first.nu_lines, second.nu_lines)
+    np.testing.assert_array_equal(first.A, np.full(3, 3.69e7))
+    np.testing.assert_array_equal(first.jupper, [1.0, 2.0, 3.0])
+    opa = OpaDirect(
+        first, np.linspace(12850, 12870, 81),
+        atomic_broadening=lambda T, P: jnp.full_like(first.A, 0.01),
+    )
+    opacity = opa.xsvector(5000.0, 0.1)
+    assert np.all(np.isfinite(opacity)) and np.all(opacity > 0)

--- a/tests/unittests/opacity/lpf/test_api_xsmatrix.py
+++ b/tests/unittests/opacity/lpf/test_api_xsmatrix.py
@@ -102,6 +102,30 @@ def test_opadirect_atomic_temperature_and_pressure_gradients(make_adb):
     np.testing.assert_allclose(actual, expected, rtol=1.0e-4, atol=1.0e-9)
 
 
+def test_opadirect_atomic_broadening_override(make_adb):
+    from exojax.database.core.broadening import doppler_sigma
+    from exojax.database.core.line_strength import line_strength
+    from exojax.opacity.lpf.lpf import xsvector
+
+    adb = make_adb()
+    broadening = lambda T, P: jnp.full_like(adb.A, 0.02)
+    opa = OpaDirect(
+        adb, np.linspace(999.8, 1002.2, 61), atomic_broadening=broadening
+    )
+    temperature, pressure = 1800.0, 0.1
+    strengths = line_strength(
+        temperature, adb.logsij0, adb.nu_lines, adb.elower,
+        adb.qr_interp_lines(temperature, adb.Tref), adb.Tref,
+    )
+    expected = xsvector(
+        opa.opainfo, doppler_sigma(adb.nu_lines, temperature, adb.line_masses),
+        broadening(temperature, pressure), strengths,
+    )
+    np.testing.assert_allclose(
+        opa.xsvector(temperature, pressure), expected, rtol=1e-12, atol=0.0
+    )
+
+
 @pytest.mark.parametrize("irwin", [False, True])
 def test_separated_atomic_line_parameters_preserve_values_and_padding(make_adb, irwin):
     from exojax.database import AdbSepVald


### PR DESCRIPTION
Add `AdbNist` to fetch atomic transitions through RADIS and calculate Direct cross sections with an explicit `atomic_broadening(T, P)` function. NIST does not provide complete damping parameters, so the function is required and supplies the total Lorentzian HWHM in cm^-1 for each line. Both `xsvector` and `xsmatrix` use the same JAX-compatible calculation.

The database validates species, sorts aligned arrays, reports discarded invalid lines, and reuses ExoJAX Barklem/Irwin partition functions and atomic array management. Cache names can be configured independently. No damping constants or ionization energies are fabricated. The same callback can override VALD/Kurucz widths; their default calculations remain unchanged. An English guide documents the physical assumptions and API.

Validation with RADIS 0.17.1 and NumPy 2.0.2:

- Focused tests cover the real RADIS parser/cache, species mismatches, missing data, fractional J, delayed transfer, masking, partition-function normalization, and Irwin line strengths.
- Direct tests cover callback requirements/shape, vector/matrix agreement, JIT, temperature/pressure gradients against finite differences, explicit zero Lorentz width, and VALD/Kurucz overrides.
- A live O I fetch produced three lines in 12850-12875 cm^-1. Direct vector/matrix results agreed with an explicit test width, and reconstructing the database reused its cache with downloads disabled.
- This branch and #785 merge without conflicts. All **123 focused tests passed** with both changes applied, including existing atomic, LPF, MODIT, RADIS adapter, and HITRAN pressure-gradient checks.

Related to #539. This PR is based directly on `develop` and can be merged independently of #785. Atomic `OpaModit`/`OpaPremodit` integration and additional partition-function sources remain separate work.
