### PR TITLE
Add selectable low-memory Newton Jacobians for RCE

### DIFF
--- a/src/exojax/atm/rce.py
+++ b/src/exojax/atm/rce.py
@@ -105,6 +105,7 @@ def solve_rce(
     max_iterations=50,
     max_active_set_iterations=30,
     max_backtracks=25,
+    jacobian_mode="sequential",
 ):
     """Solve RCE using damped Newton steps and an active set.
 
@@ -139,6 +140,11 @@ def solve_rce(
         max_iterations: Maximum Newton steps per active set.
         max_active_set_iterations: Maximum number of masks to solve.
         max_backtracks: Maximum line-search trials per Newton step.
+        jacobian_mode: Newton temperature Jacobian evaluation: ``"sequential"``
+            (default) evaluates one JVP at a time to limit spectral intermediate
+            memory; ``"jacfwd"`` batches all directions and may be faster when
+            memory permits. This does not control the separate Jacobian used
+            for implicit differentiation in ``exojax.atm.rce_implicit``.
 
     Returns:
         RceResult: Convergence requires the selected equations, stable inactive
@@ -207,6 +213,10 @@ def solve_rce(
             or value < 1
         ):
             raise ValueError(f"{name} must be a positive integer.")
+    if not isinstance(jacobian_mode, str) or jacobian_mode not in (
+        "sequential", "jacfwd"
+    ):
+        raise ValueError("jacobian_mode must be 'sequential' or 'jacfwd'.")
     if convective_mask_initial is None:
         mask = np.zeros(nlayer, dtype=bool)
     else:
@@ -249,18 +259,21 @@ def solve_rce(
             _evaluate_gradient(neutral_gradient, values[:-1], values[-1]),
         )
 
-    @jax.jit
-    def jacobian(log_t, active):
-        # Evaluate one tangent at a time to avoid a full spectral batch per
-        # temperature variable. Rows of mapped JVPs are Jacobian columns.
-        columns = jax.lax.map(
-            lambda tangent: jax.jvp(
-                lambda values: residual(values, active),
-                (log_t,), (tangent,),
-            )[1],
-            jnp.eye(log_t.size, dtype=log_t.dtype),
-        )
-        return columns.T
+    if jacobian_mode == "jacfwd":
+        jacobian = jax.jit(jax.jacfwd(residual, argnums=0))
+    else:
+        @jax.jit
+        def jacobian(log_t, active):
+            # Evaluate one tangent at a time to avoid a full spectral batch per
+            # temperature variable. Rows of mapped JVPs are Jacobian columns.
+            columns = jax.lax.map(
+                lambda tangent: jax.jvp(
+                    lambda values: residual(values, active),
+                    (log_t,), (tangent,),
+                )[1],
+                jnp.eye(log_t.size, dtype=log_t.dtype),
+            )
+            return columns.T
 
     log_t = np.log(temperatures)
 

--- a/src/exojax/atm/rce.py
+++ b/src/exojax/atm/rce.py
@@ -249,7 +249,19 @@ def solve_rce(
             _evaluate_gradient(neutral_gradient, values[:-1], values[-1]),
         )
 
-    jacobian = jax.jit(jax.jacfwd(residual, argnums=0))
+    @jax.jit
+    def jacobian(log_t, active):
+        # Evaluate one tangent at a time to avoid a full spectral batch per
+        # temperature variable. Rows of mapped JVPs are Jacobian columns.
+        columns = jax.lax.map(
+            lambda tangent: jax.jvp(
+                lambda values: residual(values, active),
+                (log_t,), (tangent,),
+            )[1],
+            jnp.eye(log_t.size, dtype=log_t.dtype),
+        )
+        return columns.T
+
     log_t = np.log(temperatures)
 
     def state_temperature(log_values):

--- a/tests/unittests/atm/test_rce.py
+++ b/tests/unittests/atm/test_rce.py
@@ -292,3 +292,9 @@ def test_gray_rce_warm_cold_starts_and_angular_resolution():
 def test_invalid_inputs_raise(options):
     with pytest.raises(ValueError):
         _toy_solve(**options)
+
+
+@pytest.mark.parametrize("jacobian_mode", ["unknown", None, 1, ["sequential"]])
+def test_invalid_jacobian_mode_raises(jacobian_mode):
+    with pytest.raises(ValueError, match="jacobian_mode"):
+        _toy_solve(jacobian_mode=jacobian_mode)

--- a/tests/unittests/atm/test_rce_gradient.py
+++ b/tests/unittests/atm/test_rce_gradient.py
@@ -97,7 +97,10 @@ def test_gradient_callback_derivatives_enter_fixed_mask_jacobian():
 
 @pytest.mark.parametrize("gradient", [0.25, _gradient], ids=["fixed", "state_dependent"])
 @pytest.mark.parametrize("initial_mask", [[False, False], [False, True], [True, True]])
-def test_newton_matrix_matches_forward_jacobian(monkeypatch, gradient, initial_mask):
+@pytest.mark.parametrize("jacobian_mode", ["sequential", "jacfwd"])
+def test_newton_matrix_matches_forward_jacobian(
+    monkeypatch, gradient, initial_mask, jacobian_mode
+):
     log_t = jnp.asarray(np.log([250.0, 350.0, 400.0]))
     mask = jnp.array(initial_mask)
 
@@ -118,7 +121,10 @@ def test_newton_matrix_matches_forward_jacobian(monkeypatch, gradient, initial_m
         return linear_solve(matrix, rhs)
 
     monkeypatch.setattr(np.linalg, "solve", capture_matrix)
-    result = _solve(neutral_gradient=gradient, convective_mask_initial=np.array(initial_mask))
+    result = _solve(
+        neutral_gradient=gradient, convective_mask_initial=np.array(initial_mask),
+        jacobian_mode=jacobian_mode,
+    )
     assert result.converged, result.status
     assert captured
     matrix, rhs = captured[0]
@@ -126,6 +132,24 @@ def test_newton_matrix_matches_forward_jacobian(monkeypatch, gradient, initial_m
     scale = np.max(np.abs(expected))
     np.testing.assert_allclose(matrix / scale, expected / scale, rtol=1e-13, atol=1e-14)
     np.testing.assert_allclose(rhs / scale, -residual(log_t) / scale, rtol=1e-13, atol=1e-14)
+
+
+@pytest.mark.parametrize("gradient", [0.25, _gradient], ids=["fixed", "state_dependent"])
+def test_jacobian_modes_have_same_solution_and_diagnostics(gradient):
+    sequential = _solve(neutral_gradient=gradient)
+    batched = _solve(neutral_gradient=gradient, jacobian_mode="jacfwd")
+    assert sequential.converged and batched.converged
+    for name in (
+        "temperature", "bottom_temperature", "radiative_flux", "convective_flux",
+        "flux_residual", "gradient_residual",
+    ):
+        np.testing.assert_allclose(
+            getattr(batched, name), getattr(sequential, name), rtol=1e-13, atol=1e-13
+        )
+    np.testing.assert_allclose(batched.scaled_residual, sequential.scaled_residual, atol=1e-5)
+    np.testing.assert_array_equal(batched.convective_mask, sequential.convective_mask)
+    for name in ("iterations", "active_set_iterations", "domain_valid", "status"):
+        assert getattr(batched, name) == getattr(sequential, name)
 
 
 @pytest.mark.parametrize("gradient", [0.25, np.array([0.25, 0.3])])

--- a/tests/unittests/atm/test_rce_gradient.py
+++ b/tests/unittests/atm/test_rce_gradient.py
@@ -95,6 +95,39 @@ def test_gradient_callback_derivatives_enter_fixed_mask_jacobian():
     np.testing.assert_allclose(matrix, finite_difference, rtol=1e-8, atol=1e-10)
 
 
+@pytest.mark.parametrize("gradient", [0.25, _gradient], ids=["fixed", "state_dependent"])
+@pytest.mark.parametrize("initial_mask", [[False, False], [False, True], [True, True]])
+def test_newton_matrix_matches_forward_jacobian(monkeypatch, gradient, initial_mask):
+    log_t = jnp.asarray(np.log([250.0, 350.0, 400.0]))
+    mask = jnp.array(initial_mask)
+
+    def residual(values):
+        return rce_residual(
+            values, jnp.array([1.0, 4.0]), 16.0, 1.0,
+            _flux, gradient, mask, flux_scale=2e-9, gradient_scale=1e-9,
+        )
+
+    expected = np.asarray(jax.jit(jax.jacfwd(residual))(log_t))
+    assert not np.allclose(expected, expected.T)
+    captured = []
+    linear_solve = np.linalg.solve
+
+    def capture_matrix(matrix, rhs):
+        if not captured:
+            captured.append((matrix.copy(), rhs.copy()))
+        return linear_solve(matrix, rhs)
+
+    monkeypatch.setattr(np.linalg, "solve", capture_matrix)
+    result = _solve(neutral_gradient=gradient, convective_mask_initial=np.array(initial_mask))
+    assert result.converged, result.status
+    assert captured
+    matrix, rhs = captured[0]
+    # Normalize tolerance-scaled equations before comparing roundoff.
+    scale = np.max(np.abs(expected))
+    np.testing.assert_allclose(matrix / scale, expected / scale, rtol=1e-13, atol=1e-14)
+    np.testing.assert_allclose(rhs / scale, -residual(log_t) / scale, rtol=1e-13, atol=1e-14)
+
+
 @pytest.mark.parametrize("gradient", [0.25, np.array([0.25, 0.3])])
 def test_constant_callback_preserves_fixed_gradient_solution(gradient):
     fixed = _solve(neutral_gradient=gradient)

--- a/tests/unittests/atm/test_rce_implicit.py
+++ b/tests/unittests/atm/test_rce_implicit.py
@@ -105,8 +105,9 @@ def test_forward_recomputes_parameters_and_matches_normal_solve():
     assert np.max(np.abs(outputs[0] - outputs[1])) > 1.0
 
 
-def test_jvp_vjp_and_jacobians_match_analytic_solution_and_finite_difference():
-    solve = _make_solver()
+@pytest.mark.parametrize("jacobian_mode", ["sequential", "jacfwd"])
+def test_jvp_vjp_and_jacobians_match_analytic_solution_and_finite_difference(jacobian_mode):
+    solve = _make_solver(jacobian_mode=jacobian_mode)
     vector = jnp.array([1.0, 0.05, 0.16])
 
     def state(values):


### PR DESCRIPTION
RCE Newton Jacobians can consume substantial memory by batching every temperature tangent through spectral transfer. Add a keyword-only `jacobian_mode` choice to `solve_rce`:

- `"sequential"` (default): evaluate one JVP at a time with `jax.lax.map`, then transpose the collected columns to form the dense Jacobian.
- `"jacfwd"`: retain the original batched forward Jacobian for workloads where memory permits and execution time matters.

Both modes hold the active mask fixed and include temperature-dependent radiation and neutral-gradient derivatives. Unsupported values raise `ValueError`. `make_implicit_rce_solver` forwards the option to its Newton solve through `solver_options`; its separate sensitivity Jacobian in `equilibrium_jvp` continues to use `jacfwd`.

Validation on Python 3.9.19, JAX/jaxlib 0.4.30, x64:

- **81 passed** across RCE core, gradient, implicit-differentiation and offline CKD tests. Coverage includes both modes' actual Newton matrices/RHS for fixed/state-dependent gradients and radiative/mixed/convective masks, solution/diagnostic equivalence, invalid option values, and implicit JVP/VJP/Jacobian comparisons with analytic derivatives and finite differences.
- An independent comparison of the two kernels covered eight convergence conditions and eleven failure conditions. All final result fields matched exactly; across 72 actual Newton matrices per version, the maximum normalized difference was `2.38e-16`.

Fresh-process A100-PCIE-40GB measurements using real water opacity (5,115 bands × 16 g ordinates), H2–H2 CIA, and the handoff's physical inputs and interpolated seeds:

| Method | Layers | Peak allocator use (GB) | Jacobian compile (s) | First execution (s) | Warm median (s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| Batched `jacfwd` | 24 | 8.325 | 12.691 | 0.280 | 0.0578 |
| Sequential JVP | 24 | 0.935 | 13.216 | 0.274 | 0.1473 |
| Sequential JVP | 48 | 1.472 | 12.740 | 0.623 | 0.5190 |
| Sequential JVP | 96 | 2.301 | 12.250 | 2.064 | 1.9540 |

Every GPU case converged in three Newton updates. At 24 layers all returned result fields matched exactly. Peak memory decreased by **8.90×**, while warmed Jacobian execution took **2.55×** as long; the explicit option exposes that tradeoff. A two-layer CPU benchmark measured compile time of 46.7 → 60.2 ms and warmed median over 1,000 calls of 6.96 → 7.43 µs.

Performance and independent equivalence measurements compare baseline `e4521441` with sequential implementation `714058e3`. The option selects those same kernels; the measurements predate the option wrapper. GPU rows ran in separate processes with `XLA_PYTHON_CLIENT_PREALLOCATE=false`. Memory is the process-lifetime `device.memory_stats()["peak_bytes_in_use"]` after the column solve. The harness captured the actual solver JIT, separated lowering/compilation and synchronized execution with `block_until_ready`; warm medians use five repetitions of the first Newton input. These are radiative columns, with direct baseline equivalence measured at 24 layers. These timings describe the Newton Jacobian, not complete gradient-based retrieval performance.

```sh
JAX_PLATFORMS=cpu JAX_ENABLE_X64=True OMP_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 \
python -m pytest -q -p no:cacheprovider \
  tests/unittests/atm/test_rce.py \
  tests/unittests/atm/test_rce_gradient.py \
  tests/unittests/atm/test_rce_implicit.py \
  tests/integration/offline/test_rce_ckd.py
```
