### PR TITLE
Use real-space profile kernels by default when building DiffGrid

### DIFF
--- a/documents/tutorials/diffgrid_nuts_retrieval.ipynb
+++ b/documents/tutorials/diffgrid_nuts_retrieval.ipynb
@@ -226,7 +226,9 @@
     "\n",
     "YT10to10 contains about 80 million transitions in this spectral interval, so loading the database and constructing the teacher can take time. The PreMODIT settings below mirror the corresponding example and define the mock observation used in this run. The teacher is needed only while the DiffGrid table is built.\n",
     "\n",
-    "Cubic Hermite interpolation is performed in inverse temperature. We therefore place the nodes uniformly in $1/T$. The example starts with 21 nodes; the validation below determines whether that is sufficient for the intended noise level."
+    "Cubic Hermite interpolation is performed in inverse temperature. We therefore place the nodes uniformly in $1/T$. The example starts with 21 nodes; the validation below determines whether that is sufficient for the intended noise level.\n",
+    "\n",
+    "This demonstration explicitly keeps the analytic kernel used for its recorded outputs. New DiffGrid tables default to the real-space kernel; see [DiffGrid](../userguide/diffgrid.rst) for selecting a kernel and matching the validation teacher."
    ]
   },
   {
@@ -381,6 +383,7 @@
     "    teacher,\n",
     "    temperature_grid=temperature_nodes,\n",
     "    pressure_grid=np.asarray(art.pressure),\n",
+    "    profile_kernel=\"analytic\",\n",
     ")\n",
     "jax.block_until_ready(opa.log_cross_section_grid)\n",
     "jax.block_until_ready(opa.log_cross_section_derivative_grid)\n",
@@ -923,6 +926,8 @@
    "metadata": {},
    "source": [
     "## Validate observation-space accuracy and gradients\n",
+    "\n",
+    "New benchmark preparations use `prepare --profile-kernel real_space` by default for both the saved PreMODIT teacher and DiffGrid construction. Use `--profile-kernel analytic` to reproduce the original kernel choice. Existing saved cases retain their recorded calculations.\n",
     "\n",
     "The benchmark's `validate` command adds the P0/PR2 checks to an existing prepared case. It reuses the saved observations and opacity archives; the numerical notebook cells above remain the original demonstration. From the repository root:\n",
     "\n",

--- a/documents/tutorials/diffgrid_nuts_retrieval.rst
+++ b/documents/tutorials/diffgrid_nuts_retrieval.rst
@@ -186,6 +186,11 @@ therefore place the nodes uniformly in :math:`1/T`. The example starts
 with 21 nodes; the validation below determines whether that is
 sufficient for the intended noise level.
 
+This demonstration explicitly keeps the analytic kernel used for its
+recorded outputs. New DiffGrid tables default to the real-space kernel;
+see :doc:`../userguide/diffgrid` for selecting a kernel and matching the
+validation teacher.
+
 .. code:: ipython3
 
     mdb = MdbExomol(
@@ -216,6 +221,7 @@ sufficient for the intended noise level.
         teacher,
         temperature_grid=temperature_nodes,
         pressure_grid=np.asarray(art.pressure),
+        profile_kernel="analytic",
     )
     jax.block_until_ready(opa.log_cross_section_grid)
     jax.block_until_ready(opa.log_cross_section_derivative_grid)
@@ -767,6 +773,11 @@ the five-profile interpolation check are specific to this example.
 
 Validate observation-space accuracy and gradients
 -------------------------------------------------
+
+New benchmark preparations use ``prepare --profile-kernel real_space``
+by default for both the saved PreMODIT teacher and DiffGrid construction.
+Use ``--profile-kernel analytic`` to reproduce the original kernel choice.
+Existing saved cases retain their recorded calculations.
 
 The benchmark’s ``validate`` command adds the P0/PR2 checks to an
 existing prepared case. It reuses the saved observations and opacity

--- a/documents/userguide/diffgrid.rst
+++ b/documents/userguide/diffgrid.rst
@@ -1,7 +1,7 @@
 DiffGrid
 ========
 
-`Last update: August 25th (2026)`
+`Last update: September 8th (2026)`
 
 **DiffGrid** is a pressure-layer-aligned opacity table for repeated,
 differentiable spectral calculations.  It is useful when the atmospheric
@@ -97,6 +97,26 @@ stores them in increasing :math:`1/T` order.  They must be finite, positive,
 and unique, and at least two nodes are required.  More nodes improve accuracy
 but increase both construction time and memory use.
 
+Profile kernel
+--------------
+
+For a PreMODIT teacher, DiffGrid defaults to ``profile_kernel="real_space"``:
+it samples the Voigt profile in real space and Fourier transforms it before
+convolution. This can reduce negative kernel oscillations and the large
+logarithmic slopes they introduce into the table. Accuracy still depends on
+the spectral and temperature grids.
+
+Construction uses a copy of the teacher with shared precomputed arrays;
+the supplied teacher is unchanged. Ordinary closed PreMODIT calculations
+continue to default to the analytic Fourier kernel. To reproduce a table
+built with that kernel, pass ``profile_kernel="analytic"`` to ``OpaDiffgrid``.
+Pass ``profile_kernel=None`` to inherit the supplied PreMODIT teacher's
+selection. Other teacher types keep their existing calculation.
+
+``opa.teacher_profile_kernel`` records the selection. Profile evaluation and
+its extra FFT are paid during table construction; DiffGrid's subsequent
+interpolation does not evaluate the profile.
+
 Fixed pressure layers
 ---------------------
 
@@ -155,6 +175,7 @@ below returns the temperature at the midpoint of every interval in
         diffgrid_interval_midpoint_temperatures,
     )
 
+    validation_teacher = teacher.with_profile_kernel(opa.teacher_profile_kernel)
     validation_temperatures = diffgrid_interval_midpoint_temperatures(opa)
     for validation_temperature in validation_temperatures:
         validation_profile = np.full(
@@ -163,7 +184,7 @@ below returns the temperature at the midpoint of every interval in
         )
         summary = compare_diffgrid_with_teacher(
             opa,
-            teacher,
+            validation_teacher,
             validation_profile,
             quantiles=(0.99,),
         )
@@ -179,6 +200,9 @@ For example, an error of 0.05 corresponds to a multiplicative ratio of about
 1.05. Quantiles combine every pressure-layer and wavenumber entry. The
 diagnostic reports numbers only; the application chooses its thresholds and
 decides whether to reject a table.
+
+Use the same profile kernel for the comparison as for construction.
+The helper rejects a known kernel mismatch with a PreMODIT teacher.
 
 ``compare_diffgrid_with_teacher`` is a host-side archive-build diagnostic, not
 an operation for a JIT-compiled retrieval. It processes one temperature

--- a/documents/userguide/premodit.rst
+++ b/documents/userguide/premodit.rst
@@ -51,6 +51,30 @@ For users who are well-acquainted with the PreMODIT algorithm, parameters can be
                       diffmode=diffmode,
                       manual_params=[dE, Tref, Twt])
 
+Profile kernel
+^^^^^^^^^^^^^^
+
+``OpaPremodit`` accepts ``profile_kernel="analytic"`` or
+``profile_kernel="real_space"``. The analytic mode uses the existing Fourier
+Voigt kernel with its alias correction. The real-space mode samples the LPF
+Voigt profile and Fourier transforms it for convolution; it can reduce
+negative kernel oscillations on coarse grids at additional evaluation cost.
+Both modes currently use Voigt profiles.
+
+Omitting the argument preserves the existing behavior: analytic for closed
+calculations and real space for stitching (``nstitch > 1``). Analytic mode
+is unavailable for stitching. An initialized calculator can be copied with
+another selection without rebuilding its line-density arrays:
+
+.. code-block:: python
+
+    sampled_opa = opa.with_profile_kernel("real_space")
+
+The original calculator is unchanged. The selected ``profile_kernel`` is
+saved and restored with PreMODIT archives; archives without this field retain
+their original closed or stitching behavior. :doc:`diffgrid` uses real space
+by default when building a table from a PreMODIT teacher.
+
 Visulization of the Line Base Density
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/documents/userguide/save_diffgrid.rst
+++ b/documents/userguide/save_diffgrid.rst
@@ -108,3 +108,7 @@ Notes
   values, and integrity digests are still validated.
 * Values supplied through ``aux`` and ``extra_meta`` must be JSON-compatible;
   finite NumPy or JAX scalars and arrays are also accepted.
