### PR TITLE
Add direct-beam SFM reflection with incident and viewing angles

### DIFF
--- a/documents/userguide/rtransfer.rst
+++ b/documents/userguide/rtransfer.rst
@@ -32,6 +32,44 @@ For reflected light, ``ArtReflectPure`` and ``ArtReflectEmis`` support both the
 flux-adding treatment and SFM-2st. The latter treats ``incoming_flux`` as a
 diffuse hemispheric flux at the top boundary.
 
+``ArtReflectPure.run_direct`` computes the reflected specific intensity for
+a direct stellar beam using SFM and Toon quadrature. Specify positive cosines
+of the incident and outgoing zenith angles, and their relative azimuth:
+
+.. code-block:: python
+
+    intensity = art.run_direct(
+        dtau, single_scattering_albedo,
+        reflectivity_surface, incoming_flux,
+        mu_in=0.6, mu_out=0.6,
+        relative_azimuth=0.0, phase_function="rayleigh",
+    )
+
+Here ``incoming_flux`` is irradiance normal to the beam; the local horizontal
+incident flux is ``mu_in * incoming_flux``. The result is specific intensity
+in the incident irradiance units per steradian. The relative azimuth is the
+angle in radians between the outward star and observer directions; full phase
+has equal direction cosines and zero relative azimuth. Use ``jax.vmap`` to
+evaluate multiple direction pairs. This method always uses direct SFM,
+independently of the diffuse ``rtsolver`` setting.
+
+The supported phase functions are ``"rayleigh"`` and ``"isotropic"``. Single
+scattering is integrated analytically in each homogeneous layer. Multiple
+scattering uses a Toon-style hemispheric source reconstructed from quadrature
+fluxes, averaged across each layer. Refine layers to check this approximation;
+Rayleigh's higher angular moments, polarization, and cloud phase functions are
+not included. Angular integration of this intensity does not exactly preserve
+the two-stream energy balance, even after layer convergence. For example,
+an isotropically scattering, conservative atmosphere of total optical depth 10 above a perfectly
+reflecting surface has about 1--5% flux errors for incident cosines 0.1--1.
+Direction-cosine derivatives at exactly normal incidence or emergence are
+not guaranteed because the angular coordinates are singular there.
+The lower boundary is Lambertian. For a transparent atmosphere,
+``intensity = reflectivity_surface * mu_in * incoming_flux / pi``.
+Disk integration to obtain geometric albedo is a separate step.
+See `Toon et al. (1989) <https://doi.org/10.1029/JD094iD13p16287>`_
+for the two-stream and source-function methods.
+
 See :doc:`../userguide/rtransfer_fbased` for the details of the `fbased` method for reflection and/or emission with scattering.
 
 All of the ``fbased`` schemes are currently based on the two-stream approximation, although the ``ibased`` schemes can specify the number of the streams.

--- a/src/exojax/rt/direct_sfm.py
+++ b/src/exojax/rt/direct_sfm.py
@@ -1,0 +1,101 @@
+"""Layer source coefficients for direct-beam two-stream reflection."""
+
+import math
+
+import jax.numpy as jnp
+
+
+def _attenuation_average(x):
+    """Return ``(1 - exp(-x)) / x``, including its differentiable limit."""
+    small = jnp.abs(x) < 1.0e-3
+    safe_x = jnp.where(small, 1.0, x)
+    regular = -jnp.expm1(-safe_x) / safe_x
+    series_x = jnp.where(small, x, 0.0)
+    series = 1.0 + series_x * (-0.5 + series_x * (1.0 / 6.0 - series_x / 24.0))
+    return jnp.where(small, series, regular)
+
+
+def _beam_moments(x):
+    """Return ``x * integral_0^1 s**n exp(-x*s) ds`` for n = 0,...,3."""
+    small = x < 1.0
+    safe_x = jnp.where(small, 1.0, x)
+    exponential = jnp.exp(-safe_x)
+    moments = [-jnp.expm1(-x)]
+    for order in range(1, 4):
+        regular = order * moments[-1] / safe_x - exponential
+        # The series avoids cancellation in the incomplete-gamma recurrence.
+        series = jnp.zeros_like(x)
+        series_x = jnp.where(small, x, 0.0)
+        for power in range(17, -1, -1):
+            coefficient = (-1.0) ** power / (
+                math.factorial(power) * (order + power + 1)
+            )
+            series = coefficient + series_x * series
+        moments.append(jnp.where(small, x * series, regular))
+    return moments
+
+
+def _direct_layer_sources(dtau, gamma1, gamma2, omega, mu0, gamma3):
+    """Return upward/downward layer sources for a unit incident direct beam.
+
+    The incident irradiance is measured normal to the beam at the layer top.
+    The diffuse incoming intensities at both boundaries are zero. The source
+    coefficients include all two-stream scattering within each uniform layer.
+    Green-function integrals avoid the particular-solution singularity at
+    ``lambda * mu0 = 1``. A Taylor branch includes the conservative limit.
+    """
+    dtau = jnp.asarray(dtau)
+    squared = (gamma1 - gamma2) * (gamma1 + gamma2) * dtau**2
+    use_taylor = squared < jnp.sqrt(jnp.finfo(squared.dtype).eps)
+    safe_squared = jnp.where(use_taylor, 1.0, squared)
+    u = jnp.sqrt(safe_squared)
+    safe_dtau = jnp.where(dtau == 0.0, 1.0, dtau)
+    lam = u / safe_dtau
+    k = 1.0 / mu0
+    x = dtau * k
+    exponential = jnp.exp(-u)
+
+    integral_a = dtau * _attenuation_average(u + x)
+    difference = x - u
+    positive = difference >= 0.0
+    absolute_difference = jnp.where(positive, difference, -difference)
+    integral_b = (
+        dtau
+        * jnp.exp(-jnp.where(positive, u, x))
+        * _attenuation_average(absolute_difference)
+    )
+    c_plus = 0.5 * (integral_a + exponential * integral_b)
+    c_minus = 0.5 * (integral_b + exponential * integral_a)
+    s_plus = 0.5 * (integral_a - exponential * integral_b) / lam
+    s_minus = 0.5 * (integral_b - exponential * integral_a) / lam
+    denominator = 0.5 * (1.0 + exponential**2) + gamma1 * dtau * _attenuation_average(
+        2.0 * u
+    )
+
+    # Cancel the common exp(-u) factor before expanding at lambda = 0.
+    # Retaining squared explicitly also preserves conservative-limit gradients.
+    taylor_squared = jnp.where(use_taylor, squared, 0.0)
+    m0, m1, m2, m3 = _beam_moments(x)
+    c_plus_taylor = mu0 * (m0 + 0.5 * taylor_squared * (m0 - 2.0 * m1 + m2))
+    c_minus_taylor = mu0 * (m0 + 0.5 * taylor_squared * m2)
+    s_plus_taylor = (
+        dtau * mu0 * (m0 - m1 + taylor_squared * (m0 - 3.0 * m1 + 3.0 * m2 - m3) / 6.0)
+    )
+    s_minus_taylor = dtau * mu0 * (m1 + taylor_squared * m3 / 6.0)
+    denominator_taylor = (
+        1.0 + 0.5 * taylor_squared + gamma1 * dtau * (1.0 + taylor_squared / 6.0)
+    )
+    c_plus = jnp.where(use_taylor, c_plus_taylor, c_plus)
+    c_minus = jnp.where(use_taylor, c_minus_taylor, c_minus)
+    s_plus = jnp.where(use_taylor, s_plus_taylor, s_plus)
+    s_minus = jnp.where(use_taylor, s_minus_taylor, s_minus)
+    denominator = jnp.where(use_taylor, denominator_taylor, denominator)
+    gamma4 = 1.0 - gamma3
+    return (
+        omega
+        * (gamma3 * c_plus + (gamma1 * gamma3 + gamma2 * gamma4) * s_plus)
+        / denominator,
+        omega
+        * (gamma4 * c_minus + (gamma1 * gamma4 + gamma2 * gamma3) * s_minus)
+        / denominator,
+    )

