### PR TITLE
Fix RV boundary and roundoff handling in benchmark validation

### DIFF
--- a/tests/benchmark/benchmark_metrics.py
+++ b/tests/benchmark/benchmark_metrics.py
@@ -113,14 +113,18 @@ def directional_check(
     tolerance=1e-3,
     in_domain=None,
     region=None,
+    stencil_resolved=None,
 ):
     """Compare JAX JVP with central differences at two adjacent supplied steps.
 
     ``in_domain`` rejects endpoints outside the allowed physical/prior domain.
     ``region`` returns scalar/array labels for smooth regions, such as per-layer
-    temperature clipping states. A region change gives one-sided diagnostics
-    only; excluded steps cannot bridge a pair of passing smooth steps. Neither
+    temperature clipping states and RV interpolation cells. A region change
+    gives one-sided diagnostics only; excluded steps cannot bridge a pair of
+    passing smooth steps. Neither
     finite sampling nor this check guarantees accuracy over an entire prior.
+    ``stencil_resolved(center, plus, minus)`` can additionally reject steps lost
+    to rounding in transformed model coordinates.
     """
     import jax
     import jax.numpy as jnp
@@ -161,6 +165,8 @@ def directional_check(
     result["nonfinite_center_indices"] = _nonfinite(center)
     center_finite = bool(np.all(np.isfinite(center)) and np.all(np.isfinite(ad)))
     center_region = region(position) if region is not None else None
+    active = direction != 0
+    represented_position = np.asarray(jnp.asarray(position))
     previous_passed = False
     for step in steps:
         record = {"step": float(step), "status": None, "passed": False}
@@ -168,6 +174,19 @@ def directional_check(
         plus, minus = position + step * direction, position - step * direction
         if not bool(domain(plus)) or not bool(domain(minus)):
             record["status"] = "out_of_domain"
+            previous_passed = False
+            continue
+        resolved = all(
+            np.all(
+                (np.asarray(jnp.asarray(endpoint)) != represented_position)[active]
+            )
+            for endpoint in (plus, minus)
+        )
+        if not resolved or (
+            stencil_resolved is not None
+            and not stencil_resolved(position, plus, minus)
+        ):
+            record["status"] = "roundoff_limited"
             previous_passed = False
             continue
         plus_value, minus_value = _array(function(plus)), _array(function(minus))
@@ -221,5 +240,9 @@ def directional_check(
     ):
         result.update(passed=False, reason="nonfinite_evaluation")
     elif not result["passed"]:
-        result["reason"] = "no_adjacent_passing_smooth_steps"
+        result["reason"] = (
+            "roundoff_limited"
+            if any(record["status"] == "roundoff_limited" for record in result["steps"])
+            else "no_adjacent_passing_smooth_steps"
+        )
     return result

--- a/tests/benchmark/diffgrid_nuts_validation.py
+++ b/tests/benchmark/diffgrid_nuts_validation.py
@@ -18,6 +18,9 @@ from benchmark_metrics import (
 from diffgrid_nuts_storage import sha256, validate_run_id, write_npz
 
 
+DEFAULT_STEPS = (1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7)
+
+
 def _json_report(value):
     """Keep failed numerical values JSON-safe; residual archives preserve NaNs."""
     if isinstance(value, dict):
@@ -212,6 +215,7 @@ def evaluate_case(
     import jax.numpy as jnp
     from jax.scipy.special import expit
     from jax.scipy.stats import norm
+    from exojax.utils.constants import c
     from exojax.opacity.diffgrid.diagnostics import (
         diffgrid_interval_midpoint_temperatures,
     )
@@ -241,12 +245,28 @@ def evaluate_case(
         physical = lower + width * np.asarray(unit)
         return physical[t_index] * pressure ** physical[a_index]
 
+    rv_index = names.index("radial_velocity")
+    physical_coordinates = jax.jit(lambda unit: lower + width * unit)
+
+    @jax.jit
+    def sampling_coordinates(unit):
+        # Match the current observation operator, including its Doppler convention.
+        physical = lower + width * unit
+        return context["nu_data"] * (1.0 + physical[rv_index] / c)
+
     def region(unit):
-        return _clip(
+        clipping = _clip(
             raw_temperature(unit),
             case_config.temperature_min,
             case_config.temperature_max,
         )["region"]
+        shifted = np.asarray(sampling_coordinates(unit))
+        nu_grid = np.asarray(context["nu_grid"])
+        # Exact knots have their own labels, distinct from either open cell.
+        cells = np.searchsorted(nu_grid, shifted, side="left") + np.searchsorted(
+            nu_grid, shifted, side="right"
+        )
+        return np.concatenate((clipping, cells))
 
     def in_domain(unit):
         unit = np.asarray(unit)
@@ -325,6 +345,7 @@ def evaluate_case(
             "potential": "NumPyro unconstrained q (Uniform-prior log odds)",
             "potential_definition": "U(q) = -log L(theta(q)) - log p(theta(q)) - log|dtheta/dq|",
             "derivative_scale": "max absolute AD-FD / max(1, max absolute AD, max absolute FD); forward divided by noise_sigma",
+            "smooth_regions": "Temperature clipping states and linear RV sampling cells; exact RV knots have separate labels.",
         },
     }
     fluxes = {method: [] for method in forwards}
@@ -406,6 +427,22 @@ def evaluate_case(
             unit = (np.asarray([values[name] for name in names]) - lower) / width
             direction = rng.normal(size=len(names))
             direction /= np.linalg.norm(direction)
+
+            def stencil_resolved(center, plus, minus):
+                active = direction != 0
+                physical = np.asarray(physical_coordinates(center))
+                shifted = np.asarray(sampling_coordinates(center))
+                for endpoint in (plus, minus):
+                    if np.any(
+                        (np.asarray(physical_coordinates(endpoint)) == physical)[active]
+                    ):
+                        return False
+                    if active[rv_index] and np.any(
+                        np.asarray(sampling_coordinates(endpoint)) == shifted
+                    ):
+                        return False
+                return True
+
             q = np.log(unit) - np.log1p(-unit)
             entry = {
                 "label": label,
@@ -431,6 +468,7 @@ def evaluate_case(
                         tolerance=settings["gradient_tolerance"],
                         in_domain=in_domain,
                         region=region,
+                        stencil_resolved=stencil_resolved,
                     )
                 if method in potentials:
                     result["potential"] = directional_check(
@@ -441,6 +479,11 @@ def evaluate_case(
                         tolerance=settings["gradient_tolerance"],
                         in_domain=lambda x: in_domain(np.asarray(expit(x))),
                         region=lambda x: region(np.asarray(expit(x))),
+                        stencil_resolved=lambda x, plus, minus: stencil_resolved(
+                            np.asarray(expit(x)),
+                            np.asarray(expit(plus)),
+                            np.asarray(expit(minus)),
+                        ),
                     )
                 else:
                     result["potential"] = {
@@ -620,7 +663,7 @@ def validate_case(args, benchmark):
             "max_interpolation_error_in_noise": args.max_interpolation_error_in_noise,
             "max_q": args.max_q,
             "gradient_tolerance": args.gradient_tolerance,
-            "steps": [1e-2, 1e-3, 1e-4, 1e-5],
+            "steps": list(DEFAULT_STEPS),
         },
     }
     with benchmark._record_execution(result_path, state):

--- a/tests/integration/offline/benchmark/test_benchmark_metrics.py
+++ b/tests/integration/offline/benchmark/test_benchmark_metrics.py
@@ -189,3 +189,28 @@ def test_invalid_step_sequences_are_rejected(metrics, steps):
 def test_a_single_good_step_does_not_establish_convergence(metrics):
     result = metrics.directional_check(lambda x: x**2, 1.0, 1.0, steps=[0.01])
     assert result["steps"][0]["passed"] and not result["passed"]
+
+
+def test_roundoff_cannot_verify_small_or_partially_lost_derivatives(metrics):
+    result = metrics.directional_check(
+        lambda x: 1e-6 * jnp.sum(x),
+        [0.0, 1.0],
+        [1.0, 1.0],
+        steps=[1e-17, 1e-18],
+    )
+    assert not result["passed"] and result["reason"] == "roundoff_limited"
+    assert all(record["status"] == "roundoff_limited" for record in result["steps"])
+    json.dumps(result, allow_nan=False)
+
+
+def test_transformed_roundoff_exclusion_cannot_bridge_passing_steps(metrics):
+    result = metrics.directional_check(
+        lambda x: x**2,
+        0.0,
+        1.0,
+        steps=[0.1, 0.01, 0.001],
+        stencil_resolved=lambda center, plus, minus: not np.isclose(plus, 0.01),
+    )
+    assert [record["passed"] for record in result["steps"]] == [True, False, True]
+    assert result["steps"][1]["status"] == "roundoff_limited"
+    assert not result["passed"]

--- a/tests/integration/offline/benchmark/test_diffgrid_nuts_validation.py
+++ b/tests/integration/offline/benchmark/test_diffgrid_nuts_validation.py
@@ -304,6 +304,88 @@ def test_exact_opacity_interpolant_passes_actual_observation_path(
     assert arrays and all(np.all(np.isfinite(array)) for array in arrays.values())
 
 
+def test_rv_stencils_detect_crossings_exact_knots_and_roundoff_in_both_coordinates(
+    validation, benchmark, synthetic_case, settings, analytic_potential, monkeypatch
+):
+    import jax.numpy as jnp
+    from exojax.postproc.response import sampling
+
+    fixture = synthetic_case
+    fixture.truth["radial_velocity"] = 0.0
+    fixture.bounds["radial_velocity"] = (-5.0, 5.0)
+    grid = jnp.asarray(fixture.case["nu_grid"])
+    # Zero RV puts all six observations exactly on interior interpolation knots.
+    fixture.case["nu_data"] = np.asarray(grid)[[24, 27, 30, 33, 36, 39]]
+    fixture.context["nu_data"] = jnp.asarray(fixture.case["nu_data"])
+    spectrum = jnp.arange(grid.size, dtype=grid.dtype) ** 2
+
+    def factory(opacity, context, config):
+        return lambda temperature, methane, radius, rv, vsini: sampling(
+            context["nu_data"], grid, spectrum, rv
+        )
+
+    monkeypatch.setattr(benchmark, "_make_forward_model", factory)
+    check = validation.directional_check
+    calls = []
+
+    def capture(function, position, direction, **kwargs):
+        calls.append((function, position, direction, kwargs))
+        return {"passed": True}
+
+    monkeypatch.setattr(validation, "directional_check", capture)
+    custom_steps = [3e-3, 2e-4]
+    report, _ = _evaluate(
+        validation,
+        benchmark,
+        fixture,
+        dict(settings, num_prior_points=0, steps=custom_steps),
+    )
+    assert report["passed"] and len(calls) == 6
+    assert all(call[3]["steps"] == custom_steps for call in calls)
+
+    # Forward uses unit-prior coordinates; potential uses logit coordinates.
+    for function, position, direction, options in (calls[0], calls[2]):
+        options = dict(options, steps=validation.DEFAULT_STEPS)
+        boundary = check(function, position, direction, **options)
+        assert not boundary["passed"]
+        assert all(record["status"] == "kink" for record in boundary["steps"])
+        assert all("one_sided_derivatives" in record for record in boundary["steps"])
+
+        nearby = position + 2.7e-6 * direction
+        result = check(function, nearby, direction, **options)
+        assert result["passed"], result
+        assert [record["status"] for record in result["steps"]] == (
+            ["kink"] * 4 + ["smooth"] * 2
+        )
+        assert all(record["passed"] for record in result["steps"][-2:])
+        coarse = check(function, nearby, direction, **dict(options, steps=custom_steps))
+        assert not coarse["passed"]
+        assert [record["step"] for record in coarse["steps"]] == custom_steps
+
+        # Inputs still move, but the Doppler factor rounds back to its center.
+        tiny_steps = [1e-12, 1e-13]
+        for step in tiny_steps:
+            for sign in (-1, 1):
+                endpoint = np.asarray(jnp.asarray(position + sign * step * direction))
+                assert np.all(endpoint != np.asarray(jnp.asarray(position)))
+        unresolved = check(
+            function, position, direction, **dict(options, steps=tiny_steps)
+        )
+        assert not unresolved["passed"] and unresolved["reason"] == "roundoff_limited"
+        assert all(
+            record["status"] == "roundoff_limited" for record in unresolved["steps"]
+        )
+
+    # A finite logit near saturation can move while its physical parameters do not.
+    function, position, direction, options = calls[2]
+    saturated = np.full_like(position, 30.0)
+    assert options["in_domain"](saturated)
+    result = check(
+        function, saturated, direction, **dict(options, steps=[1e-3, 1e-4])
+    )
+    assert not result["passed"] and result["reason"] == "roundoff_limited"
+
+
 @pytest.mark.parametrize(
     "fault",
     ["nonfinite", "offset", "broken_gradient", "missing_numpyro", "nonfinite_domain"],
@@ -466,6 +548,7 @@ def test_validation_selection_and_saved_residuals_are_verified(
         )
     report_path = saved_case.output_dir / "validations/baseline/validation.json"
     report = json.loads(report_path.read_text())
+    assert report["settings"]["steps"] == list(validation.DEFAULT_STEPS)
     with pytest.raises(ValueError, match="provenance"):
         benchmark._validate_result_evidence(
             saved_case.output_dir, {}, digest, "baseline"


### PR DESCRIPTION
Finite-difference checks in the DiffGrid NUTS benchmark can cross a linear RV interpolation boundary and report a misleading derivative mismatch. Very small perturbations can also disappear through floating-point rounding and falsely pass a check.

Include RV sampling cells and exact knots in the smooth-region labels, preserve one-sided diagnostics for boundary crossings, and reject unresolved perturbations in input, physical-parameter, Doppler, and logit-transformed coordinates. Extend the default step sequence through `1e-6` and `1e-7` so nearby smooth points can satisfy the existing two-adjacent-step criterion without relaxing tolerances.

Regression tests cover forward and potential coordinates, exact knots, nearby crossings, custom step sequences, and partial or transformed roundoff.

## Validation

- CPU: 71 tests passed across `test_benchmark_metrics.py`, `test_diffgrid_nuts_validation.py`, and `tests/unittests/postproc/test_response.py`.
- `git diff --check` passed.