+* The saved ``teacher_profile_kernel`` records which PreMODIT kernel built
+  the table. Loading preserves the stored values and does not rebuild them
+  using the current default. Older archives without this metadata load with
+  ``teacher_profile_kernel=None`` because their kernel is unknown.

--- a/src/exojax/opacity/_common/profconv.py
+++ b/src/exojax/opacity/_common/profconv.py
@@ -11,7 +11,11 @@ from jax.lax import scan
 
 from exojax.signal.ola import _fft_length
 from exojax.opacity._common.ditkernel import fold_voigt_kernel_logst
-from exojax.opacity._common.lpffilter import _open_filter_length, generate_open_lpffilter
+from exojax.opacity._common.lpffilter import (
+    _open_filter_length,
+    generate_closed_lpffilter,
+    generate_open_lpffilter,
+)
 
 
 def _check_complex(x):
@@ -72,7 +76,7 @@ def calc_open_nu_xsection_from_lsd_zeroscan(
     return  jnp.fft.irfft(fftvalvk) * R 
     
 def calc_xsection_from_lsd_zeroscan(
-    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
+    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid, *, profile_kernel="analytic"
 ):
     """Compute cross section from LSD in MODIT algorithm using scan+fft to avoid 4GB memory limit in fft and zero padding in scan
 
@@ -87,10 +91,38 @@ def calc_xsection_from_lsd_zeroscan(
         nsigmaD (float): normaized Gaussian STD
         nu_grid (array): wavenumber grid [Nnus]
         log_gammaL_grid (array): logarithm of gammaL grid [Ngamma]
+        profile_kernel (str): "analytic" for the Fourier-space Voigt kernel,
+            or "real_space" for the FFT of the sampled LPF Voigt profile.
 
     Returns:
         Closed Cross section in the log nu grid [Nnus]
     """
+    if profile_kernel not in ("analytic", "real_space"):
+        raise ValueError("profile_kernel must be 'analytic' or 'real_space'.")
+
+    Ng_nu = len(nu_grid)
+    if profile_kernel == "real_space":
+        profile_dtype = jnp.result_type(Slsd, nsigmaD, log_ngammaL_grid)
+
+        def convolve_profile(value, inputs):
+            density, gamma = inputs
+            profile = generate_closed_lpffilter(Ng_nu, nsigmaD, gamma).astype(
+                profile_dtype
+            )
+            density_fft = jnp.fft.rfft(
+                jnp.concatenate([density, jnp.zeros_like(density)])
+            )
+            return value + density_fft * jnp.fft.rfft(profile), None
+
+        # Build each profile inside the scan to avoid a full profile-grid buffer.
+        init = jnp.zeros(
+            Ng_nu + 1,
+            dtype=jnp.result_type(profile_dtype, jnp.complex64),
+        )
+        fftvalvk, _ = scan(
+            convolve_profile, init, (Slsd.T, jnp.exp(log_ngammaL_grid))
+        )
+        return jnp.fft.irfft(fftvalvk)[:Ng_nu] * R / nu_grid
 
     def f(val, x):
         Slsd_k, vk_k = x
@@ -100,7 +132,6 @@ def calc_xsection_from_lsd_zeroscan(
         val += v
         return val, None
 
-    Ng_nu = len(nu_grid)
     vk = fold_voigt_kernel_logst(
         jnp.fft.rfftfreq(2 * Ng_nu, 1),
         nsigmaD,

--- a/src/exojax/opacity/diffgrid/api.py
+++ b/src/exojax/opacity/diffgrid/api.py
@@ -24,6 +24,8 @@ class OpaDiffgrid(OpaCalc):
     Attributes:
         method: Always ``"diffgrid"`` for this calculator.
         teacher_method: Method name of the calculator used to build the table.
+        teacher_profile_kernel: PreMODIT kernel used for construction, or None
+            for other teachers and legacy archives with unknown kernel.
         diffgrid_info: Immutable table values and coordinates.
         aux: User-specified auxiliary metadata restored from a saved archive.
         user_meta: User provenance metadata restored from a saved archive.
@@ -35,6 +37,8 @@ class OpaDiffgrid(OpaCalc):
         temperature_grid: Union[np.ndarray, jnp.ndarray],
         pressure_grid: Union[np.ndarray, jnp.ndarray],
         min_cross_section: float = 1.0e-35,
+        *,
+        profile_kernel: Optional[str] = "real_space",
     ) -> None:
         """Initialize and build a diffgrid opacity table.
 
@@ -47,11 +51,21 @@ class OpaDiffgrid(OpaCalc):
             min_cross_section: Positive floor applied before taking logarithms.
                 Defaults to ``1e-35`` cm2 to stabilize zero or negative
                 round-off from the teacher.
+            profile_kernel: For a PreMODIT teacher, select ``"real_space"``
+                (default) or ``"analytic"``; None inherits its current mode.
+                The supplied teacher is not modified. Other teacher types use
+                their own xsmatrix implementation unchanged.
 
         Raises:
             ValueError: If a grid is invalid or the teacher is not ready.
         """
         self._validate_teacher(base_opa)
+        if profile_kernel not in (None, "analytic", "real_space"):
+            raise ValueError("profile_kernel must be 'analytic', 'real_space', or None.")
+        from exojax.opacity.premodit.api import OpaPremodit
+
+        if isinstance(base_opa, OpaPremodit) and profile_kernel is not None:
+            base_opa = base_opa.with_profile_kernel(profile_kernel)
         temperature_grid = self._validated_grid(
             "temperature_grid", temperature_grid, minimum_size=2
         )
@@ -68,6 +82,13 @@ class OpaDiffgrid(OpaCalc):
         super().__init__(base_opa.nu_grid)
         self.method = "diffgrid"
         self.teacher_method = getattr(base_opa, "method", None)
+        self.teacher_profile_kernel = (
+            base_opa._resolve_profile_kernel(
+                getattr(base_opa, "profile_kernel", None), base_opa.nstitch
+            )
+            if isinstance(base_opa, OpaPremodit)
+            else None
+        )
         self.aux = {}
         self.user_meta = {}
 
@@ -125,6 +146,9 @@ class OpaDiffgrid(OpaCalc):
 
         state = meta["opa_state"]
         self.teacher_method = state.get("teacher_method")
+        self.teacher_profile_kernel = state.get("teacher_profile_kernel")
+        if self.teacher_profile_kernel not in (None, "analytic", "real_space"):
+            raise ValueError("Invalid saved DiffGrid teacher_profile_kernel.")
         optional_attributes = state.get("optional_attributes", {})
         for attribute in ("wavelength_order", "resolution", "molmass"):
             if attribute in optional_attributes:

--- a/src/exojax/opacity/diffgrid/diagnostics.py
+++ b/src/exojax/opacity/diffgrid/diagnostics.py
@@ -193,7 +193,9 @@ def compare_diffgrid_with_teacher(
         diffgrid: Ready pressure-aligned Diffgrid opacity calculator.
         teacher: Ready reference opacity calculator on the same wavenumber
             grid. Its ``xsmatrix`` method must accept temperature and pressure
-            profiles.
+            profiles. A PreMODIT teacher must use the table's recorded kernel;
+            use ``teacher.with_profile_kernel(diffgrid.teacher_profile_kernel)``
+            to make a matching copy when necessary.
         temperature_profile: Layer temperatures in K, shape ``(nlayer,)``.
         quantiles: Quantile levels to report. Defaults to ``(0.99,)``.
 
@@ -209,6 +211,20 @@ def compare_diffgrid_with_teacher(
 
     quantiles = _validated_quantiles(quantiles)
     pressure_grid, nu_grid = _validated_comparison_grids(diffgrid, teacher)
+    from exojax.opacity.premodit.api import OpaPremodit
+
+    recorded_kernel = getattr(diffgrid, "teacher_profile_kernel", None)
+    if (
+        isinstance(teacher, OpaPremodit)
+        and recorded_kernel is not None
+        and recorded_kernel != teacher._resolve_profile_kernel(
+            getattr(teacher, "profile_kernel", None), teacher.nstitch
+        )
+    ):
+        raise ValueError(
+            "PreMODIT profile_kernel differs from the DiffGrid teacher. Use "
+            "teacher.with_profile_kernel(diffgrid.teacher_profile_kernel)."
+        )
     log_cross_section_floor = _validated_log_cross_section_floor(diffgrid)
 
     temperature_profile = np.asarray(temperature_profile)

--- a/src/exojax/opacity/diffgrid/io.py
+++ b/src/exojax/opacity/diffgrid/io.py
@@ -148,6 +148,7 @@ def _diffgrid_metadata(
             "teacher_method": _normalize_json_value(
                 getattr(opa, "teacher_method", None)
             ),
+            "teacher_profile_kernel": getattr(opa, "teacher_profile_kernel", None),
             "optional_attributes": optional_attributes,
         },
     }
@@ -417,6 +418,10 @@ def _validate_archive_metadata(
         opa_state["teacher_method"], str
     ):
         raise ValueError("teacher_method metadata must be a string or null.")
+    if opa_state.get("teacher_profile_kernel") not in (
+        None, "analytic", "real_space"
+    ):
+        raise ValueError("Invalid saved DiffGrid teacher_profile_kernel.")
     optional_attributes = opa_state["optional_attributes"]
     if not isinstance(optional_attributes, Mapping):
         raise ValueError("optional_attributes metadata must be a mapping.")

--- a/src/exojax/opacity/premodit/api.py
+++ b/src/exojax/opacity/premodit/api.py
@@ -5,6 +5,7 @@ using pre-computed grids. PreMODIT offers the fastest computation speed by using
 optimized parameter grids and efficient memory management.
 """
 
+from copy import copy
 from functools import partial
 import logging
 from typing import Optional, Union, Literal, Dict, Any, Tuple, List
@@ -60,6 +61,7 @@ class OpaPremodit(OpaCalc):
         broadening_parameter_resolution: Broadening parameter resolution configuration
         single_broadening: Whether using single broadening mode
         ngrid_broadpar: Number of broadening parameter grid points
+        profile_kernel: ``"analytic"`` or ``"real_space"`` Voigt kernel.
         aux: User-specified auxiliary metadata persisted through save/load
     """
 
@@ -80,6 +82,7 @@ class OpaPremodit(OpaCalc):
         memory_policy: Optional[MemoryPolicy] = None,
         *,
         delete_mdb_after_init: bool = True,
+        profile_kernel: Optional[Literal["analytic", "real_space"]] = None,
     ) -> None:
         """Initialize OpaPremodit opacity calculator.
 
@@ -111,6 +114,11 @@ class OpaPremodit(OpaCalc):
             delete_mdb_after_init: Drop the local reference to the provided mdb
                 inside ``__init__`` to encourage early GC. External references are
                 unaffected. Defaults to True (same as prior behavior).
+            profile_kernel: Closed-mode Voigt kernel: ``"analytic"`` uses the
+                existing Fourier expression; ``"real_space"`` FFTs the sampled
+                LPF Voigt. None preserves the existing defaults: analytic for
+                nstitch=1, real_space for stitching. Stitching requires
+                real_space.
 
         Raises:
             ValueError: If no molecular lines are within the wavenumber grid
@@ -130,6 +138,7 @@ class OpaPremodit(OpaCalc):
                 _cutwing = memory_policy.cutwing
 
         check_jax64bit(_allow_32bit)
+        self.profile_kernel = self._resolve_profile_kernel(profile_kernel, _nstitch)
 
         # default setting
         self.method = "premodit"
@@ -343,6 +352,13 @@ class OpaPremodit(OpaCalc):
             self.dit_grid_resolution = float(self.dit_grid_resolution)
         self.cutwing = float(state["cutwing"])
         self.nstitch = int(state["nstitch"])
+        if "profile_kernel" in state and state["profile_kernel"] not in (
+            "analytic", "real_space"
+        ):
+            raise ValueError("Invalid saved PreMODIT profile_kernel.")
+        self.profile_kernel = self._resolve_profile_kernel(
+            state.get("profile_kernel"), self.nstitch
+        )
         self.alias = state["alias"]
         self.ngrid_broadpar = int(state["ngrid_broadpar"])
         self.ngrid_elower = int(state["ngrid_elower"])
@@ -399,6 +415,29 @@ class OpaPremodit(OpaCalc):
             else:
                 raise ValueError("Serialized opa missing lbd coefficients for stitching mode.")
         self.ready = True
+
+    @staticmethod
+    def _resolve_profile_kernel(profile_kernel, nstitch):
+        if profile_kernel is None:
+            return "real_space" if nstitch > 1 else "analytic"
+        if profile_kernel not in ("analytic", "real_space"):
+            raise ValueError("profile_kernel must be 'analytic' or 'real_space'.")
+        if nstitch > 1 and profile_kernel != "real_space":
+            raise ValueError("Stitching requires profile_kernel='real_space'.")
+        return profile_kernel
+
+    def with_profile_kernel(self, profile_kernel):
+        """Return a calculator with another kernel, sharing precomputed arrays.
+
+        The original calculator is unchanged. No line-density rebuild is needed;
+        the selected kernel applies to both vector and matrix evaluations.
+        """
+        result = copy(self)
+        result.profile_kernel = self._resolve_profile_kernel(
+            profile_kernel, self.nstitch
+        )
+        return result
+
     def __eq__(self, other: object) -> bool:
         """Check equality with another OpaPremodit instance.
 
@@ -417,6 +456,14 @@ class OpaPremodit(OpaCalc):
             and np.array_equal(self.T_gQT, other.T_gQT)
             and np.array_equal(self.gQT, other.gQT)
             and (self.diffmode == other.diffmode)
+            and (
+                self._resolve_profile_kernel(
+                    getattr(self, "profile_kernel", None), self.nstitch
+                )
+                == self._resolve_profile_kernel(
+                    getattr(other, "profile_kernel", None), other.nstitch
+                )
+            )
             and (self.ngrid_broadpar == other.ngrid_broadpar)
             and (self.wavelength_order == other.wavelength_order)
             and (self.version_auto_trange == other.version_auto_trange)
@@ -762,6 +809,7 @@ class OpaPremodit(OpaCalc):
                 qt,
                 self.Tref_broadening,
                 self.Twt,
+                profile_kernel=getattr(self, "profile_kernel", "analytic"),
             )
         else:
             raise ValueError("nstitch should be integer and larger than 1.")
@@ -851,6 +899,7 @@ class OpaPremodit(OpaCalc):
                 qtarr,
                 self.Tref_broadening,
                 self.Twt,
+                profile_kernel=getattr(self, "profile_kernel", "analytic"),
             )
         else:
             raise ValueError("nstitch should be integer and larger than 1.")