--- a/src/exojax/rt/reflect.py
+++ b/src/exojax/rt/reflect.py
@@ -1,3 +1,5 @@
+from math import isfinite
+
 import jax.numpy as jnp
 from exojax.rt.common import ArtCommon
 from exojax.rt.planck import piB, piBarr
@@ -5,10 +7,12 @@ from exojax.rt.rtransfer import (
     initialize_gaussian_quadrature,
     rtrun_reflect_fluxadding_toonhm,
     rtrun_reflect_sfm2st_toonhm,
+    rtrun_reflect_sfm2st_direct,
     setrt_toonhm,
     setrt_toonhm_with_absorption,
 )
 from jax.lax import scan
+from jax.core import Tracer
 
 
 def _surface_optical_depth(dtau, pressure_boundary, pressure_surface):
@@ -112,7 +116,10 @@ class ArtAbsPure(ArtCommon):
 
 
 class ArtReflectPure(ArtCommon):
-    """Atmospheric RT for Pure Reflected light (no source term)
+    """Atmospheric RT for reflected light without thermal emission.
+
+    ``run`` solves diffuse illumination. ``run_direct`` separately returns
+    directional intensity for an incident stellar beam using two-stream SFM.
 
     Attributes:
         pressure_layer: pressure profile in bar
@@ -203,6 +210,75 @@ class ArtReflectPure(ArtCommon):
         else:
             print("rtsolver=", self.rtsolver)
             raise ValueError("Unknown radiative transfer solver (rtsolver).")