--- a/src/exojax/opacity/premodit/ioopa.py
+++ b/src/exojax/opacity/premodit/ioopa.py
@@ -111,6 +111,9 @@ def saveopa_premodit(
             "dbtype": opa.dbtype,
             "molmass": float(opa.molmass),
             "diffmode": int(opa.diffmode),
+            "profile_kernel": opa._resolve_profile_kernel(
+                getattr(opa, "profile_kernel", None), opa.nstitch
+            ),
             "wavelength_order": opa.wavelength_order,
             "version_auto_trange": int(opa.version_auto_trange),
             "dit_grid_resolution": (

--- a/src/exojax/opacity/premodit/premodit.py
+++ b/src/exojax/opacity/premodit/premodit.py
@@ -724,7 +724,7 @@ def xsmatrix_nu_open_second(
     return xsm
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsvector_zeroth(
     T,
     P,
@@ -741,6 +741,8 @@ def xsvector_zeroth(
     qt,
     Tref_broadening,
     Twt=None,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section vector, with scan+fft, using the zero-th Taylor expansion
 
@@ -760,6 +762,7 @@ def xsvector_zeroth(
         qt (_type_): partirion function ratio
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: not used
+        profile_kernel: "analytic" or "real_space" Voigt kernel
     Returns:
         jnp.array: cross section in cgs vector
     """
@@ -772,12 +775,18 @@ def xsvector_zeroth(
     #    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     # )
     xs = calc_xsection_from_lsd_zeroscan(
-        Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
+        Slsd,
+        R,
+        pmarray,
+        nsigmaD,
+        nu_grid,
+        log_ngammaL_grid,
+        profile_kernel=profile_kernel,
     )
     return xs
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsvector_first(
     T,
     P,
@@ -794,6 +803,8 @@ def xsvector_first(
     qt,
     Tref_broadening,
     Twt,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section vector, with scan+fft, using the first Taylor expansion
 
@@ -814,6 +825,7 @@ def xsvector_first(
         qt (_type_): partirion function ratio
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: temperature used in the weight point
+        profile_kernel: "analytic" or "real_space" Voigt kernel
 
     Returns:
         jnp.array: cross section in cgs vector
@@ -827,12 +839,18 @@ def xsvector_first(
     #    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     # )
     xs = calc_xsection_from_lsd_zeroscan(
-        Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
+        Slsd,
+        R,
+        pmarray,
+        nsigmaD,
+        nu_grid,
+        log_ngammaL_grid,
+        profile_kernel=profile_kernel,
     )
     return xs
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsvector_second(
     T,
     P,
@@ -849,6 +867,8 @@ def xsvector_second(
     qt,
     Tref_broadening,
     Twt,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section vector, with scan+fft, using the second Taylor expansion
 
@@ -868,6 +888,7 @@ def xsvector_second(
         qt (_type_): partirion function ratio
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: temperature used in the weight point
+        profile_kernel: "analytic" or "real_space" Voigt kernel
 
     Returns:
         jnp.array: cross section in cgs vector
@@ -880,12 +901,18 @@ def xsvector_second(
     # xs = calc_xsection_from_lsd_scanfft(Slsd, R, pmarray, nsigmaD, nu_grid,
     #                                    log_ngammaL_grid)
     xs = calc_xsection_from_lsd_zeroscan(
-        Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
+        Slsd,
+        R,
+        pmarray,
+        nsigmaD,
+        nu_grid,
+        log_ngammaL_grid,
+        profile_kernel=profile_kernel,
     )
     return xs
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsmatrix_zeroth(
     Tarr,
     Parr,
@@ -902,6 +929,8 @@ def xsmatrix_zeroth(
     qtarr,
     Tref_broadening,
     Twt=None,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section matrix given atmospheric layers, for diffmode=0, with scan+fft
 
@@ -921,6 +950,7 @@ def xsmatrix_zeroth(
         qtarr (_type_): partition function ratio layers
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: not used
+        profile_kernel: "analytic" or "real_space" Voigt kernel
 
     Returns:
         jnp.array : cross section matrix (Nlayer, N_wavenumber)
@@ -936,13 +966,14 @@ def xsmatrix_zeroth(
     # v1.6
     # xsm = vmap(calc_xsection_from_lsd_scanfft, (0, None, None, 0, None, 0),
     #           0)(Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid)
-    xsm = vmap(calc_xsection_from_lsd_zeroscan, (0, None, None, 0, None, 0), 0)(
+    convolve = partial(calc_xsection_from_lsd_zeroscan, profile_kernel=profile_kernel)
+    xsm = vmap(convolve, (0, None, None, 0, None, 0), 0)(
         Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     )
     return xsm
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsmatrix_first(
     Tarr,
     Parr,
@@ -959,6 +990,8 @@ def xsmatrix_first(
     qtarr,
     Tref_broadening,
     Twt,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section matrix given atmospheric layers, for diffmode=1, with scan+fft
 
@@ -978,6 +1011,7 @@ def xsmatrix_first(
         qtarr (_type_): partition function ratio layers
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: weight temperature in K
+        profile_kernel: "analytic" or "real_space" Voigt kernel
 
     Returns:
         jnp.array : cross section matrix (Nlayer, N_wavenumber)
@@ -994,13 +1028,14 @@ def xsmatrix_first(
     # xsm = vmap(calc_xsection_from_lsd_scanfft, (0, None, None, 0, None, 0), 0)(
     #    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     # )
-    xsm = vmap(calc_xsection_from_lsd_zeroscan, (0, None, None, 0, None, 0), 0)(
+    convolve = partial(calc_xsection_from_lsd_zeroscan, profile_kernel=profile_kernel)
+    xsm = vmap(convolve, (0, None, None, 0, None, 0), 0)(
         Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     )
     return xsm
 
 
-@jit
+@partial(jit, static_argnames=("profile_kernel",))
 def xsmatrix_second(
     Tarr,
     Parr,
@@ -1017,6 +1052,8 @@ def xsmatrix_second(
     qtarr,
     Tref_broadening,
     Twt,
+    *,
+    profile_kernel="analytic",
 ):
     """compute cross section matrix given atmospheric layers, for diffmode=1, with scan+fft
 
@@ -1036,6 +1073,7 @@ def xsmatrix_second(
         qtarr (_type_): partition function ratio layers
         Tref_broadening: reference temperature for broadening in Kelvin
         Twt: weight temperature in K
+        profile_kernel: "analytic" or "real_space" Voigt kernel
 
     Returns:
         jnp.array : cross section matrix (Nlayer, N_wavenumber)
@@ -1052,7 +1090,8 @@ def xsmatrix_second(
     # xsm = vmap(calc_xsection_from_lsd_scanfft, (0, None, None, 0, None, 0), 0)(
     #    Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     # )
-    xsm = vmap(calc_xsection_from_lsd_zeroscan, (0, None, None, 0, None, 0), 0)(
+    convolve = partial(calc_xsection_from_lsd_zeroscan, profile_kernel=profile_kernel)
+    xsm = vmap(convolve, (0, None, None, 0, None, 0), 0)(
         Slsd, R, pmarray, nsigmaD, nu_grid, log_ngammaL_grid
     )
     return xsm

--- a/tests/benchmark/diffgrid_nuts_benchmark.py
+++ b/tests/benchmark/diffgrid_nuts_benchmark.py
@@ -117,6 +117,8 @@ class CaseConfig:
     premodit_diffmode: int = 1
     broadening_resolution: float = 0.2
     observation_seed: int = 1
+    # Missing fields in existing prepared cases retain the original teacher.
+    profile_kernel: str = "analytic"
 
 
 def _finite_or_none(value: Any) -> float | None:
@@ -599,6 +601,7 @@ def _prepare(args, state):
         number_of_wavenumbers=args.number_of_wavenumbers,
         number_of_layers=args.number_of_layers,
         number_of_temperature_nodes=args.number_of_temperature_nodes,
+        profile_kernel=args.profile_kernel,
     )
     mdb_path = args.mdb_path.expanduser().resolve()
     cia_path = args.cia_path.expanduser().resolve()
@@ -638,6 +641,7 @@ def _prepare(args, state):
             "value": case_config.broadening_resolution,
         },
         wavelength_order="ascending",
+        profile_kernel=case_config.profile_kernel,
     )
     _block_opacity(teacher)
     timings["premodit_build_seconds"] = time.perf_counter() - start
@@ -654,6 +658,7 @@ def _prepare(args, state):
         teacher,
         temperature_grid=temperature_nodes,
         pressure_grid=np.asarray(art_for_grid.pressure),
+        profile_kernel=case_config.profile_kernel,
     )
     _block_opacity(diffgrid)
     timings["diffgrid_build_seconds"] = time.perf_counter() - start
@@ -2259,6 +2264,12 @@ def _parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument("--number-of-wavenumbers", type=int, default=7500)
     prepare_parser.add_argument("--number-of-layers", type=int, default=100)
     prepare_parser.add_argument("--number-of-temperature-nodes", type=int, default=21)
+    prepare_parser.add_argument(
+        "--profile-kernel",
+        choices=("analytic", "real_space"),
+        default="real_space",
+        help="Kernel used by both the saved PreMODIT teacher and DiffGrid construction.",
+    )
     prepare_parser.add_argument(
         "--max-interpolation-error-in-noise", type=float, default=0.01
     )

--- a/tests/integration/offline/benchmark/test_diffgrid_nuts_benchmark.py
+++ b/tests/integration/offline/benchmark/test_diffgrid_nuts_benchmark.py
@@ -129,6 +129,7 @@ def test_legacy_cli_arguments_and_defaults(benchmark, tmp_path):
     )
     assert prepare.handler == benchmark.prepare
     assert prepare.number_of_layers == 4 and prepare.overwrite
+    assert prepare.profile_kernel == "real_space"
     run = parser.parse_args(
         [
             "run",
@@ -168,6 +169,17 @@ def test_legacy_cli_arguments_and_defaults(benchmark, tmp_path):
         parser.parse_args(["run", "--method", "diffgrid", "--run-id", "before"]).run_id
         == "before"
     )
+
+
+@pytest.mark.parametrize("profile_kernel", ["analytic", "real_space"])
+def test_profile_kernel_selection_and_legacy_case_metadata(benchmark, profile_kernel):
+    args = benchmark._parser().parse_args(
+        ["prepare", "--profile-kernel", profile_kernel]
+    )
+    case_config = benchmark.CaseConfig(profile_kernel=args.profile_kernel)
+
+    assert benchmark.asdict(case_config)["profile_kernel"] == profile_kernel
+    assert benchmark.CaseConfig(**{}).profile_kernel == "analytic"
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/opacity/_common/test_real_space_profile.py
+++ b/tests/unittests/opacity/_common/test_real_space_profile.py
@@ -1,0 +1,148 @@
+"""Numerical checks against independent, discrete Voigt convolutions."""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.special import voigt_profile
+
+from exojax.opacity._common.profconv import calc_xsection_from_lsd_zeroscan
+
+
+def _density(length=32):
+    density = np.zeros((length, 2))
+    density[[0, 7, length - 1], 0] = [0.4, 1.3, 0.2]
+    density[[0, 18, length - 1], 1] = [0.3, 0.5, 0.7]
+    return density
+
+
+def _direct_convolution(density, sigma, gammas, resolution, nu_grid):
+    coordinates = np.arange(len(density))
+    offsets = coordinates[:, None] - coordinates[None, :]
+    profiles = voigt_profile(offsets[:, :, None], sigma, gammas)
+    return np.sum(profiles * density[None, :, :], axis=(1, 2)) * resolution / nu_grid
+
+
+def _convolve(density, sigma, gammas, resolution, nu_grid, **kwargs):
+    pmarray = (-1.0) ** jnp.arange(len(density) + 1)
+    return calc_xsection_from_lsd_zeroscan(
+        jnp.asarray(density),
+        resolution,
+        pmarray,
+        sigma,
+        jnp.asarray(nu_grid),
+        jnp.log(gammas),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("sigma", [0.3, 1.2])
+def test_real_space_matches_discrete_voigt_at_both_boundaries(sigma):
+    density = _density()
+    gammas = jnp.array([0.02, 1.4])
+    nu_grid = np.geomspace(2000.0, 2010.0, len(density))
+    actual = jax.jit(partial(_convolve, profile_kernel="real_space"))(
+        density, sigma, gammas, 2400.0, nu_grid
+    )
+    expected = _direct_convolution(density, sigma, gammas, 2400.0, nu_grid)
+    np.testing.assert_allclose(actual, expected, rtol=2e-6, atol=5e-9)
+    assert np.min(actual) >= 0.0
+
+
+def test_real_space_temperature_and_width_jvp_vjp_match_scipy_differences():
+    density = _density()
+    nu_grid = np.geomspace(2000.0, 2010.0, len(density))
+
+    def spectrum(parameters):
+        temperature, gaussian_scale, lorentz_scale = parameters
+        sigma = gaussian_scale * jnp.sqrt(temperature)
+        gammas = (
+            jnp.array([0.05, 0.4])
+            * lorentz_scale
+            * temperature ** -jnp.array([0.4, 0.7])
+        )
+        return _convolve(
+            density, sigma, gammas, 2400.0, nu_grid, profile_kernel="real_space"
+        )
+
+    def reference(parameters):
+        temperature, gaussian_scale, lorentz_scale = parameters
+        sigma = gaussian_scale * np.sqrt(temperature)
+        gammas = (
+            np.array([0.05, 0.4])
+            * lorentz_scale
+            * temperature ** -np.array([0.4, 0.7])
+        )
+        return _direct_convolution(density, sigma, gammas, 2400.0, nu_grid)
+
+    position = jnp.array([1.1, 0.6, 0.7])
+    direction = jnp.array([0.3, -0.2, 0.4])
+    step = 1e-5
+    _, tangent = jax.jvp(jax.jit(spectrum), (position,), (direction,))
+    finite_tangent = (
+        reference(position + step * direction) - reference(position - step * direction)
+    ) / (2 * step)
+    np.testing.assert_allclose(tangent, finite_tangent, rtol=2e-5, atol=2e-8)
+
+    cotangent = np.linspace(-0.4, 0.8, len(density))
+    _, pullback = jax.vjp(jax.jit(spectrum), position)
+    (gradient,) = pullback(jnp.asarray(cotangent))
+    finite_gradient = np.array(
+        [
+            cotangent
+            @ (reference(position + step * axis) - reference(position - step * axis))
+            / (2 * step)
+            for axis in np.eye(len(position))
+        ]
+    )
+    np.testing.assert_allclose(gradient, finite_gradient, rtol=2e-5, atol=2e-8)
+
+
+def test_analytic_default_is_unchanged():
+    density = _density()
+    args = (density, 0.6, jnp.array([0.05, 0.4]), 1.0, jnp.ones(len(density)))
+    np.testing.assert_array_equal(
+        _convolve(*args), _convolve(*args, profile_kernel="analytic")
+    )
+
+
+def test_real_space_avoids_negative_kernel_ringing():
+    density = jnp.zeros((32, 1)).at[16, 0].set(1.0)
+    args = (density, 0.3, jnp.array([1e-6]), 1.0, jnp.ones(32))
+    analytic = _convolve(*args, profile_kernel="analytic")
+    real_space = _convolve(*args, profile_kernel="real_space")
+    expected = voigt_profile(np.arange(32) - 16, 0.3, 1e-6)
+    assert np.min(analytic) < -0.01
+    assert np.min(real_space) >= 0.0
+    np.testing.assert_allclose(real_space, expected, rtol=2e-6, atol=5e-9)
+
+
+def test_invalid_profile_kernel_is_rejected():
+    density = _density()
+    with pytest.raises(ValueError, match="profile_kernel"):
+        _convolve(
+            density, 0.6, jnp.array([0.05, 0.4]), 1.0, jnp.ones(32),
+            profile_kernel="invalid",
+        )
+
+
+@pytest.mark.parametrize("enable_x64", [False, True])
+def test_real_space_float32_inputs_preserve_precision(enable_x64):
+    with jax.experimental.enable_x64(enable_x64):
+        density = jnp.asarray(_density(), dtype=jnp.float32)
+        sigma = jnp.float32(0.6)
+        gammas = jnp.array([0.05, 0.4], dtype=jnp.float32)
+        nu_grid = jnp.ones(len(density), dtype=jnp.float32)
+        actual = _convolve(
+            density,
+            sigma,
+            gammas,
+            jnp.float32(1.0),
+            nu_grid,
+            profile_kernel="real_space",
+        )
+        expected = _direct_convolution(density, sigma, gammas, 1.0, nu_grid)
+        assert actual.dtype == jnp.float32
+        np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=5e-7)

--- a/tests/unittests/opacity/_common/test_real_space_profile.py
+++ b/tests/unittests/opacity/_common/test_real_space_profile.py
@@ -130,7 +130,9 @@ def test_invalid_profile_kernel_is_rejected():
 
 @pytest.mark.parametrize("enable_x64", [False, True])
 def test_real_space_float32_inputs_preserve_precision(enable_x64):
-    with jax.experimental.enable_x64(enable_x64):
+    previous_x64 = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", enable_x64)
+    try:
         density = jnp.asarray(_density(), dtype=jnp.float32)
         sigma = jnp.float32(0.6)
         gammas = jnp.array([0.05, 0.4], dtype=jnp.float32)
@@ -146,3 +148,5 @@ def test_real_space_float32_inputs_preserve_precision(enable_x64):
         expected = _direct_convolution(density, sigma, gammas, 1.0, nu_grid)
         assert actual.dtype == jnp.float32
         np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=5e-7)
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)

--- a/tests/unittests/opacity/diffgrid/test_diffgrid_api.py
+++ b/tests/unittests/opacity/diffgrid/test_diffgrid_api.py
@@ -75,7 +75,10 @@ def diffgrid_setup():
         temperature_grid = np.asarray(
             [600.0, 850.0, 1150.0, 1500.0, 1900.0], dtype=np.float32
         )
-        opa = OpaDiffgrid(teacher, temperature_grid, pressure)
+        # Keep this interpolation regression on its original analytic teacher.
+        opa = OpaDiffgrid(
+            teacher, temperature_grid, pressure, profile_kernel="analytic"
+        )
         return opa, teacher, pressure, temperature_grid
 
 
@@ -152,6 +155,31 @@ def test_diffgrid_accepts_range_boundaries_across_dtypes():
         assert np.all(np.isfinite(np.asarray(compiled)))
     finally:
         jax.config.update("jax_enable_x64", previous_x64)
+
+
+@pytest.mark.parametrize("profile_kernel", ["analytic", "real_space", None])
+def test_generic_teacher_is_unchanged_by_profile_selection(profile_kernel):
+    teacher = _AnalyticTeacher()
+    temperature = np.asarray([800.0, 1200.0])
+    pressure = np.asarray([0.3, 1.0])
+    diffgrid = OpaDiffgrid(
+        teacher, temperature, pressure, profile_kernel=profile_kernel
+    )
+
+    assert diffgrid.teacher_profile_kernel is None
+    assert not hasattr(teacher, "profile_kernel")
+    np.testing.assert_allclose(
+        diffgrid.xsmatrix(temperature),
+        teacher.xsmatrix(temperature, pressure),
+        rtol=1.0e-12,
+    )
+
+
+def test_diffgrid_rejects_invalid_profile_kernel():
+    with pytest.raises(ValueError, match="profile_kernel"):
+        OpaDiffgrid(
+            _AnalyticTeacher(), [800.0, 1200.0], [1.0], profile_kernel="unknown"
+        )
 
 
 def test_diffgrid_improves_on_linear_log_interpolation(diffgrid_setup):

--- a/tests/unittests/opacity/diffgrid/test_diffgrid_io.py
+++ b/tests/unittests/opacity/diffgrid/test_diffgrid_io.py
@@ -139,6 +139,7 @@ def _assert_same_diffgrid(expected, actual):
     assert actual.ready is True
     assert actual.method == "diffgrid"
     assert actual.teacher_method == expected.teacher_method
+    assert actual.teacher_profile_kernel == expected.teacher_profile_kernel
     assert actual.opainfo is actual.diffgrid_info
     for key in ARRAY_KEYS:
         actual_array = (
@@ -189,6 +190,7 @@ def test_npz_roundtrip_preserves_tables_metadata_and_optional_attributes(
     assert metadata["opa_type"] == "OpaDiffgrid"
     assert metadata["exojax_version"] == __version__
     assert metadata["opa_state"]["teacher_method"] == "analytic"
+    assert metadata["opa_state"]["teacher_profile_kernel"] is None
     assert metadata["units"] == {
         "wavenumber": "cm^-1",
         "pressure": "bar",
@@ -231,6 +233,48 @@ def test_zarr_roundtrip_preserves_tables(tmp_path, diffgrid_case):
     assert loaded.wavelength_order == opa.wavelength_order
     np.testing.assert_array_equal(loaded.wav, opa.wav)
     assert loaded.resolution == pytest.approx(opa.resolution)
+
+
+@pytest.mark.parametrize("format", ["npz", "zarr"])
+def test_legacy_archive_has_unknown_teacher_kernel(tmp_path, diffgrid_case, format):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "legacy_diffgrid"
+    saveopa(opa, str(path), format=format)
+    if format == "npz":
+        metadata_path = _metadata_path(path.with_suffix(".npz"))
+        metadata = json.loads(metadata_path.read_text())
+        del metadata["opa_state"]["teacher_profile_kernel"]
+        metadata_path.write_text(json.dumps(metadata))
+    else:
+        import zarr
+
+        group = zarr.open(str(path.with_suffix(".zarr")), mode="a")
+        state = dict(group.attrs["opa_state"])
+        del state["teacher_profile_kernel"]
+        group.attrs["opa_state"] = state
+
+    loaded = OpaDiffgrid.from_saved_opa(str(path.with_suffix("." + format)))
+
+    assert loaded.teacher_profile_kernel is None
+    np.testing.assert_array_equal(
+        loaded.xsmatrix(np.asarray([800.0, 1200.0])),
+        opa.xsmatrix(np.asarray([800.0, 1200.0])),
+    )
+
+
+@pytest.mark.parametrize("profile_kernel", ["unsupported", 42, ["real_space"]])
+def test_load_rejects_invalid_teacher_kernel_metadata(
+    tmp_path, diffgrid_case, profile_kernel
+):
+    opa, _, _ = diffgrid_case
+    path = tmp_path / "invalid_kernel"
+    saveopa(opa, str(path), format="npz")
+    arrays, metadata = _read_npz_archive(path.with_suffix(".npz"))
+    metadata["opa_state"]["teacher_profile_kernel"] = profile_kernel
+    _write_npz_archive(path.with_suffix(".npz"), arrays, metadata)
+
+    with pytest.raises(ValueError, match="teacher_profile_kernel"):
+        OpaDiffgrid.from_saved_opa(str(path.with_suffix(".npz")))
 
 
 def test_loads_schema_compliant_npz_from_external_producer(tmp_path):

--- a/tests/unittests/opacity/premodit/test_premodit_save_load.py
+++ b/tests/unittests/opacity/premodit/test_premodit_save_load.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 import pytest
 
@@ -37,12 +39,13 @@ def _build_minimal_ready_opa() -> OpaPremodit:
     opa.cutwing = 1.0
     opa.nstitch = 1
     opa.alias = "close"
+    opa.profile_kernel = "analytic"
 
     multi_index_uniqgrid = np.array([[0, 0]])
     elower_grid = np.array([0.1, 0.2])
     ngamma_ref_grid = np.array([0.05])
     n_Texp_grid = np.array([0.01])
-    R = np.array([1.0])
+    R = np.array(1.0)
     pmarray = np.ones(len(nu_grid) + 1, dtype=np.float64)
     pmarray[1::2] *= -1.0
     opa.ngrid_broadpar = len(multi_index_uniqgrid)
@@ -84,8 +87,9 @@ def _build_minimal_ready_opa() -> OpaPremodit:
 
 
 @pytest.mark.parametrize("format", ["npz", "zarr"])
-def test_save_and_load_roundtrip(tmp_path, format):
-    opa = _build_minimal_ready_opa()
+@pytest.mark.parametrize("profile_kernel", ["analytic", "real_space"])
+def test_save_and_load_roundtrip(tmp_path, format, profile_kernel):
+    opa = _build_minimal_ready_opa().with_profile_kernel(profile_kernel)
     artifact = tmp_path / "opa_roundtrip"
     expected_cross_section = np.asarray(opa.xsvector(500.0, 1.0))
     saveopa_premodit(opa, str(artifact), format=format)
@@ -93,6 +97,7 @@ def test_save_and_load_roundtrip(tmp_path, format):
     loaded = OpaPremodit.from_saved_opa(str(artifact) + "." + format)
 
     assert loaded == opa
+    assert loaded.profile_kernel == profile_kernel
     assert np.allclose(loaded.gamma_ref, opa.gamma_ref)
     assert np.allclose(loaded.n_Texp, opa.n_Texp)
     assert np.array_equal(loaded.opainfo[0], opa.opainfo[0])
@@ -122,3 +127,17 @@ def test_aux_metadata_persists_through_roundtrip(tmp_path):
         "labels": ["co", 1],
         "nested": {"values": [1, 2, 3]},
     }
+
+
+@pytest.mark.parametrize("profile_kernel", ["unsupported", None, 42])
+def test_load_rejects_invalid_profile_kernel_metadata(tmp_path, profile_kernel):
+    opa = _build_minimal_ready_opa()
+    artifact = tmp_path / "invalid_profile"
+    saveopa_premodit(opa, str(artifact), format="npz")
+    metadata_path = tmp_path / "invalid_profile_metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["opa_state"]["profile_kernel"] = profile_kernel
+    metadata_path.write_text(json.dumps(metadata))
+
+    with pytest.raises(ValueError, match="profile_kernel"):
+        OpaPremodit.from_saved_opa(str(artifact.with_suffix(".npz")))

--- a/tests/unittests/opacity/premodit/test_profile_kernel.py
+++ b/tests/unittests/opacity/premodit/test_profile_kernel.py
@@ -135,6 +135,7 @@ def test_diffgrid_selects_kernel_without_mutating_compiled_teacher(
     pressure = np.asarray([0.3, 1.0])
     compiled_teacher = jax.jit(teacher.xsmatrix)
     before = compiled_teacher(temperature, pressure)
+    before_eager = teacher.xsmatrix(temperature, pressure)
     coefficients = teacher.lbd_coeff
 
     diffgrid = OpaDiffgrid(
@@ -145,8 +146,8 @@ def test_diffgrid_selects_kernel_without_mutating_compiled_teacher(
     assert teacher.profile_kernel == teacher_mode
     assert teacher.lbd_coeff is coefficients
     np.testing.assert_array_equal(compiled_teacher(temperature, pressure), before)
-    np.testing.assert_allclose(
-        teacher.xsmatrix(temperature, pressure), before, rtol=1.0e-12
+    np.testing.assert_array_equal(
+        teacher.xsmatrix(temperature, pressure), before_eager
     )
     selected_teacher = teacher.with_profile_kernel(expected_mode)
     np.testing.assert_allclose(

--- a/tests/unittests/opacity/premodit/test_profile_kernel.py
+++ b/tests/unittests/opacity/premodit/test_profile_kernel.py
@@ -1,0 +1,207 @@
+"""Offline API checks for selectable PreMODIT profile kernels."""
+
+import json
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from exojax.database.contracts import Lines, MDBMeta, MDBSnapshot
+from exojax.opacity import OpaDiffgrid, OpaPremodit, saveopa
+from exojax.opacity.diffgrid.diagnostics import compare_diffgrid_with_teacher
+from exojax.utils.grids import wavenumber_grid
+
+
+def _teacher(*, diffmode=0, **kwargs):
+    snapshot = MDBSnapshot(
+        meta=MDBMeta(
+            dbtype="exomol",
+            molmass=18.0,
+            T_gQT=np.asarray([300.0, 1000.0, 2000.0]),
+            gQT=np.asarray([1.0, 2.0, 4.0]),
+        ),
+        lines=Lines(
+            nu_lines=np.asarray([999.0, 1000.0, 1002.0]),
+            elower=np.asarray([20.0, 350.0, 900.0]),
+            line_strength_ref_original=np.asarray([2.0e-23, 4.0e-23, 3.0e-23]),
+        ),
+        n_Texp=np.asarray([0.5, 0.5, 0.5]),
+        alpha_ref=np.asarray([0.06, 0.06, 0.06]),
+    )
+    nu_grid, _, _ = wavenumber_grid(
+        995.0, 1005.0, 32, unit="cm-1", xsmode="premodit"
+    )
+    opa = OpaPremodit.from_snapshot(
+        snapshot,
+        nu_grid,
+        diffmode=diffmode,
+        broadening_resolution={"mode": "single", "value": (0.06, 0.5)},
+        **kwargs,
+    )
+    opa.manual_setting(dE=300.0, Tref=1000.0, Twt=1200.0, Tmin=500.0, Tmax=1800.0)
+    return opa
+
+
+@pytest.mark.parametrize("diffmode", [0, 1, 2])
+@pytest.mark.parametrize("profile_kernel", ["analytic", "real_space"])
+def test_vector_matrix_and_gradients_for_each_kernel(diffmode, profile_kernel):
+    original = _teacher(diffmode=diffmode)
+    assert original.profile_kernel == "analytic"
+    opa = original.with_profile_kernel(profile_kernel)
+    assert opa.lbd_coeff is original.lbd_coeff
+    assert opa.pre_modit_info is original.pre_modit_info
+    assert opa is not original
+    assert original.profile_kernel == "analytic"
+    assert (opa == original) == (profile_kernel == "analytic")
+
+    temperature = jnp.asarray([850.0, 1100.0])
+    pressure = jnp.asarray([0.3, 1.0])
+    vectors = jnp.stack(
+        [opa.xsvector(t, p) for t, p in zip(temperature, pressure)]
+    )
+    matrix = jax.jit(opa.xsmatrix)(temperature, pressure)
+    np.testing.assert_allclose(matrix, vectors, rtol=1.0e-12, atol=1.0e-35)
+    if profile_kernel == "analytic":
+        np.testing.assert_array_equal(
+            matrix, jax.jit(original.xsmatrix)(temperature, pressure)
+        )
+    else:
+        assert np.min(matrix) >= 0.0
+
+    # The weighted linear observable probes both temperature and pressure AD
+    # without adding a log floor or any extra nonsmooth operation.
+    weights = jnp.linspace(0.5, 1.5, len(opa.nu_grid))
+
+    def objective(parameters):
+        return jnp.sum(weights * opa.xsvector(parameters[0], parameters[1])) / 1.0e-22
+
+    parameters = jnp.asarray([850.0, 0.3])
+    gradient = jax.jit(jax.grad(objective))(parameters)
+    steps = np.asarray([1.0e-2, 1.0e-5])
+    finite_difference = []
+    for index, step in enumerate(steps):
+        offset = np.zeros(2)
+        offset[index] = step
+        finite_difference.append(
+            (objective(parameters + offset) - objective(parameters - offset))
+            / (2.0 * step)
+        )
+    assert np.all(np.isfinite(gradient))
+    np.testing.assert_allclose(
+        gradient, finite_difference, rtol=3.0e-5, atol=1.0e-12
+    )
+
+
+def test_constructor_selects_real_space_and_rejects_invalid_mode():
+    opa = _teacher(profile_kernel="real_space")
+    reference = _teacher().with_profile_kernel("real_space")
+    np.testing.assert_array_equal(
+        opa.xsvector(850.0, 0.3), reference.xsvector(850.0, 0.3)
+    )
+    with pytest.raises(ValueError, match="profile_kernel"):
+        _teacher(profile_kernel="unknown")
+    with pytest.raises(ValueError, match="profile_kernel"):
+        opa.with_profile_kernel("unknown")
+
+
+def test_stitching_keeps_real_space_default():
+    opa = _teacher(nstitch=2)
+    assert opa.profile_kernel == "real_space"
+    np.testing.assert_array_equal(
+        opa.xsvector(850.0, 0.3),
+        opa.with_profile_kernel("real_space").xsvector(850.0, 0.3),
+    )
+    with pytest.raises(ValueError, match="real_space"):
+        _teacher(nstitch=2, profile_kernel="analytic")
+    with pytest.raises(ValueError, match="real_space"):
+        opa.with_profile_kernel("analytic")
+
+
+@pytest.mark.parametrize(
+    ("teacher_mode", "options", "expected_mode"),
+    [
+        ("analytic", {}, "real_space"),
+        ("analytic", {"profile_kernel": "analytic"}, "analytic"),
+        ("analytic", {"profile_kernel": None}, "analytic"),
+        ("real_space", {"profile_kernel": None}, "real_space"),
+    ],
+)
+def test_diffgrid_selects_kernel_without_mutating_compiled_teacher(
+    teacher_mode, options, expected_mode
+):
+    teacher = _teacher(profile_kernel=teacher_mode)
+    temperature = jnp.asarray([800.0, 1200.0])
+    pressure = np.asarray([0.3, 1.0])
+    compiled_teacher = jax.jit(teacher.xsmatrix)
+    before = compiled_teacher(temperature, pressure)
+    coefficients = teacher.lbd_coeff
+
+    diffgrid = OpaDiffgrid(
+        teacher, np.asarray([800.0, 1200.0]), pressure, **options
+    )
+
+    assert diffgrid.teacher_profile_kernel == expected_mode
+    assert teacher.profile_kernel == teacher_mode
+    assert teacher.lbd_coeff is coefficients
+    np.testing.assert_array_equal(compiled_teacher(temperature, pressure), before)
+    np.testing.assert_allclose(
+        teacher.xsmatrix(temperature, pressure), before, rtol=1.0e-12
+    )
+    selected_teacher = teacher.with_profile_kernel(expected_mode)
+    np.testing.assert_allclose(
+        diffgrid.xsmatrix(temperature),
+        selected_teacher.xsmatrix(temperature, pressure),
+        rtol=1.0e-12,
+        atol=1.0e-35,
+    )
+    if expected_mode != teacher.profile_kernel:
+        with pytest.raises(ValueError, match="with_profile_kernel"):
+            compare_diffgrid_with_teacher(diffgrid, teacher, temperature)
+    summary = compare_diffgrid_with_teacher(diffgrid, selected_teacher, temperature)
+    assert summary.maximum_absolute_log_cross_section_error < 1.0e-12
+
+
+@pytest.mark.parametrize("format", ["npz", "zarr"])
+@pytest.mark.parametrize("profile_kernel", ["analytic", "real_space"])
+def test_diffgrid_persists_selected_teacher_kernel(tmp_path, format, profile_kernel):
+    teacher = _teacher()
+    temperature = np.asarray([800.0, 1200.0])
+    pressure = np.asarray([0.3, 1.0])
+    diffgrid = OpaDiffgrid(
+        teacher, temperature, pressure, profile_kernel=profile_kernel
+    )
+    path = tmp_path / "diffgrid"
+    saveopa(diffgrid, str(path), format=format)
+    loaded = OpaDiffgrid.from_saved_opa(str(path.with_suffix("." + format)))
+    assert loaded.teacher_profile_kernel == profile_kernel
+    np.testing.assert_array_equal(
+        loaded.xsmatrix(temperature), diffgrid.xsmatrix(temperature)
+    )
+
+
+@pytest.mark.parametrize("nstitch", [1, 2])
+@pytest.mark.parametrize("format", ["npz", "zarr"])
+def test_legacy_premodit_kernel_is_inferred_from_stitching(tmp_path, nstitch, format):
+    teacher = _teacher(nstitch=nstitch)
+    path = tmp_path / "legacy"
+    saveopa(teacher, str(path), format=format)
+    if format == "npz":
+        metadata_path = tmp_path / "legacy_metadata.json"
+        metadata = json.loads(metadata_path.read_text())
+        del metadata["opa_state"]["profile_kernel"]
+        metadata_path.write_text(json.dumps(metadata))
+    else:
+        import zarr
+
+        group = zarr.open(str(path.with_suffix(".zarr")), mode="a")
+        state = dict(group.attrs["opa_state"])
+        del state["profile_kernel"]
+        group.attrs["opa_state"] = state
+
+    loaded = OpaPremodit.from_saved_opa(str(path.with_suffix("." + format)))
+
+    assert loaded.profile_kernel == ("analytic" if nstitch == 1 else "real_space")
+    np.testing.assert_array_equal(
+        loaded.xsvector(850.0, 0.3), teacher.xsvector(850.0, 0.3)
+    )


### PR DESCRIPTION
DiffGrid construction can amplify near-zero opacity cancellation from the analytic Fourier Voigt kernel into large logarithmic temperature slopes. Add a sampled real-space Voigt kernel and use it by default when building DiffGrid tables from PreMODIT.

- Keep the existing on-the-fly PreMODIT defaults: analytic for closed calculations and the existing real-space kernel for stitching. Add `profile_kernel="analytic" | "real_space"` and `with_profile_kernel(...)` to select a mode without rebuilding line-density arrays.
- Default `OpaDiffgrid` to `profile_kernel="real_space"`, with explicit analytic selection or `None` to inherit the supplied teacher's mode. Construction shares the teacher's precomputed arrays through a copy, leaving the original unchanged.
- Persist the selected kernel in PreMODIT and DiffGrid archives, retain legacy archive behavior, and reject diagnostic comparisons with a known teacher-kernel mismatch.
- Add `prepare --profile-kernel` to the NUTS benchmark, keeping the saved teacher and table construction aligned. Preserve existing case settings and CLI arguments. Document the defaults and explicitly retain the analytic selection used by the tutorial's recorded outputs.

Validation:

- Full CPU unit and offline integration suite: **1337 passed, 6 skipped** in 291.04 s, using Python 3.12 and JAX 0.6.2. Command: `env PYTHONPATH=/home/kawahara/exojax/src JAX_PLATFORMS=cpu NUMBA_DISABLE_JIT=1 MPLCONFIGDIR=/tmp/exojax-real-space-tests-mpl /tmp/exojax-starter-env/bin/python -m pytest -q tests/unittests tests/integration/offline --durations=20`.
- Numerical tests compare the sampled convolution with independent SciPy Voigt sums, check automatic derivatives against finite differences, and cover negative ringing, all PreMODIT diffmodes, selection defaults, teacher-copy behavior, NPZ/Zarr round trips, and legacy metadata.
- Rebuilt the saved CH4 table through the public API on CPU and checked all 41 spectral validation points: all passed, with maximum error/noise `0.000633794401` (limit `0.01`) and maximum Q `0.000560356236`.
- GPU validation on an NVIDIA RTX 6000 Ada (JAX 0.6.2, float64): all **41/41 spectral probes passed**, with maximum error/noise `0.000633794401` and maximum Q `0.000560356236`. The analytic baseline passed 39/41, with maximum error/noise `0.347102744`. Physics settings, priors, probes, and thresholds are unchanged; saved artifact hashes match.
- GPU directional AD-FD validation passed **100/102 checks**. Only the previously diagnosed forward check crossing an RV interpolation boundary failed, in both methods. Earlier CPU checks with local steps `1e-6` and `1e-7` agree for both methods. The launcher stopped before NUTS, so this is not a complete P0 validation pass. RV boundary handling will be addressed in a separate PR.
- GPU DiffGrid construction took 3.589 s versus 2.094 s in the analytic baseline (single measurements including compilation). Table payload and the recorded post-build GPU memory snapshot were unchanged; no sampling speed measurement is available.
- Follow-up test compatibility checks: **20 focused CPU tests passed**. Precision tests use public JAX configuration with restoration; teacher immutability is checked by exact before/after comparisons for both eager and compiled calls. Numerical accuracy tolerances are unchanged.
- `git diff --check` and notebook JSON/code-cell syntax checks passed. Recorded notebook outputs are unchanged; the notebook was not rerun.

NUTS runs remain unperformed. Both kernel choices currently implement Voigt profiles; a general non-Voigt profile API is outside this change.