+
+    def run_direct(
+        self,
+        dtau,
+        single_scattering_albedo,
+        reflectivity_surface,
+        incoming_flux,
+        mu_in,
+        mu_out,
+        relative_azimuth=0.0,
+        phase_function="rayleigh",
+    ):
+        """Compute reflected specific intensity for a direct stellar beam.
+
+        This method uses SFM with Toon quadrature independently of the
+        diffuse ``rtsolver`` setting. It supports isotropic or Rayleigh
+        scattering, a Lambertian lower boundary, and no thermal emission.
+
+        Args:
+            dtau: Total layer optical depths, top to bottom (N_layer, N_nus).
+            single_scattering_albedo: Scattering / total extinction, with
+                the same shape as dtau and values in [0, 1].
+            reflectivity_surface: Lambertian surface albedo (N_nus or scalar).
+            incoming_flux: Beam-normal spectral irradiance (N_nus or scalar).
+                The horizontal incident flux is mu_in times this value.
+            mu_in: Positive cosine of the stellar zenith angle, scalar (0, 1].
+            mu_out: Positive cosine of the observer zenith angle, scalar (0, 1].
+            relative_azimuth: Azimuth difference between the outward star and
+                observer directions, in radians. Full phase has mu_in=mu_out
+                and relative_azimuth=0.
+            phase_function: "rayleigh" (default) or "isotropic".
+
+        Returns:
+            Specific intensity (N_nus), in the incoming irradiance units per
+            steradian. This is neither hemispheric flux nor geometric albedo.
+
+        Notes:
+            Single scattering is integrated analytically. Multiple scattering
+            uses a Toon-style hemispheric source reconstructed from quadrature
+            fluxes and averaged across each layer. Refine layers to check
+            convergence. Angular integration of the approximate intensity does
+            not exactly preserve the two-stream energy balance. Higher Rayleigh
+            angular moments, polarization, cloud phase functions and disk integration
+            are not included. Use jax.vmap for multiple direction pairs.
+            Angle bounds must also hold when inputs are traced by JAX.
+            Derivatives with respect to a direction cosine are not guaranteed
+            at exactly normal incidence or emergence (a coordinate singularity).
+        """
+        for name, value in (("mu_in", mu_in), ("mu_out", mu_out)):
+            if jnp.ndim(value) != 0:
+                raise ValueError(f"{name} must be a scalar; use jax.vmap for angles")
+            if not isinstance(value, Tracer) and not 0.0 < float(value) <= 1.0:
+                raise ValueError(f"{name} must satisfy 0 < {name} <= 1")
+        if jnp.ndim(relative_azimuth) != 0:
+            raise ValueError("relative_azimuth must be a scalar")
+        if not isinstance(relative_azimuth, Tracer) and not isfinite(
+            float(relative_azimuth)
+        ):
+            raise ValueError("relative_azimuth must be finite")
+        return rtrun_reflect_sfm2st_direct(
+            jnp.asarray(dtau),
+            jnp.asarray(single_scattering_albedo),
+            jnp.asarray(reflectivity_surface),
+            jnp.asarray(incoming_flux),
+            mu_in,
+            mu_out,
+            relative_azimuth,
+            phase_function,
+        )
 
     def run_ckd(
         self,

--- a/src/exojax/rt/rtransfer.py
+++ b/src/exojax/rt/rtransfer.py
@@ -31,6 +31,8 @@
 
 """
 
+from functools import partial
+
 import jax.numpy as jnp
 from jax import jit
 from jax.lax import scan
@@ -39,8 +41,10 @@ from jax.scipy.integrate import trapezoid
 from exojax.signal.integrate import simpson
 from exojax.rt.toon import (
     params_hemispheric_mean,
+    params_quadrature,
     zetalambda_coeffs,
 )
+from exojax.rt.direct_sfm import _direct_layer_sources
 from exojax.rt.twostream import (
     compute_tridiag_diagonals_and_vector,
     set_scat_trans_absorption_coeffs,
@@ -795,6 +799,94 @@ def rtrun_reflect_sfm2st_toonhm(
         mus,
         weights,
     )
+
+
+@partial(jit, static_argnames=("phase_function",))
+def rtrun_reflect_sfm2st_direct(
+    dtau,
+    single_scattering_albedo,
+    reflectivity_surface,
+    incoming_flux,
+    mu_in,
+    mu_out,
+    relative_azimuth=0.0,
+    phase_function="rayleigh",
+):
+    """Return specific intensity for direct illumination using two-stream SFM.
+
+    ``incoming_flux`` is beam-normal irradiance; the horizontal incident flux
+    is ``mu_in * incoming_flux``. Both positive direction cosines are scalar.
+    ``relative_azimuth`` is the azimuth difference between the outward star
+    and observer directions, in radians. The result is physical intensity
+    (irradiance per steradian), rather than the pi-I scale used internally.
+
+    Isotropic and Rayleigh single scattering are integrated analytically in
+    each homogeneous layer. Multiple scattering uses Toon quadrature with
+    g=0 and a Toon-style hemispheric, layer-averaged source reconstruction. This
+    approximation does not retain Rayleigh's higher angular moments or
+    polarization. Resolve the diffuse source by refining the optical-depth
+    layers. Angular integration of this approximate intensity need not conserve
+    the two-stream flux exactly, even after layer convergence. The lower
+    boundary is Lambertian; the top has no diffuse source.
+    No disk integration is performed.
+    """
+    if phase_function not in ("isotropic", "rayleigh"):
+        raise ValueError("phase_function must be 'isotropic' or 'rayleigh'")
+
+    gamma_1, gamma_2, gamma_3, _ = params_quadrature(
+        single_scattering_albedo, jnp.zeros_like(dtau), mu_in
+    )
+    trans, scat, absorption = set_scat_trans_absorption_coeffs(
+        gamma_1, gamma_2, dtau
+    )
+    source_plus, source_minus = _direct_layer_sources(
+        dtau, gamma_1, gamma_2, single_scattering_albedo, mu_in, gamma_3
+    )
+    tau = jnp.concatenate((jnp.zeros_like(dtau[:1]), jnp.cumsum(dtau, axis=0)))
+    beam = incoming_flux * jnp.exp(-tau / mu_in)
+    surface = jnp.broadcast_to(reflectivity_surface, dtau.shape[1:])
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        trans,
+        scat,
+        jnp.zeros_like(dtau),
+        surface,
+        surface * mu_in * beam[-1],
+        absorption_coeff=absorption,
+        source_plus=source_plus * beam[:-1],
+        source_minus=source_minus * beam[:-1],
+    )
+
+    # F+ and F- contain scattered light only, so scattering this field adds
+    # the multiple-scattering contribution without counting the beam twice.
+    diffuse_source = 0.25 * single_scattering_albedo * (
+        flux_plus[:-1] + flux_plus[1:] + flux_minus[:-1] + flux_minus[1:]
+    )
+    diffuse_pi_intensity = rtrun_emis_pureabs_ibased_intensity_surface(
+        dtau, diffuse_source, flux_plus[-1], jnp.atleast_1d(mu_out)
+    )[0]
+
+    phase = 1.0
+    if phase_function == "rayleigh":
+        sine_product_squared = (1.0 - mu_in**2) * (1.0 - mu_out**2)
+        # Keep derivatives finite when either direction is exactly normal.
+        at_normal = sine_product_squared == 0.0
+        sine_product = jnp.where(
+            at_normal, 0.0, jnp.sqrt(jnp.where(at_normal, 1.0, sine_product_squared))
+        )
+        cos_scattering = -(
+            mu_in * mu_out + sine_product * jnp.cos(relative_azimuth)
+        )
+        phase = 0.75 * (1.0 + cos_scattering**2)
+
+    attenuation = jnp.exp(-tau[:-1] / mu_out) * -jnp.expm1(
+        -dtau * (1.0 / mu_in + 1.0 / mu_out)
+    )
+    single_pi_intensity = jnp.sum(
+        0.25 * single_scattering_albedo * phase * beam[:-1] * attenuation
+        * mu_in / (mu_in + mu_out),
+        axis=0,
+    )
+    return (diffuse_pi_intensity + single_pi_intensity) / jnp.pi
 
 
 def setrt_toonhm(

--- a/src/exojax/rt/twostream.py
+++ b/src/exojax/rt/twostream.py
@@ -63,6 +63,8 @@ def compute_fluxadding_coeffs(
     reflectivity_bottom,
     source_bottom,
     absorption_coeff=None,
+    source_plus=None,
+    source_minus=None,
 ):
     """Computes upward effective reflection/source at all interfaces.
 
@@ -74,6 +76,8 @@ def compute_fluxadding_coeffs(
         source_bottom: Bottom boundary source (Nnus).
         absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
             it is reconstructed from the transmission and scattering coefficients.
+        source_plus, source_minus: Optional upward/downward layer source fluxes.
+            Each overrides the corresponding thermal source when provided.
 
     Returns:
         tuple: Rplus, Splus, each with shape (Nlayer + 1, Nnus).
@@ -86,6 +90,8 @@ def compute_fluxadding_coeffs(
         )
     absorption_coeff = jnp.broadcast_to(absorption_coeff, trans_coeff.shape)
     pihatB = absorption_coeff * reduced_source_function
+    source_plus = pihatB if source_plus is None else source_plus
+    source_minus = pihatB if source_minus is None else source_minus
     non_scattering_coeff = trans_coeff + absorption_coeff
     stable_scat_coeff = _pack_scat_and_non_scattering_coeffs(
         scat_coeff, non_scattering_coeff
@@ -97,7 +103,7 @@ def compute_fluxadding_coeffs(
 
     def f(carry_ip1, arr):
         Rplus_prev, Splus_prev = carry_ip1
-        stable_scat_coeff_i, trans_coeff_i, pihatB_i = arr
+        stable_scat_coeff_i, trans_coeff_i, source_plus_i, source_minus_i = arr
         stores_non_scattering = jnp.signbit(stable_scat_coeff_i)
         scat_coeff_i = jnp.where(
             stores_non_scattering,
@@ -111,7 +117,8 @@ def compute_fluxadding_coeffs(
             1.0 - scat_reflect,
         )
         Splus_each = (
-            pihatB_i + trans_coeff_i * (Splus_prev + pihatB_i * Rplus_prev) / denom
+            source_plus_i
+            + trans_coeff_i * (Splus_prev + source_minus_i * Rplus_prev) / denom
         )
         Rplus_each = scat_coeff_i + trans_coeff_i**2 * Rplus_prev / denom
         RS = [Rplus_each, Splus_each]
@@ -121,7 +128,8 @@ def compute_fluxadding_coeffs(
     arrin = [
         stable_scat_coeff[::-1],
         trans_coeff[::-1],
-        pihatB[::-1],
+        source_plus[::-1],
+        source_minus[::-1],
     ]
     _, stackedRS = scan(f, [Rplus_bottom, Splus_bottom], arrin)
     Rplus_reverse, Splus_reverse = stackedRS
@@ -137,6 +145,8 @@ def compute_fluxadding_downward_coeffs(
     reduced_source_function,
     source_top=None,
     absorption_coeff=None,
+    source_plus=None,
+    source_minus=None,
 ):
     """Computes downward effective reflection/source at all interfaces.
 
@@ -150,6 +160,8 @@ def compute_fluxadding_downward_coeffs(
         source_top: Top boundary incoming flux (Nnus). Defaults to zero.
         absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
             it is reconstructed from the transmission and scattering coefficients.
+        source_plus, source_minus: Optional upward/downward layer source fluxes.
+            Each overrides the corresponding thermal source when provided.
 
     Returns:
         tuple: Rminus, Sminus, each with shape (Nlayer + 1, Nnus).
@@ -166,6 +178,8 @@ def compute_fluxadding_downward_coeffs(
         )
     absorption_coeff = jnp.broadcast_to(absorption_coeff, trans_coeff.shape)
     pihatB = absorption_coeff * reduced_source_function
+    source_plus = pihatB if source_plus is None else source_plus
+    source_minus = pihatB if source_minus is None else source_minus
     non_scattering_coeff = trans_coeff + absorption_coeff
     stable_scat_coeff = _pack_scat_and_non_scattering_coeffs(
         scat_coeff, non_scattering_coeff
@@ -175,7 +189,7 @@ def compute_fluxadding_downward_coeffs(
 
     def f(carry_i, arr):
         Rminus_prev, Sminus_prev = carry_i
-        stable_scat_coeff_i, trans_coeff_i, pihatB_i = arr
+        stable_scat_coeff_i, trans_coeff_i, source_plus_i, source_minus_i = arr
         stores_non_scattering = jnp.signbit(stable_scat_coeff_i)
         scat_coeff_i = jnp.where(
             stores_non_scattering,
@@ -189,13 +203,14 @@ def compute_fluxadding_downward_coeffs(
             1.0 - scat_reflect,
         )
         Sminus_each = (
-            pihatB_i + trans_coeff_i * (Sminus_prev + pihatB_i * Rminus_prev) / denom
+            source_minus_i
+            + trans_coeff_i * (Sminus_prev + source_plus_i * Rminus_prev) / denom
         )
         Rminus_each = scat_coeff_i + trans_coeff_i**2 * Rminus_prev / denom
         RS = [Rminus_each, Sminus_each]
         return RS, RS
 
-    arrin = [stable_scat_coeff, trans_coeff, pihatB]
+    arrin = [stable_scat_coeff, trans_coeff, source_plus, source_minus]
     _, stackedRS = scan(f, [Rminus_top, Sminus_top], arrin)
     Rminus_layers, Sminus_layers = stackedRS
 
@@ -212,6 +227,8 @@ def solve_fluxadding_twostream_fluxes(
     source_bottom,
     source_top=None,
     absorption_coeff=None,
+    source_plus=None,
+    source_minus=None,
 ):
     """Computes two-stream upward and downward fluxes at all interfaces.
 
@@ -224,6 +241,8 @@ def solve_fluxadding_twostream_fluxes(
         source_top: Top boundary incoming flux (Nnus). Defaults to zero.
         absorption_coeff: Absorption coefficient (Nlayer, Nnus). If omitted,
             it is reconstructed from the transmission and scattering coefficients.
+        source_plus, source_minus: Optional upward/downward layer source fluxes.
+            Each overrides the corresponding thermal source when provided.
 
     Returns:
         tuple: flux_plus, flux_minus, each with shape (Nlayer + 1, Nnus).
@@ -236,6 +255,8 @@ def solve_fluxadding_twostream_fluxes(
         reflectivity_bottom,
         source_bottom,
         absorption_coeff,
+        source_plus,
+        source_minus,
     )
     Rminus, Sminus = compute_fluxadding_downward_coeffs(
         trans_coeff,
@@ -243,6 +264,8 @@ def solve_fluxadding_twostream_fluxes(
         reduced_source_function,
         source_top,
         absorption_coeff,
+        source_plus,
+        source_minus,
     )
 
     denom = (1.0 - Rplus) + Rplus * (1.0 - Rminus)

--- a/tests/unittests/rt/test_reflect_direct.py
+++ b/tests/unittests/rt/test_reflect_direct.py
@@ -1,0 +1,261 @@
+"""Physical limits and differentiation of reflection from a direct beam."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.linalg import expm
+
+from exojax.rt import ArtReflectPure
+from exojax.rt.direct_sfm import _direct_layer_sources
+from exojax.rt.twostream import (
+    set_scat_trans_absorption_coeffs,
+    solve_fluxadding_twostream_fluxes,
+)
+
+try:
+    from jax import enable_x64
+except ImportError:
+    from jax.experimental import enable_x64
+
+
+@pytest.fixture(autouse=True)
+def _double_precision():
+    with enable_x64():
+        yield
+
+
+def _art(nlayer=2, nnus=3):
+    return ArtReflectPure(nlayer=nlayer, nu_grid=jnp.arange(nnus) + 1000.0)
+
+
+def test_direct_absorbing_black_atmosphere_returns_zero():
+    dtau = jnp.array([[0.0, 0.3, 40.0], [0.0, 0.7, 60.0]])
+    actual = _art().run_direct(
+        dtau, jnp.zeros_like(dtau), jnp.zeros(3), jnp.ones(3), 0.4, 0.7
+    )
+
+    np.testing.assert_array_equal(actual, np.zeros(3))
+
+
+@pytest.mark.parametrize("transparent", [True, False])
+def test_direct_lambert_surface_normalization_and_absorption(transparent):
+    dtau = jnp.array([[0.0, 0.2, 0.7], [0.0, 0.3, 1.1]])
+    if transparent:
+        dtau = jnp.zeros_like(dtau)
+    albedo = jnp.array([0.2, 0.4, 0.8])
+    incident = jnp.array([1.0, 2.0, 3.0])
+    mu_in, mu_out = 0.3, 0.7
+
+    actual = _art().run_direct(
+        dtau, jnp.zeros_like(dtau), albedo, incident, mu_in, mu_out
+    )
+    expected = (
+        albedo
+        * mu_in
+        * incident
+        / np.pi
+        * jnp.exp(-jnp.sum(dtau, axis=0) * (1.0 / mu_in + 1.0 / mu_out))
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1.0e-12, atol=0.0)
+
+
+@pytest.mark.parametrize("nlayer", [2, 7])
+@pytest.mark.parametrize("phase_function", ["isotropic", "rayleigh"])
+@pytest.mark.parametrize("mu_in,mu_out,azimuth", [(1.0, 1.0, 0.0), (0.2, 0.7, 1.1)])
+def test_direct_weak_scattering_matches_analytic_single_scattering(
+    nlayer, phase_function, mu_in, mu_out, azimuth
+):
+    total_tau = jnp.array([0.0, 1.0e-8, 1.0, 100.0])
+    fractions = jnp.arange(1.0, nlayer + 1.0)
+    fractions = fractions / jnp.sum(fractions)
+    dtau = fractions[:, None] * total_tau[None, :]
+    omega = 1.0e-8
+    incident = jnp.array([1.0, 2.0, 3.0, 4.0])
+
+    actual = _art(nlayer, 4).run_direct(
+        dtau,
+        jnp.full_like(dtau, omega),
+        jnp.zeros(4),
+        incident,
+        mu_in,
+        mu_out,
+        relative_azimuth=azimuth,
+        phase_function=phase_function,
+    )
+    cos_phase = mu_in * mu_out + np.sqrt(1.0 - mu_in**2) * np.sqrt(
+        1.0 - mu_out**2
+    ) * np.cos(azimuth)
+    phase = 1.0 if phase_function == "isotropic" else 0.75 * (1.0 + cos_phase**2)
+    expected = (
+        omega
+        * incident
+        / (4.0 * np.pi)
+        * phase
+        * mu_in
+        / (mu_in + mu_out)
+        * -jnp.expm1(-total_tau * (1.0 / mu_in + 1.0 / mu_out))
+    )
+
+    # Multiple scattering contributes only at second order in omega.
+    np.testing.assert_allclose(actual, expected, rtol=2.0e-6, atol=0.0)
+
+
+def test_direct_rayleigh_backscatter_and_azimuth_dependence():
+    art = _art()
+    dtau = jnp.full((2, 3), 0.1)
+    inputs = (dtau, jnp.full_like(dtau, 1.0e-8), jnp.zeros(3), jnp.ones(3))
+    mu = 1.0 / np.sqrt(2.0)
+
+    isotropic = art.run_direct(*inputs, mu, mu, phase_function="isotropic")
+    backscatter = art.run_direct(*inputs, mu, mu, relative_azimuth=0.0)
+    right_angle = art.run_direct(*inputs, mu, mu, relative_azimuth=np.pi)
+
+    np.testing.assert_allclose(backscatter / isotropic, 1.5, rtol=2.0e-7)
+    np.testing.assert_allclose(right_angle / isotropic, 0.75, rtol=2.0e-7)
+
+
+def test_direct_jit_and_gradients_at_transparency_resonance_and_conservative_limit():
+    art = _art(nnus=4)
+    dtau = jnp.array([[0.0, 0.3, 0.7, 20.0], [0.0, 0.5, 1.1, 80.0]])
+    omega = jnp.broadcast_to(jnp.array([0.0, 2.0 / 3.0, 0.8, 1.0]), dtau.shape)
+
+    def reflected_sum(optical_depth, scattering_albedo):
+        return jnp.sum(
+            art.run_direct(
+                optical_depth,
+                scattering_albedo,
+                jnp.full(4, 0.2),
+                jnp.ones(4),
+                1.0,
+                0.6,
+            )
+        )
+
+    value, gradients = jax.jit(jax.value_and_grad(reflected_sum, argnums=(0, 1)))(
+        dtau, omega
+    )
+    assert np.isfinite(value)
+    for derivative in gradients:
+        assert np.all(np.isfinite(derivative))
+
+    # Check an interior derivative of each independent optical property.
+    step = 1.0e-5
+    perturbation = jnp.zeros_like(dtau).at[0, 2].set(step)
+    finite_tau = (
+        reflected_sum(dtau + perturbation, omega)
+        - reflected_sum(dtau - perturbation, omega)
+    ) / (2.0 * step)
+    finite_omega = (
+        reflected_sum(dtau, omega + perturbation)
+        - reflected_sum(dtau, omega - perturbation)
+    ) / (2.0 * step)
+    np.testing.assert_allclose(gradients[0][0, 2], finite_tau, rtol=2.0e-5, atol=1.0e-9)
+    np.testing.assert_allclose(
+        gradients[1][0, 2], finite_omega, rtol=2.0e-5, atol=1.0e-9
+    )
+
+
+def test_direct_full_phase_lambert_sphere_has_two_thirds_surface_albedo():
+    art = _art(nnus=2)
+    dtau = jnp.zeros((2, 2))
+    albedo = jnp.array([0.3, 0.8])
+    incident = jnp.array([2.0, 3.0])
+    abscissa, weights = np.polynomial.legendre.leggauss(8)
+    mus = jnp.asarray((abscissa + 1.0) / 2.0)
+    weights = jnp.asarray(weights / 2.0)
+
+    intensities = jax.jit(
+        jax.vmap(lambda mu: art.run_direct(dtau, dtau, albedo, incident, mu, mu))
+    )(mus)
+    geometric_albedo = (
+        2.0
+        * np.pi
+        * jnp.sum(weights[:, None] * mus[:, None] * intensities, axis=0)
+        / incident
+    )
+
+    np.testing.assert_allclose(geometric_albedo, 2.0 * albedo / 3.0, rtol=1.0e-12)
+
+
+@pytest.mark.parametrize(
+    "mu_in,mu_out", [(0.0, 0.5), (0.5, -0.1), (1.1, 0.5), (0.5, np.nan)]
+)
+def test_direct_rejects_invalid_angles(mu_in, mu_out):
+    dtau = jnp.ones((2, 3))
+    with pytest.raises(ValueError):
+        _art().run_direct(dtau, dtau, jnp.zeros(3), jnp.ones(3), mu_in, mu_out)
+
+
+def test_direct_rejects_unknown_phase_function():
+    dtau = jnp.ones((2, 3))
+    with pytest.raises(ValueError, match="phase"):
+        _art().run_direct(
+            dtau,
+            dtau,
+            jnp.zeros(3),
+            jnp.ones(3),
+            0.5,
+            0.5,
+            phase_function="unknown",
+        )
+
+
+@pytest.mark.parametrize("omega", [0.5, 2.0 / 3.0, 1.0])
+@pytest.mark.parametrize("mu_in", [0.2, 1.0])
+def test_direct_layer_sources_match_matrix_exponential(omega, mu_in):
+    dtau = jnp.array([0.0, 0.1, 3.0])
+    gamma1 = np.sqrt(3.0) * (1.0 - omega / 2.0)
+    gamma2 = np.sqrt(3.0) * omega / 2.0
+    gamma3 = 0.5
+    actual = _direct_layer_sources(dtau, gamma1, gamma2, omega, mu_in, gamma3)
+
+    # Propagate [F_plus, F_minus, beam] through a homogeneous layer, then
+    # impose zero incoming diffuse flux at both boundaries.
+    equation = np.array(
+        [
+            [gamma1, -gamma2, -omega * gamma3],
+            [gamma2, -gamma1, omega * (1.0 - gamma3)],
+            [0.0, 0.0, -1.0 / mu_in],
+        ]
+    )
+    expected = []
+    for optical_depth in np.asarray(dtau):
+        transfer = expm(equation * optical_depth)
+        source_plus = -transfer[0, 2] / transfer[0, 0]
+        source_minus = transfer[1, 0] * source_plus + transfer[1, 2]
+        expected.append((source_plus, source_minus))
+
+    np.testing.assert_allclose(
+        actual, np.asarray(expected).T, rtol=1.0e-11, atol=1.0e-14
+    )
+
+
+@pytest.mark.parametrize("mu_in", [0.2, 1.0])
+def test_direct_conservative_layer_stack_conserves_beam_energy(mu_in):
+    dtau = jnp.array([[0.0, 1.0e-8, 0.01], [0.1, 0.3, 0.5], [0.9, 2.7, 10.0]])
+    omega = jnp.ones_like(dtau)
+    gamma = jnp.full_like(dtau, np.sqrt(3.0) / 2.0)
+    trans, scat, absorption = set_scat_trans_absorption_coeffs(gamma, gamma, dtau)
+    source_plus, source_minus = _direct_layer_sources(
+        dtau, gamma, gamma, omega, mu_in, 0.5
+    )
+    tau = jnp.concatenate((jnp.zeros_like(dtau[:1]), jnp.cumsum(dtau, axis=0)))
+    beam = jnp.exp(-tau / mu_in)
+
+    flux_plus, flux_minus = solve_fluxadding_twostream_fluxes(
+        trans,
+        scat,
+        jnp.zeros_like(dtau),
+        jnp.zeros(3),
+        jnp.zeros(3),
+        absorption_coeff=absorption,
+        source_plus=source_plus * beam[:-1],
+        source_minus=source_minus * beam[:-1],
+    )
+
+    # All incident energy leaves the top or reaches the black lower boundary.
+    np.testing.assert_allclose(
+        flux_plus[0] + flux_minus[-1] + mu_in * beam[-1], mu_in, rtol=1.0e-12
+    )


### PR DESCRIPTION
## Purpose and behavior

`ArtReflectPure.run` accepts a diffuse incident hemispheric flux. A stellar beam illuminating a particular atmospheric column additionally requires an incident direction, a viewing direction, and a directional intensity output. This PR adds `ArtReflectPure.run_direct` for that calculation, using direct-beam forcing of a two-stream solution followed by the source function method (SFM).

The initial scope is a plane-parallel atmosphere with isotropic or Rayleigh scattering, a Lambertian lower boundary, and no thermal emission. The API returns specific intensity for one direction pair. It supports JAX differentiation and can be mapped over direction pairs with `jax.vmap`. Geometric albedo and planetary disk integration remain separate calculations.

## API and normalization

```python
intensity = art.run_direct(
    dtau,
    single_scattering_albedo,
    reflectivity_surface=0.0,
    incoming_flux=stellar_flux,
    mu_in=0.6,
    mu_out=0.6,
    relative_azimuth=0.0,
    phase_function="rayleigh",  # or "isotropic"
)
```

`dtau` and `single_scattering_albedo` have shape `(N_layer, N_nus)`, ordered from the top downward. The surface albedo and incident irradiance can be scalars or wavelength vectors. Both direction cosines are scalars in `(0, 1]`.

Let optical depth increase downward and write

$$
\mu_0 = \mu_{in}, \qquad \mu = \mu_{out}.
$$

`incoming_flux` is the spectral irradiance measured **perpendicular to the incident beam**, denoted by $F_0$. Its attenuated value is

$$
B(\tau)=F_0 e^{-\tau/\mu_0}.
$$

The incident flux through a horizontal surface is therefore $\mu_0 F_0$. The returned array has shape `(N_nus,)` and contains **physical specific intensity** $I$, in the incident irradiance units per steradian. Internally, the existing formal solver uses a $\pi I$ scale; this method divides by $\pi$ before returning.

The separate method makes this normalization explicit. `run_direct` always uses direct SFM, independently of the diffuse `rtsolver` and `nstream` settings. Existing `run` and CKD behavior are preserved.

### Geometry and phase functions

The relative azimuth $\Delta\phi$ is measured in radians between the **outward directions toward the star and observer**. With this convention, the atmospheric scattering angle obeys

$$
\cos\Theta=-\left[\mu_0\mu+\sqrt{(1-\mu_0^2)(1-\mu^2)}\cos\Delta\phi\right].
$$

Full phase has $\mu_0=\mu$, $\Delta\phi=0$, and $\Theta=\pi$. The supported single-scattering phase functions are normalized so that $\int P\,d\Omega=4\pi$:

$$
P_{\rm isotropic}=1, \qquad P_{\rm Rayleigh}=\frac{3}{4}(1+\cos^2\Theta).
$$

## Algorithm

### 1. Solve the diffuse field driven by the stellar beam

The two-stream fluxes $F^+$ and $F^-$ contain scattered and surface-reflected light; they exclude the unscattered stellar beam. Within each homogeneous layer, the forced equations are

$$
\frac{d}{d\tau}\begin{pmatrix}F^+\\F^-\end{pmatrix}
=\begin{pmatrix}\gamma_1&-\gamma_2\\\gamma_2&-\gamma_1\end{pmatrix}
\begin{pmatrix}F^+\\F^-\end{pmatrix}
+\omega B(\tau)\begin{pmatrix}-\gamma_3\\\gamma_4\end{pmatrix}.
$$

Here $\omega$ is the single-scattering albedo. The implementation uses Toon quadrature with $g=0$:

$$
\gamma_1=\sqrt{3}(1-\omega/2),\quad
\gamma_2=\sqrt{3}\,\omega/2,\quad
\gamma_3=\gamma_4=\frac12,\quad
\lambda=\sqrt{\gamma_1^2-\gamma_2^2}=\sqrt{3(1-\omega)}.
$$

For layer $i$, the resulting direct-beam source fluxes $q_i^+$ and $q_i^-$ enter the flux-adding relations

$$
F_i^+=R_iF_i^-+T_iF_{i+1}^++q_i^+,
\qquad
F_{i+1}^-=T_iF_i^-+R_iF_{i+1}^++q_i^-.
$$

Direct illumination generally produces **unequal upward and downward layer sources**. The flux-adding routines now accept optional `source_plus` and `source_minus` arrays to represent them. Omitting these arguments retains the existing equal thermal-source calculation.

At the top, there is no incoming diffuse flux. At a Lambertian lower boundary of albedo $a_s$,

$$
F_0^-=0, \qquad F_N^+=a_s\left[F_N^-+\mu_0B(\tau_N)\right].
$$

### 2. Integrate direct-beam single scattering analytically

For layer-top optical depth $\tau_i$ and layer thickness $\Delta\tau_i$, the single-scattering contribution to the top-of-atmosphere intensity is

$$
I_{\rm single}
=\sum_i\frac{\omega_i P(\Theta)F_0}{4\pi}
\frac{\mu_0}{\mu_0+\mu}
e^{-\tau_i(1/\mu_0+1/\mu)}
\left[1-e^{-\Delta\tau_i(1/\mu_0+1/\mu)}\right].
$$

This retains the full selected phase function and both the incoming and outgoing attenuation paths. `expm1` preserves the optically thin limit.

### 3. Apply SFM to the diffuse field and surface

The diffuse scattering source is reconstructed from the two-stream fluxes and averaged between the interfaces of each layer:

$$
\pi\overline{S}_i^{\rm diffuse}
=\frac{\omega_i}{4}
\left[F_i^++F_{i+1}^++F_i^-+F_{i+1}^-\right].
$$

Using the existing layer-constant intensity formal solution gives

$$
I_{\rm diffuse+surface}
=\sum_i\overline{S}_i^{\rm diffuse}
\left[e^{-\tau_i/\mu}-e^{-\tau_{i+1}/\mu}\right]
+\frac{F_N^+}{\pi}e^{-\tau_N/\mu}.
$$

The result is $I=I_{\rm single}+I_{\rm diffuse+surface}$. Since the diffuse field excludes the original beam, scattering that field supplies the additional scattering orders without counting the direct-beam single-scattering term twice.

For a transparent atmosphere, the expression reduces to the Lambertian normalization

$$
I=\frac{a_s\mu_0F_0}{\pi}.
$$

## Stable direct-layer sources

`direct_sfm.py` evaluates the forced layer sources through analytic Green-function integrals. For a layer of thickness $d$, let $B_i$ be the beam-normal irradiance at its top and define

$$
H=\cosh(\lambda d)+\frac{\gamma_1}{\lambda}\sinh(\lambda d).
$$

Then

$$
q_i^+=\frac{\omega B_i}{H}\int_0^d e^{-t/\mu_0}
\left[\gamma_3\cosh(\lambda(d-t))+
\frac{\gamma_1\gamma_3+\gamma_2\gamma_4}{\lambda}\sinh(\lambda(d-t))\right]dt,
$$

$$
q_i^-=\frac{\omega B_i}{H}\int_0^d e^{-t/\mu_0}
\left[\gamma_4\cosh(\lambda t)+
\frac{\gamma_1\gamma_4+\gamma_2\gamma_3}{\lambda}\sinh(\lambda t)\right]dt.
$$

The implementation uses exponentially scaled forms of these expressions, rather than evaluating large hyperbolic functions. Small-argument series for the attenuation averages and beam moments avoid cancellation. A Taylor branch in $(\lambda d)^2$ preserves the conservative limit and its derivatives. In particular, the implementation handles:

- zero layer optical depth;
- conservative scattering, $\omega=1$ and $\lambda=0$;
- the apparent particular-solution singularity at $\lambda\mu_0=1$.

The helper returns coefficients for unit beam-normal irradiance at the layer top; the caller multiplies by the attenuated incident beam.

## Accuracy and scope

Only the direct-beam single-scattering term retains the complete Rayleigh angular dependence. Multiple scattering uses $g=0$ quadrature fluxes and a **Toon-style hemispheric source reconstruction**. This is a mixed angular approximation; higher Rayleigh angular moments, polarization, cloud phase functions, and thermal emission are outside this implementation.

Layer refinement resolves the averaging of the diffuse source. It does **not** remove the angular approximation. The internal two-stream solution conserves energy for conservative scattering; for a black lower boundary the tested identity is

$$
F_0^+ + F_N^- + \mu_0B(\tau_N)=\mu_0F_0.
$$

However, integrating the reconstructed directional intensity over outgoing angles need not reproduce that two-stream flux exactly. A local diagnostic with isotropic conservative scattering, total optical depth 10, a perfectly reflecting surface, and 2,000 uniform layers found reflected/input flux ratios of approximately 0.9535, 0.9632, and 0.9880 for incident cosines 0.1, 0.5, and 1.0. These approximately 1–5% differences are limitations of the source/angular approximation, and are documented in the user guide.

Angle bounds must also hold for traced inputs. Derivatives with respect to direction cosines at exactly normal incidence or emergence are not guaranteed because those angular coordinates are singular there.

## Validation

**71 tests passed: 27 new direct-reflection cases and 44 existing RT cases.** The new tests cover:

- absorbing atmospheres with black or Lambertian lower boundaries, including the transparent-surface normalization;
- the analytic weak-scattering limit across layer partitions, optical depths, and viewing directions;
- Rayleigh backscattering and azimuth dependence;
- JIT and finite gradients at zero optical depth, conservative scattering, and the apparent resonance, plus finite-difference derivative checks at interior points;
- the full-phase Lambert-sphere identity $A_g=2a_s/3$, evaluated in the test by integrating directional intensities;
- independent layer-source reference values from a three-state ODE solved with `scipy.linalg.expm`;
- conservative two-stream energy balance across nonuniform layers and invalid-angle/phase-function handling.

```bash
JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 python -m pytest -q \
  tests/unittests/rt/test_reflect_direct.py \
  tests/unittests/rt/test_reflect_sfm2st.py \
  tests/unittests/rt/test_toon.py \
  tests/unittests/rt/test_twostream.py \
  tests/unittests/rt/test_emis_scat_sfm2st.py \
  tests/unittests/rt/test_reflect_ckd.py \
  tests/unittests/rt/test_reflect_emis_ckd.py \
  tests/unittests/rt/test_opart_fluxadding.py
```

An additional local diagnostic compared directional intensities with POSEIDON v1.2 `reflection_Toon`, explicitly selecting its `multi_phase=1` reconstruction and matching the optical properties and five viewing directions. For paired total-depth/scattering-albedo cases `(0.1, 0.2)`, `(1, 0.8)`, and `(10, 0.999)`, the maximum relative differences were:

| Uniform layers | Maximum relative intensity difference |
| ---: | ---: |
| 16 | 6.315e-3 |
| 64 | 4.254e-4 |
| 256 | 2.672e-5 |
| 1,024 | 1.671e-6 |

This is a convergence check against the **same simplified diffuse reconstruction**, not a comparison against POSEIDON's default higher-moment Rayleigh treatment or the HD 189733 b retrieval spectrum. It is not part of CI and requires the external POSEIDON source. The checked `emission.py` SHA-256 was `0f0681885c91f7976e48438f445b0838d382e335923d18aa2b834ad0ae2880bd`.

The algorithm follows the two-stream/source-function framework of [Toon et al. (1989)](https://doi.org/10.1029/JD094iD13p16287). This PR contains the RT implementation, its tests, and API documentation; the existing HD 189733 b data and reports are not included.
